### PR TITLE
'computed.observe should not establish new observers on callback'

### DIFF
--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -120,7 +120,9 @@ export class ComputedValue<T> implements IObservable, IDerivation {
 		return autorun(() => {
 			let newValue = this.get();
 			if (!firstTime || fireImmediately) {
+				globalState.inUntracked++;
 				listener(newValue, prevValue);
+				globalState.inUntracked--;
 			}
 			firstTime = false;
 			prevValue = newValue;

--- a/test/observe.js
+++ b/test/observe.js
@@ -43,3 +43,28 @@ test('observe object and map properties', function(t) {
 	
 	t.end();	
 });
+
+test('observe computed values', function(t) {
+	var eventsCount = 0;
+
+	var o = m.observable({
+		a: 5,
+		b: 5,
+	});
+
+	var c = m.computed(function() { return o.a; });
+
+	var d2 = c.observe(function() {
+		o.a;
+		o.b;
+		eventsCount++;
+	});
+
+	o.a = 6;
+	o.b = 100000;
+
+	t.equal(eventsCount, 1);
+
+	t.end();
+
+});

--- a/test/observe.js
+++ b/test/observe.js
@@ -45,25 +45,24 @@ test('observe object and map properties', function(t) {
 });
 
 test('observe computed values', function(t) {
-	var eventsCount = 0;
+	var events = [];
 
-	var o = m.observable({
-		a: 5,
-		b: 5,
+	var v = m.observable(0);
+	var f = m.observable(0);
+	var c = m.computed(function() { return v.get(); });
+
+	var d2 = c.observe(function(newV, oldV) {
+		v.get();
+		f.get();
+		events.push([newV, oldV]);
 	});
 
-	var c = m.computed(function() { return o.a; });
+	v.set(6);
+	f.set(10);
 
-	var d2 = c.observe(function() {
-		o.a;
-		o.b;
-		eventsCount++;
-	});
-
-	o.a = 6;
-	o.b = 100000;
-
-	t.equal(eventsCount, 1);
+	t.deepEqual(events, [
+		[6, 0]
+	]);
 
 	t.end();
 


### PR DESCRIPTION
The problem:
```js
var obs = observable({a: 1, b: 1});
var targetValue = observable(1);
var someComputed = computed(() => targetValue.get());
someComputed.observe(() => console.log(obs.a, obs.b));

targetValue.set(2); // ok, logs 1 1
obs.a = 2;          // fail, logs 2 1
obs.b = 2;          // fail, logs 2 2
```