### PR TITLE
Fixed a typo in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ MobX is one of the least obtrusive libraries you can use for state management. T
 With MobX you don't need to normalize your data. This makes the library very suitable for very complex domain models (At Mendix for example ~500 different domain classes in a single application).
 
 ### Referential integrity is guaranteed
-Since data doesn't need to be normalized, and MobX automatically tracks the relations between state and derivations, you get referential integrity for free. Rendering something that is accessed through three levels of indirection? No problem, MobX will track them and re-render whenever one of the references changes. As a result staleness bugs are a thing of the past. As a programmer you might forget that changing some data might influence an seemingly unrelated component in a corner case. MobX won't forget.
+Since data doesn't need to be normalized, and MobX automatically tracks the relations between state and derivations, you get referential integrity for free. Rendering something that is accessed through three levels of indirection? No problem, MobX will track them and re-render whenever one of the references changes. As a result staleness bugs are a thing of the past. As a programmer you might forget that changing some data might influence a seemingly unrelated component in a corner case. MobX won't forget.
 
 ### Simpler actions are easier to maintain
 As demonstrated above, modifying state when using MobX is very straightforward. You simply write down your intentions. MobX will take care of the rest.


### PR DESCRIPTION
"An" should be "a" in line 144 of the readme:

"...changing some data might influence a seemingly unrelated component in ~~an~~ **a** corner case.  Mobx won't forget."
