### PR TITLE
Fix typos and improve consistency

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,7 +7,7 @@
 * [Core API](refguide/api.md)
   * [observable](refguide/observable.md)
   * [@observable](refguide/observable-decorator.md)
-  * [(@)computed](refguide/computed-decorator.md) 
+  * [(@)computed](refguide/computed-decorator.md)
   * [autorun](refguide/autorun.md)
   * [@observer](refguide/observer-component.md)
 * Best Practices For Large Apps
@@ -16,7 +16,7 @@
   * [Optimizing React components](best/react-performance.md)
 <!--  * Routing Universal applications -->
 * How does MobX work?
-  * [In depth explanation of MobX](https://medium.com/@mweststrate/becoming-fully-reactive-an-in-depth-explanation-of-mobservable-55995262a254#.gh651s1ta)
+  * [In depth explanation of MobX](https://medium.com/@mweststrate/becoming-fully-reactive-an-in-depth-explanation-of-mobservable-55995262a254)
 * Tips & Tricks
   * [DevTools](best/devtools.md)
   * [ES5 / ES6 / TypeScript syntax](best/syntax.md)

--- a/docs/best/actions.md
+++ b/docs/best/actions.md
@@ -2,7 +2,7 @@
 
 Writing actions is straight-forward when using MobX.
 Just create, change or delete data and MobX will make sure that changes are picked up by the store and the components that depend on your data.
-Based on the store we have created in the previous paragraph, actions become as simple as:
+Based on the store we have created in the previous section, actions become as simple as:
 
 ```javascript
 var todo = todoStore.createTodo();
@@ -28,7 +28,7 @@ This is what happens with the `isLoading` property in the `todoStore` for exampl
 ```
 
 After completing the asynchronous action, just update your data and your views will update.
-The render function of a React component could be come as simple as:
+The render function of a React component could become as simple as:
 
 ```javascript
 import {observer} from "mobx-react";

--- a/docs/best/react-performance.md
+++ b/docs/best/react-performance.md
@@ -1,17 +1,17 @@
-# Optimizing rendering React components 
+# Optimizing rendering React components
 
 MobX is very fast, [often even faster than Redux](https://twitter.com/mweststrate/status/718444275239882753). But here are some tips to get most out of React and MobX. Note that most tips apply to React in general and are not specific for MobX.
 
 ## Use many small components
 
 `@observer` components will track all values they use and re-render if any of them changes.
-So the smaller your components are, the smaller the change they have to re-render; it means that more parts of your user interface have the possibility to render independently of each other. 
+So the smaller your components are, the smaller the change they have to re-render; it means that more parts of your user interface have the possibility to render independently of each other.
 
 ## Render lists in dedicated components
 
 This is especially true when rendering big collections.
 React is notoriously bad at rendering large collections as the reconciler has to evaluate the components produced by a collection on each collection change.
-It is therefor recommended to have components that just map over a collection and render it, and render nothing else:
+It is therefore recommended to have components that just map over a collection and render it, and render nothing else:
 
 Bad:
 
@@ -27,7 +27,7 @@ Bad:
         </div>)
     }
 }
-```         
+```
 
 In the above listing React will unnecessarily need to reconcile all TodoView components when the `user.name` changes. They won't re-render, but the reconcile process is expensive in itself.
 
@@ -52,7 +52,7 @@ Good:
         </ul>)
     }
 }
-```         
+```
 
 ## Don't use array indexes as keys
 
@@ -67,17 +67,17 @@ If this happens deeper in your component tree, less components have to re-render
 Fast:
 
 `<DisplayName person={person} />`
- 
+
 Slower:
 
 `<DisplayName name={person.name} />`.
 
-There is nothing wrong the the latter.
-But a change in the `name` property will in the first case trigger the `DisplayName` to re-render, while in the latter the owner of the component has to re-render.
-However, it is more important for your components to have an comprehensible api then applying this optimization.
+There is nothing wrong to the latter.
+But a change in the `name` property will, in the first case, trigger the `DisplayName` to re-render, while in the latter, the owner of the component has to re-render.
+However, it is more important for your components to have an comprehensible API then applying this optimization.
 To have the best of both worlds, consider making smaller components:
 
-`const PersonNameDispayer = observer(({ props }) => <DisplayName name={props.person.name} />)` 
+`const PersonNameDispayer = observer(({ props }) => <DisplayName name={props.person.name} />)`
 
 ## Bind functions early
 
@@ -87,7 +87,7 @@ Bad:
 
 ```javascript
 render() {
-    return <MyWidget onClick={() => { alert('hi') }} />  
+    return <MyWidget onClick={() => { alert('hi') }} />
 }
 ```
 
@@ -95,7 +95,7 @@ Good:
 
 ```javascript
 render() {
-    return <MyWidget onClick={this.handleClick} />  
+    return <MyWidget onClick={this.handleClick} />
 }
 
 handleClick = () => {
@@ -103,4 +103,4 @@ handleClick = () => {
 }
 ```
 
-The bad example will always yield the `shouldComponent` of `PureRenderMixin` used in `MyWidget` to always yield false as you pass a new function each time the parent is re-rendered. 
+The bad example will always yield the `shouldComponent` of `PureRenderMixin` used in `MyWidget` to always yield false as you pass a new function each time the parent is re-rendered.

--- a/docs/best/store.md
+++ b/docs/best/store.md
@@ -8,20 +8,20 @@ There are many ways of working with MobX and React, and this is just one of them
 
 Let's start with _stores_.
 In the next sections we will discuss _actions_ and React _components_ as well.
-Stores can be found in any flux architecture and can be compared a bit with controllers in the MVC pattern.
-The main responsibility of stores is to move _logic_ and _state_ out of your components into a standalone testable unit that can be used in both frontend and backend javascript.
+Stores can be found in any Flux architecture and can be compared a bit with controllers in the MVC pattern.
+The main responsibility of stores is to move _logic_ and _state_ out of your components into a standalone testable unit that can be used in both frontend and backend JavaScript.
 
 ## Stores for the user interface state
 
 Most applications benefit from having at least two stores.
-One for the _ui state_ and one or more for the _domain state_.
+One for the _UI state_ and one or more for the _domain state_.
 The advantage of separating those two is you can reuse and test _domain state_ universally, and you might very well reuse it in other applications.
 The _ui-state-store_ however is often very specific for your application.
 But usually very simple as well.
-This store typically doesn't have much logic in it, but will store a plethora of loosely coupled pieces of information about the ui.
-This is ideal as most applications will change the ui state often during the development process.
+This store typically doesn't have much logic in it, but will store a plethora of loosely coupled pieces of information about the UI.
+This is ideal as most applications will change the UI state often during the development process.
 
-Things you will typically find in ui stores:
+Things you will typically find in UI stores:
 * Session information
 * Information about how far your application has loaded
 * Information that will not be stored in the backend
@@ -32,13 +32,13 @@ Things you will typically find in ui stores:
   * Currently active theme
 * User interface state as soon as it effects multiple, further unrelated components:
   * Current selection
-  * Visibility of toolbars, etc..
+  * Visibility of toolbars, etc.
   * State of a wizard
   * State of a global overlay
 
 It might very well be that these pieces of information start as internal state of a specific component (for example the visibility of a toolbar).
 But after a while you discover that you need this information somewhere else in your application.
-Instead of pushing state in such a case upwards in the component tree, like you would do in plain react apps, you just move that state to the _ui-state-store_.
+Instead of pushing state in such a case upwards in the component tree, like you would do in plain React apps, you just move that state to the _ui-state-store_.
 
 Make sure this state is a singleton.
 For isomorphic applications you might also want to provide a stub implementation of this store with sane defaults so that all components render as expected.
@@ -53,16 +53,16 @@ import {observable, computed, asStructure} from 'mobx';
 import jquery from 'jquery';
 
 class UiState {
-    @observable language = "en_US";    
+    @observable language = "en_US";
     @observable pendingRequestCount = 0;
 
-    // asStructure makes sure observer won't be signaled onlyif the 
+    // asStructure makes sure observer won't be signaled only if the
     // dimensions object changed in a deepEqual manner
     @observable windowDimensions = asStructure({
         width: jquery(window).width(),
         height: jquery(window).height()
     });
-    
+
 	constructor() {
         jquery.resize(() => {
             this.windowDimensions = getWindowDimensions();
@@ -96,7 +96,7 @@ These are the responsibility of a store:
 * Make sure there is only one instance of each of your domain objects.
 The same user, order or todo should not be twice in your memory.
 This way you can safely use references and also be sure you are looking at the latest instance, without ever having to resolve a reference.
-This is fast, straight forward and convenient when debugging.
+This is fast, straightforward and convenient when debugging.
 * Provide backend integration. Store data when needed.
 * Update existing instances if updates are received from the backend.
 * Provide a stand-alone, universal, testable component of your application.
@@ -104,14 +104,15 @@ This is fast, straight forward and convenient when debugging.
 * There should be only one instance of a store.
 
 ### Domain objects
+
 Each domain object should be expressed using its own class (or constructor function).
 It is recommended to store your data in _denormalized_ form.
 There is no need to treat your client-side application state as some kind of database.
-Real references, cyclic data structures and instance methods are powerful concepts in javascript.
+Real references, cyclic data structures and instance methods are powerful concepts in JavaScript.
 Domain objects are allowed to refer directly to domain objects from other stores.
-Remember; we want to keep our actions and views as simple as possible and needing to manage references and doing garbage collection yourself might be a step backward.
-Unlike many flux architectures, with `mobx` there is no need to denormalize your data, and this makes it a lot simpler to build the _essentially_ complex parts of your application:
-Your business rules, actions and user interface.
+Remember: we want to keep our actions and views as simple as possible and needing to manage references and doing garbage collection yourself might be a step backward.
+Unlike many Flux architectures, with MobX there is no need to denormalize your data, and this makes it a lot simpler to build the _essentially_ complex parts of your application:
+your business rules, actions and user interface.
 
 Domain objects can delegate all their logic to the store they belong to if that suits your application well.
 It is possible to express your domain objects as plain objects, but classes have some important advantages over plain objects:
@@ -268,6 +269,4 @@ export class Todo {
         this.saveHandler();
     }
 }
-
-
 ```

--- a/docs/best/syntax.md
+++ b/docs/best/syntax.md
@@ -3,7 +3,7 @@
 Here are some examples show you how you can make the state of a simple todo application observable,
 using either plain objects or classes.
 MobX ships with TypeScript typings in the package (supported in TypeScript 1.6 and higher).
-So `import * as mobx from "mobx"` gives access to the strongly typed api without further imports.
+So `import * as mobx from "mobx"` gives access to the strongly typed API without further imports.
 
 ## Creating objects
 
@@ -113,16 +113,16 @@ const MyOtherComponent = observer(props => // ..or with destructuring: ({user}) 
 );
 ```
 
-Please note that `onButtonClick` is not just a class method, but an instance field which get a bound function.
+Please note that `onButtonClick` is not just a class method, but an instance field which gets a bound function.
 This is the most convenient and the fastest way to create bound event handlers.
 If `{this.onButtonClick.bind(this)}` or `{(e) => this.onButtonClick(e)}` was used instead in the rendering, each render invocation would create a new closures.
-That is not only slightly slower in itself, 
-but it will also cause the `button` (or any other component) to be always re-rendered because you are effectively passing a new event handler to the button each time `MyComponent` is rendered.  
+That is not only slightly slower in itself,
+but it will also cause the `button` (or any other component) to be always re-rendered because you are effectively passing a new event handler to the button each time `MyComponent` is rendered.
 
 
 ## Enabling decorators in your transpiler
 
 Decorators are not supported by default when using TypeScript or Babel pending a definitive definition in the ES standard.
 * For _typescript_, enable the `--experimentalDecorators` compiler flag or set the compiler option `experimentalDecorators` to `true` in `tsconfig.json` (Recommended)
-* For _babel5_, make sure `--stage 0` is passed to the babel CLI
+* For _babel5_, make sure `--stage 0` is passed to the Babel CLI
 * For _babel6_, see the example configuration as suggested in this [issue](https://github.com/mobxjs/mobx/issues/105)

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -9,8 +9,8 @@ Yes, see the [rx-mobx](https://www.npmjs.com/package/rx-mobx) interoperability p
 
 ##### When to use RxJS instead of MobX?
 For anything that involves explictly working with the concept of time,
-or when you need to reason about the historical values / events of an observable (and not just the latest) RxJs is recommended as it provides the more low level primitives.
-Whenever you want react to _state_ instead of _events_, MobX offers an easier and more high level approach.
+or when you need to reason about the historical values / events of an observable (and not just the latest), RxJs is recommended as it provides more low-level primitives.
+Whenever you want to react to _state_ instead of _events_, MobX offers an easier and more high-level approach.
 In practice, combining RxJS and MobX might result in really powerful constructions.
 Use for example RxJS to process and throttle user events and as a result of that update the state.
 If the state has been made observable by MobX, it will then take care of updating the UI and other derivations accordingly.
@@ -33,12 +33,12 @@ MobX is *not* a framework. It does not tell you how to structure your code, wher
 Flux implementations that do not work on the assumption that the data in their stores is immutable should work well with MobX.
 However, the need for Flux is reduced when using MobX.
 MobX already optimizes rendering, and it works with most kinds of data, including cycles and classes.
-So other programming paradigms like classic MVC can now be easily applied in applications that combine ReactJS with mobx.
+So other programming paradigms like classic MVC can now be easily applied in applications that combine ReactJS with MobX.
 
 ##### Can I use MobX together with framework X?
 
 Probably.
-MobX is framework agnostic and can be applied in any JS environment.
+MobX is framework agnostic and can be applied in any modern JS environment.
 It just ships with a small function to transform ReactJS components into reactive view functions for convenience.
 MobX works just as well server side, and is already combined with jQuery (see this [Fiddle](http://jsfiddle.net/mweststrate/vxn7qgdw)) and [Deku](https://gist.github.com/mattmccray/d8740ea97013c7505a9b).
 
@@ -48,5 +48,5 @@ Yes, see [createTransformer](http://mobxjs.github.io/mobx/refguide/create-transf
 
 ##### Can you tell me how it works?
 
-Sure, join the reactiflux channel our checkout [dnode.ts](lib/dnode.ts). Or, submit an issue to motivate me to make some nice drawings :).
-And look at this [Medium article](https://medium.com/@mweststrate/becoming-fully-reactive-an-in-depth-explanation-of-mobservable-55995262a254 ).
+Sure, join the reactiflux channel or checkout the code. Or, submit an issue to motivate me to make some nice drawings :).
+And look at this [Medium article](https://medium.com/@mweststrate/becoming-fully-reactive-an-in-depth-explanation-of-mobservable-55995262a254).

--- a/docs/intro/concepts.md
+++ b/docs/intro/concepts.md
@@ -80,4 +80,4 @@ todoStore.todos[0].completed = true;
 
 ```
 
-In the [10 minute introduction to MobX and React](https://mobxjs.github.io/mobx/getting-started.html) you can dive deeper into this example and build an user interface using [React](https://facebook.github.io/react/) around it.
+In the [10 minute introduction to MobX and React](https://mobxjs.github.io/mobx/getting-started.html) you can dive deeper into this example and build a user interface using [React](https://facebook.github.io/react/) around it.

--- a/docs/intro/overview.md
+++ b/docs/intro/overview.md
@@ -21,9 +21,9 @@ var appState = observable({
 We didn't make our `appState` observable just for nothing;
 you can now create views that automatically update whenever relevant data in the `appState` changes.
 MobX will find the minimal way to update your views.
-This single fact saves you ton's of boilerplate and is [wickedly efficient](mendix.com/tech-blog/making-react-reactive-pursuit-high-performing-easily-maintainable-react-apps/).
+This single fact saves you tons of boilerplate and is [wickedly efficient](https://mendix.com/tech-blog/making-react-reactive-pursuit-high-performing-easily-maintainable-react-apps/).
 
-Generally speaking any function can become a reactive view that observes it data, and MobX can be applied in any ES5 conformant JavaScript environment.
+Generally speaking any function can become a reactive view that observes its data, and MobX can be applied in any ES5 conformant JavaScript environment.
 But here is an (ES6) example of a view in the form of a React component.
 
 ```javascript

--- a/docs/refguide/api.md
+++ b/docs/refguide/api.md
@@ -1,13 +1,13 @@
-## Top level api
+## Top level API
 
 These are the most important functions available in the `mobx` namespace:
 
 ### [observable(value)](observable)
-The `observable` function is the swiss knife of mobx and enriches any data structure or function with observable capabilities.
+The `observable` function is the Swiss knife of MobX and enriches any data structure or function with observable capabilities.
 
 ### [autorun(function)](autorun)
-Turns a function into an observer so that it will automatically be re-evaluated if any data values it uses changes.
+Turns a function into an observer so that it will automatically be re-evaluated if any data value it uses changes.
 
 ### [observer(reactJsComponent)](observer-component)
-The `observer` function (and ES6 decorator) from the `mobx-react` turns any Reactjs component into a reactive one.
+The `observer` function (and ES6 decorator) from the `mobx-react` turns any ReactJS component into a reactive one.
 From there on it will responds automatically to any relevant change in _observable_ data that was used by its render method.

--- a/docs/refguide/autorun-async.md
+++ b/docs/refguide/autorun-async.md
@@ -4,18 +4,18 @@
 
 Just like `autorun` except that the action won't be invoked synchronously but asynchronously after the minimum amount of milliseconds has passed.
 The `action` will be run and observed.
-However, instead of running the action immediately when the values observed by it have changed, the `minimumDelay` will be awaited before re-execution the `action` again.
+However, instead of running the action immediately when the values it observes have changed, the `minimumDelay` will be awaited before re-execution the `action` again.
 
-If observed values are changed multiple times while waiting, the action is still triggered only once, so in the sense it achieves a similar effect as a transaction.
+If observed values are changed multiple times while waiting, the action is still triggered only once, so in a sense it achieves a similar effect than a transaction.
 This might be useful for stuff that is expensive and doesn't need to happen synchronously; such as debouncing server communication.
 
 Returns a disposer to cancel the autorun.
 
 ```javascript
 autorunAsync(() => {
-	// assuming that profile.asJson returns an observable json representation of profile,
-	// send it to the server each time it is changed, but await at least 300mseconds before sending it
-	// when send, the latest value of profile.asJson will be used.
+	// Assuming that profile.asJson returns an observable Json representation of profile,
+	// send it to the server each time it is changed, but await at least 300 milliseconds before sending it.
+	// When sent, the latest value of profile.asJson will be used.
 	sendProfileToServer(profile.asJson);
 }, 300);
 ```

--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -1,17 +1,17 @@
 # @computed
 
 Decorator that can be used on ES6 or TypeScript derivable class properties to make them observable.
-The @computed can only be used on `get` functions for instance properties. 
+The `@computed` can only be used on `get` functions for instance properties.
 
 Use `@computed` if you have a value that can be derived in a pure manner from other observables.
 
-Don't confuse `@computed` with `autorun`. They are both reactively invoked expressions, 
-but use `@computed` if you want to reactively produce a new value that can be used by other observers and 
+Don't confuse `@computed` with `autorun`. They are both reactively invoked expressions,
+but use `@computed` if you want to reactively produce a new value that can be used by other observers and
 `autorun` if you don't want to produce a new value but rather invoke some imperative code like logging, network requests etc.
 
 Computed properties can be optimized away in many cases by MobX as they are assumed to be pure.
-So they will not be invoked when there input parameters didn't modifiy or if they are not observed by some other computed value or autorun. 
- 
+So they will not be invoked when their input parameters didn't modifiy or if they are not observed by some other computed value or autorun.
+
 
 ```javascript
 import {observable, computed} from "mobx";
@@ -34,20 +34,20 @@ If your environment doesn't support decorators or field initializers,
 `@computed get funcName() { }` is sugar for [`extendObservable(this, { funcName: func })`](extend-observable.md)
 
 
-@computed be parameterized. @computed({asStructure: true}) makes sure that the result of a derivation is compared structurally instead of referentially with its preview value. This makes sure that observers of the computation don't re-evaluate if new structures are returned that are structurally equal to the original ones. This is very useful when working with point, vector or color structures for example. It behaves the same as the asStructure modifier for observable values.
+`@computed` be parameterized. `@computed({asStructure: true})` makes sure that the result of a derivation is compared structurally instead of referentially with its preview value. This makes sure that observers of the computation don't re-evaluate if new structures are returned that are structurally equal to the original ones. This is very useful when working with point, vector or color structures for example. It behaves the same as the `asStructure` modifier for observable values.
 
-@computed properties are not enumerable.
+`@computed` properties are not enumerable.
 
 ### Enabling decorators in your transpiler
 
 Decorators are not supported by default when using TypeScript or Babel pending a definitive definition in the ES standard.
 * For _typescript_, enable the `--experimentalDecorators` compiler flag or set the compiler option `experimentalDecorators` to `true` in `tsconfig.json` (Recommended)
-* For _babel5_, make sure `--stage 0` is passed to the babel CLI
+* For _babel5_, make sure `--stage 0` is passed to the Babel CLI
 * For _babel6_, see the example configuration as suggested in this [issue](https://github.com/mobxjs/mobx/issues/105)
 
 # `computed(expression)`
 
-`computed` can also be invoked directly as function. 
+`computed` can also be invoked directly as function.
 Just like `observable(primitive value)` it will create a stand-alone observable.
 Use `.get()` on the returned object to get the current value of the computation, or `.observe(callback)` to observe it's changes.
 
@@ -96,5 +96,5 @@ so make sure your code doesn't rely on any side effects in those functions.
 ---
 
 These two forms of `observable`, one for primitives and references, and one for functions, form the core of MobX.
-The rest of the api is just syntactic sugar around these two core operations.
+The rest of the API is just syntactic sugar around these two core operations.
 Nonetheless, you will rarely use these forms; using objects is just a tat more convenient.

--- a/docs/refguide/create-transformer.md
+++ b/docs/refguide/create-transformer.md
@@ -3,17 +3,17 @@
 `createTransformer<A, B>(transformation: (value: A) => B, onCleanup?: (result: B, value?: A) => void): (value: A) => B`
 
 `createTransformer` turns a function (that should transforms one value into another value) into a reactive and memoizing function.
-In other words, if the `transformation` functions computes B given a specific A, the same B will be returned for all other future invocations of the transformation with the same A.
+In other words, if the `transformation` function computes B given a specific A, the same B will be returned for all other future invocations of the transformation with the same A.
 However, if A changes, the transformation will be re-applied so that B is updated accordingly.
 And last but not least, if nobody is using the transformation of a specific A anymore, it's entry will be removed from the memoization table.
 
 With `createTransformer` it is very easy to transform a complete data graph into another data graph.
 Transformation functions can be composed so that you can build a tree using lots of small transformations.
 The resulting data graph will never be stale, it will be kept in sync with the source by applying small patches to the result graph.
-This makes it very easy to achieve powerful patterns similar to like sideways data loading, map-reduce, tracking state history using immutable data structures etc...
+This makes it very easy to achieve powerful patterns similar to sideways data loading, map-reduce, tracking state history using immutable data structures etc.
 
 The optional `onCleanup` function can be used to get a notification when a transformation of an object is no longer needed.
-This can be used to dispose resources attached to the result object if needed. 
+This can be used to dispose resources attached to the result object if needed.
 
 Always use transformations inside a reaction like `@observer` or `autorun`.
 Transformations will, like any other computed value, fall back to lazy evaluation if not observed by something, which sort of defeats their purpose.
@@ -63,13 +63,13 @@ The autorunner triggers the serialization of the `store` object, which in turn s
 Let's take closer look at the life of an imaginary example box#3.
 
 1. The first time box#3 is passed by `map` to `serializeBox`,
-the serializeBox transformation is executed and an entry containing box#3 and it's serialized representation is added to the internal memoization table of `serializeBox`.
+the serializeBox transformation is executed and an entry containing box#3 and its serialized representation is added to the internal memoization table of `serializeBox`.
 2. Imagine that another box is added to the `store.boxes` list.
 This would cause the `serializeState` function to re-compute, resulting in a complete remapping of all the boxes.
 However, all the invocations of `serializeBox` will now return their old values from the memoization tables since their transformation functions didn't (need to) run again.
 3. Secondly, if somebody changes a property of box#3 this will cause the application of the `serializeBox` to box#3 to re-compute, just like any other reactive function in MobX.
-Since the transformation will now produce a new json object based on box#3, all observers of that specific transformation will be forced to run again as well.
-The `serializeState` transformation in this case.
+Since the transformation will now produce a new Json object based on box#3, all observers of that specific transformation will be forced to run again as well.
+That's the `serializeState` transformation in this case.
 `serializeState` will now produce a new value in turn and map all the boxes again. But except for box#3, all other boxes will be returned from the memoization table.
 4. Finally, if box#3 is removed from `store.boxes`, `serializeState` will compute again.
 But since it will no longer be using the application of `serializeBox` to box#3,
@@ -78,16 +78,16 @@ This signals the memoization table that the entry can be removed so that it is r
 
 So effectively we have achieved state tracking using immutable, shared datas structures here.
 All boxes and arrows are mapped and reduced into single state tree.
-Each change will result in a new entry in the `states` array, but the different entries will share almost all of their box and arrow representations. 
+Each change will result in a new entry in the `states` array, but the different entries will share almost all of their box and arrow representations.
 
 ## Transforming a datagraph into another reactive data graph
 
 Instead of returning plain values from a transformation function, it is also possible to return observable objects.
 This can be used to transform an observable data graph into a another observable data graph, which can be used to transform... you get the idea.
 
-Here is small example that encodes a reactive file explorer that will update it's representation upon each change. 
+Here is a small example that encodes a reactive file explorer that will update its representation upon each change.
 Data graphs that are built this way will in general react a lot faster and will consist of much more straight-forward code,
-in comparison to derived data graph that are updated using your own code. See the [performance tests](https://github.com/mobxjs/mobx/blob/3ea1f4af20a51a1cb30be3e4a55ec8f964a8c495/test/perf/transform-perf.js#L4) for some examples.
+compared to derived data graph that are updated using your own code. See the [performance tests](https://github.com/mobxjs/mobx/blob/3ea1f4af20a51a1cb30be3e4a55ec8f964a8c495/test/perf/transform-perf.js#L4) for some examples.
 
 Unlike the previous example, the `transformFolder` will only run once as long as a folder remains visible;
 the `DisplayFolder` objects track the associated `Folder` objects themselves.
@@ -95,10 +95,10 @@ the `DisplayFolder` objects track the associated `Folder` objects themselves.
 In the following example all mutations to the `state` graph will be processed automatically.
 Some examples:
 1. Changing the name of a folder will update it's own `path` property and the `path` property of all its descendants.
-2. Collapsing a folder will remove all descendant DisplayFolders from the tree.
+2. Collapsing a folder will remove all descendant `DisplayFolders` from the tree.
 3. Expanding a folder will restore them again.
-4. Setting a search filter will remove all nodes that do not match the filter, unless they have a descendant that matches the filter.  
-5. Etc...
+4. Setting a search filter will remove all nodes that do not match the filter, unless they have a descendant that matches the filter.
+5. Etc.
 
 
 
@@ -107,7 +107,7 @@ function Folder(parent, name) {
 	this.parent = parent;
 	m.extendObservable(this, {
 		name: name,
-		children: m.fastArray(),
+		children: m.asFlat([]),
 	});
 }
 

--- a/docs/refguide/expr.md
+++ b/docs/refguide/expr.md
@@ -1,10 +1,10 @@
 # Expr
 
 `expr` can be used to create temporarily computed values inside computed values.
-Nesting computed values is useful when you use it to split of cheap computations to prevent expensive computations to run.
+Nesting computed values is useful to create cheap computations to prevent expensive computations to run.
 
-In the following example the expression prevents that the `TodoView` component is re-rendered if the selection changes.
-Instead the component will only re-render each time that the relevant todo is (de)selected.
+In the following example the expression prevents that the `TodoView` component is re-rendered if the selection changes elsewhere.
+Instead the component will only re-render when the relevant todo is (de)selected.
 
 ```javascript
 const TodoView = observer(({todo, editorState}) => {

--- a/docs/refguide/extending.md
+++ b/docs/refguide/extending.md
@@ -4,12 +4,12 @@
 
 At some point you might want to have more data structures or other things (like streams) that can be used in reactive computations.
 Achieving that is pretty simple by using the `Atom` class.
-Atoms can be used to signal mobx that some observable data source has been observed or changed.
-And mobx will signal the atom whenever it is used or no longer in use.
+Atoms can be used to signal MobX that some observable data source has been observed or changed.
+And MobX will signal the atom whenever it is used or no longer in use.
 
 The following example demonstrates how you can create an observable `Clock`, which can be used in reactive functions,
-and returns the current date time.
-This clock will only actually tick if it is observed by someone. 
+and returns the current date-time.
+This clock will only actually tick if it is observed by someone.
 
 The complete API of the `Atom` class is demonstrated by this example.
 
@@ -20,45 +20,45 @@ class Clock {
 	atom;
 	intervalHandler = null;
 	currentDateTime;
-	
+
 	constructor() {
-		// creates an atom to interact with the mobx core algorithm
+		// creates an atom to interact with the MobX core algorithm
 		this.atom =	new Atom(
-			// first param a name for this atom, for debugging purposes
+			// first param: a name for this atom, for debugging purposes
 			"Clock",
 			// second (optional) parameter: callback for when this atom transitions from unobserved to observed.
 			() => this.startTicking(),
 			// third (optional) parameter: callback for when this atom transitions from observed to unobserved
-			// note that the same atom transition multiple times between these two states
+			// note that the same atom transitions multiple times between these two states
 			() => this.stopTicking()
-		); 
+		);
 	}
-	
+
 	getTime() {
-		// let mobx know this observable data source has been used
-		this.atom.reportObserved();	
+		// let MobX know this observable data source has been used
+		this.atom.reportObserved();
 		if (!this.intervalHandler) {
 			this.tick(); // do the initial tick
 		}
 		return this.currentDateTime;
 	}
-	
+
 	tick() {
 		this.currentDateTime = new Date();
-		// let mobx know that this data source has changed
+		// let MobX know that this data source has changed
 		this.atom.reportChanged();
 	}
-	
+
 	startTicking() {
 		this.intervalHandler = setInterval(
-			() => this.tick(), 
+			() => this.tick(),
 			1000
 		);
 	}
-	
+
 	stopTicking() {
 		clearInterval(this.intervalHandler);
-		this.intervalHandler = null;	
+		this.intervalHandler = null;
 	}
 }
 
@@ -76,7 +76,7 @@ disposer();
 ## Reactions
 
 `Reaction` allows you to create your own 'auto runner'.
-Reactions track a function and signal when the function should be executed again because one or more dependencies have changed. 
+Reactions track a function and signal when the function should be executed again because one or more dependencies have changed.
 
 
 

--- a/docs/refguide/extras.md
+++ b/docs/refguide/extras.md
@@ -1,4 +1,4 @@
-This are utilities exposed by mobx which might come in handy at some point. But most probably you won't need them. Ever.
+This are utilities exposed by MobX which might come in handy at some point. But most probably you won't need them. Ever.
 
 ## SimpleEventEmitter
 

--- a/docs/refguide/is-observable.md
+++ b/docs/refguide/is-observable.md
@@ -1,6 +1,6 @@
 # isObservable
 
-Returns true if the given value was made observable by mobx.
+Returns true if the given value was made observable by MobX.
 Optionally accepts a second string parameter to see whether a specific property is observable.
 
 ```javascript
@@ -19,12 +19,12 @@ isObservable(person, "age"); // false
 
 # isObservableMap
 
-Returns true if the given object is created using `mobx.map`
+Returns true if the given object is created using `mobx.map`.
 
 # isObservableArray
 
-Returns true if the given obect is an array that was made observable using `mobx.observable(array)`
+Returns true if the given obect is an array that was made observable using `mobx.observable(array)`.
 
 # isObservableObject
 
-Returns true if the given object is an object that was made observable using `mobx.observable(object)`
+Returns true if the given object is an object that was made observable using `mobx.observable(object)`.

--- a/docs/refguide/map.md
+++ b/docs/refguide/map.md
@@ -18,7 +18,7 @@ It is not needed to use the `new` keyword, `map` will always return a newly crea
 * `clear()`. Removes all entries from this map.
 * `size`. Returns the amount of entries in this map.
 
-The following functions are not in the ES6 spec but available in MobX:
-* `toJs()`. Returns a shallow plain object representation of this map. (For a deep copy use `mobx.toJSON(map)`). 
+The following functions are not in the ES6 spec but are available in MobX:
+* `toJs()`. Returns a shallow plain object representation of this map. (For a deep copy use `mobx.toJSON(map)`).
 * `observe(listener)`. Registers a listener that fires upon each change in this map, similarly to the events that are emitted for [Object.observe](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/observe).
 * `merge(object | map)`. Copies all entries from the provided object into this map.

--- a/docs/refguide/modifiers.md
+++ b/docs/refguide/modifiers.md
@@ -1,4 +1,4 @@
-# modifiers for observable
+# Modifiers for observable
 
 By default, `observable` recursively makes all the values of _plain_ objects and arrays recursively observable.
 Besides that it automatically converts functions without arguments into reactive views or derived properties.
@@ -8,7 +8,7 @@ Note that modifiers are 'sticky', they are interpreted as being annotations.
 They do not only apply to the current value, but also to all values that are assigned in the future to the same attribute.
 
 Note that the attributes class instances (all objects that have a prototype) will not be made observable automatically by `observable`.
-It is considered to be the responsibility of the class definition / constructor function to mark the necessary attributes of an class instance observable / computed. 
+It is considered to be the responsibility of the class definition / constructor function to mark the necessary attributes of an class instance observable / computed.
 
 ## asReference
 
@@ -35,7 +35,7 @@ console.log(test.someFunc); // still a function
 
 ## asStructure
 
-Can be used on non-cyclic, plain javascript values.
+Can be used on non-cyclic, plain JavaScript values.
 Instead of comparing old values with new values based on whether the reference has changed, values are compared using deep equality before notifying any observers.
 This is useful if you are working with 'struct' like objects like colors or coordinates.
 `asStructure` can be used on reactive functions, plain objects and arrays.

--- a/docs/refguide/observable-decorator.md
+++ b/docs/refguide/observable-decorator.md
@@ -2,7 +2,7 @@
 
 Decorator that can be used on ES6 or TypeScript class properties to make them observable.
 The @observable can be used on instance fields and property getters.
-This offers fine-grained control on which parts of your object should become observable.
+This offers fine-grained control on which parts of your object become observable.
 
 ```javascript
 import {observable} from "mobx";
@@ -29,5 +29,5 @@ If your environment doesn't support decorators or field initializers,
 
 Decorators are not supported by default when using TypeScript or Babel pending a definitive definition in the ES standard.
 * For _typescript_, enable the `--experimentalDecorators` compiler flag or set the compiler option `experimentalDecorators` to `true` in `tsconfig.json` (Recommended)
-* For _babel5_, make sure `--stage 0` is passed to the babel CLI
+* For _babel5_, make sure `--stage 0` is passed to the Babel CLI
 * For _babel6_, see the example configuration as suggested in this [issue](https://github.com/mobxjs/mobx/issues/105)

--- a/docs/refguide/observable.md
+++ b/docs/refguide/observable.md
@@ -1,6 +1,6 @@
 # observable
 
-`observable` is to MobX as `$` is to jQuery.
+`observable` is to MobX what `$` is to jQuery.
 Making data observable starts with this function.
 If data is observable, views that depend on that data will update automatically.
 
@@ -10,7 +10,7 @@ but these are the available variations:
 
 ## Objects
 
-If a plain javascript object is passed to `observable` (that is, an object that wasn't created using a constructor function),
+If a plain JavaScript object is passed to `observable` (that is, an object that wasn't created using a constructor function),
 MobX will recursively pass all its values through `observable`.
 This way the complete object (tree) is in-place instrumented to make it observable.
 
@@ -46,7 +46,7 @@ Properties that are added to the object at a later time won't become observable,
 * Only plain objects will be made observable. For non-plain objects it is considered the responsibility of the constructor to initialize the observable properties.
 Either use the [`@observable`](observable.md) annotation or the [`extendObservable`](extend-observable.md) function.
 * Argumentless functions will be automatically turned into views, just like [`@computed`](computed-decorator) would do. For view `this` will be automatically bound to the object it is defined on.
-However, if a function expression (ES6 / typescript) is used, `this` will be bound to undefined, so you probably want to either refer to the object directly, or use a classic function.
+However, if a function expression (ES6 / TypeScript) is used, `this` will be bound to `undefined`, so you probably want to either to refer to the object directly, or to use a classic function.
 * `observable` is applied recursively, both on instantiation and to any new values that will be assigned to observable properties in the future.
 * These defaults are fine in 95% of the cases, but for more fine-grained on how and which properties should be made observable, see the [modifiers](modifiers.md) section.
 
@@ -90,7 +90,7 @@ Bear in mind that `Array.isArray(observable([]))` will yield `false`, so wheneve
 it is a good idea to _create a shallow copy before passing it to other libraries or built-in functions_ (which is good practice anyway) by using `array.slice()` or `array.peek()`.
 So `Array.isArray(observable([]).slice())` will yield `true`.
 
-Unlike the built-in implementation of the functions `sort` and `reverse`, observableArray.sort and reverse  will not change the array in-place, but only will return a sorted / reversed copy. 
+Unlike the built-in implementation of the functions `sort` and `reverse`, observableArray.sort and reverse  will not change the array in-place, but only will return a sorted / reversed copy.
 
 Besides all built-in functions, the following goodies are available as well on observable arrays:
 
@@ -99,15 +99,15 @@ Besides all built-in functions, the following goodies are available as well on o
 * `replace(newItems)` Replaces all existing entries in the array with new ones.
 * `find(predicate: (item, index, array) => boolean, thisArg?, fromIndex?)` Basically the same as the ES7 `Array.find` proposal, except for the additional `fromIndex` parameter.
 * `remove(value)` Remove a single item by value from the array. Returns `true` if the item was found and removed.
-* `peek()` Returns an array with all the values which can safely be passed to other libraries, similar to `slice()`.  
-In contrast to `slice`, `peek` peek doesn't create a defensive copy. Use this in performance critical applications if you know for sure that you use the array in a read-only manner.  
-In performance cricital sections it is recommend to use [fastArray](../refguide/fast-array.md) as well.
+* `peek()` Returns an array with all the values which can safely be passed to other libraries, similar to `slice()`.
+In contrast to `slice`, `peek` doesn't create a defensive copy. Use this in performance critical applications if you know for sure that you use the array in a read-only manner.
+In performance critical sections it is recommend to use a flat observable array as well.
 
 
 ## Primitive values and references
 
 For all type of values, with the exception of _plain objects_, _arrays_ and _functions without arguments_ this overload is run.
-In practice, you probably won't use this overload as it is often more convenient to use `observable` on an object or 
+In practice, you probably won't use this overload as it is often more convenient to use `observable` on an object or
 [`extendObservable`](../refguide/extend-observable.md) (or `@observable`) to introduce observable properties on existing objects.
 
 `observable` accepts scalar values and returns an object with a getter / setter function that holds this value.

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -1,23 +1,23 @@
 # Observe
 
 Given an observable `object` and a `listener` method, `observe(object, listener)` starts listening for changes on the given object.
-The callbacks are invoked with values as described in the specs of 
+The callbacks are invoked with values as described in the specs of
 [Object.observe](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/observe)
 and [Array.observe](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/observe).
 
 Unlike `autorun`, `observe` does not respect transactions and is always invoked immediately after altering an object. This makes it useful for invariant checking or input transformations.
-But note that in most cases `autorun` is a better and more powerful alternative to observe. Especially for scalars and objects.
+But note that in most cases `autorun` is a better and more powerful alternative to `observe`. Especially for scalars and objects.
 
 Accepted objects are:
 * Observable maps (created using `mobx.map(object)`). Possibly emitted event types are: `"add"`, `"update"` and `"delete"`.
 * Observable objects (created using `mobx.observable(object)`). Possibly emitted event types are `"update"`, and in combination with `extendObservable`, `"add"` might fire as well.
 * Observable arrays (created using `mobx.observable(array)`). Possibly emitted event types are `"update"` and `"splice"`.
-* Plain objects will be passed through `mobx.observable` first. See 'Observable objects' for further details. 
+* Plain objects will be passed through `mobx.observable` first. See 'Observable objects' for further details.
 * Plain arrays are _not_ accepted by `observe`. Pass them through `mobx.observable` first.
 * Observable object / map + property name (string) can be used to observe a single property.
 
 The function returns a `disposer` function that can be used to cancel the observer.
-Note that `transaction` does not affect the working of the `observe` method(s). This means that even inside an transaction `observe` will fire its listeners for each mutation.
+Note that `transaction` does not affect the working of the `observe` method(s). This means that even inside a transaction `observe` will fire its listeners for each mutation.
 Hence `autorun` is usually a more powerful alternative.
 
 Example:

--- a/docs/refguide/observer-component.md
+++ b/docs/refguide/observer-component.md
@@ -1,7 +1,7 @@
 # @observer
 
 The `observer` function / decorator can be used to turn ReactJS components into reactive components.
-It wraps the component's render function in `mobx.autorun` to make sure that any data that is used during the rendering of a component forces a rerendering upon change.
+It wraps the component's render function in `mobx.autorun` to make sure that any data that is used during the rendering of a component forces a re-rendering upon change.
 It is available through the separate `mobx-react` package.
 
 ```javascript
@@ -24,12 +24,12 @@ setInterval(() => {
 React.render(<Timer timerData={timerData} />, document.body)
 ```
 
-Tip: when `observer` needs to be combined with other decorators or higher-order-components, make sure that `observer` is the most inner (first applied) decorator;
+Tip: when `observer` needs to be combined with other decorators or higher-order-components, make sure that `observer` is the innermost (first applied) decorator;
 otherwise it might do nothing at all.
 
 ## ES5 support
 
-In ES5 environments, observer components can be simple declared using `observer(React.createClass({ ... `. See also the [syntax guide](../best/syntax)
+In ES5 environments, observer components can be simple declared using `observer(React.createClass({ ... `. See also the [syntax guide](../best/syntax.md)
 
 ## Stateless function components
 
@@ -48,7 +48,7 @@ const Timer = observer(({ props }) =>
 Just like normal classes, you can introduce observable properties on a component by using the `@observable` decorator.
 This means that you can have local state in components that doesn't need to be manged by React's verbose and imperative `setState` mechanism, but is as powerful.
 The reactive state will be picked up by `render` but will not explicitly invoke other React lifecycle methods like `componentShouldUpdate` or `componentWillUpdate`.
-If you need those, just use the normal React `state` based api's.
+If you need those, just use the normal React `state` based APIs.
 
 The example above could also have been written as:
 
@@ -58,13 +58,13 @@ import {observable} from "mobx"
 
 @observer class Timer extends React.Component {
 	@observable secondsPassed = 0
-	
+
 	componentWillMount() {
 		setInterval(() => {
 			this.secondsPassed++
 		}, 1000)
 	}
-	
+
 	render() {
 		return (<span>Seconds passed: { this.secondsPassed } </span> )
 	}
@@ -92,7 +92,7 @@ See the relevant [section](../best/react-performance.md).
 
 ## MobX-React-DevTools
 
-In combination with `@observer` you can use the MobX-React-DevTools, it shows exactly when your components are rerendered and you can inspect the data dependencies of your components.
+In combination with `@observer` you can use the MobX-React-DevTools, it shows exactly when your components are re-rendered and you can inspect the data dependencies of your components.
 See the [DevTools](../best/devtools.md) section.
 
 ## Characteristics of observer components
@@ -108,5 +108,5 @@ See the [DevTools](../best/devtools.md) section.
 
 Decorators are not supported by default when using TypeScript or Babel pending a definitive definition in the ES standard.
 * For _typescript_, enable the `--experimentalDecorators` compiler flag or set the compiler option `experimentalDecorators` to `true` in `tsconfig.json` (Recommended)
-* For _babel5_, make sure `--stage 0` is passed to the babel CLI
+* For _babel5_, make sure `--stage 0` is passed to the Babel CLI
 * For _babel6_, see the example configuration as suggested in this [issue](https://github.com/mobxjs/mobx/issues/105)

--- a/docs/refguide/transaction.md
+++ b/docs/refguide/transaction.md
@@ -1,7 +1,7 @@
 # Transaction
 
 `transaction(worker: () => void)` can be used to batch a bunch of updates without notifying any observers until the end of the transaction.
-`transaction` takes a single, paremeterless `worker` function as argument and runs it.
+`transaction` takes a single, parameterless `worker` function as argument and runs it.
 No observers are notified until this function has completed.
 `transaction` returns any value that was returned by the `worker` function.
 Note that `transaction` runs completely synchronously.

--- a/docs/refguide/when.md
+++ b/docs/refguide/when.md
@@ -19,11 +19,11 @@ class MyResource {
 			() => this.dispose()
 		);
 	}
-	
+
 	@observable get isVisible() {
 		// indicate whether this item is visible
 	}
-	
+
 	dispose() {
 		// dispose
 	}
@@ -31,4 +31,4 @@ class MyResource {
 
 ```
 
-_In mobx 1.0 this method was called `autorunUntil`._
+_In MobX 1.0 this method was called `autorunUntil`._


### PR DESCRIPTION
Another round of nitpicking changes... :smile: 

Beyond fixing typos and improving consistency (case of names, among others), I made an editorial change I mentioned in issues: I removed the two mentions of fastArray, one in text and one in code.
For the latter, I replaced with `m.asFlat([])` (I hope it is correct), for the former, I mentioned this "trick".

Obviously, feel free to revert or change any modification I made...