### PR TITLE
fix makeNonEnumerable bug in iOS 7.x 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chanjet-mobx",
+  "name": "mobx",
   "version": "2.1.3",
   "description": "Simple, scalable state management.",
   "main": "lib/mobx.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mobx",
+  "name": "chanjet-mobx",
   "version": "2.1.3",
   "description": "Simple, scalable state management.",
   "main": "lib/mobx.js",

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -286,9 +286,9 @@ makeNonEnumerable(ObservableArray.prototype, [
 	"unshift",
 	"reverse",
 	"sort",
+	"remove",
 	"toString",
 	"toLocaleString",
-	"remove",
 ]);
 Object.defineProperty(ObservableArray.prototype, "length", {
 	enumerable: false,


### PR DESCRIPTION
makeNonEnumerable ObservableArray.prototype have weird result in iOS 7.x.
**toString** changed to **toLocalString**, **toLocalString** changed to **remove**, but **remove** changed **toString** !!!
