### PR TITLE
Fix context in @action

### DIFF
--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -53,13 +53,7 @@ function babelActionValueDecorator(name: string, target, prop, descriptor): Prop
 		configurable: true,
 		enumerable: false,
 		get: function() {
-			const implementation = action(name, descriptor.initializer.call(this));
-			Object.defineProperty(target, prop, {
-				enumerable: false,
-				writable: false,
-				value: implementation
-			});
-			return implementation;
+			return action(name, descriptor.initializer.call(this));
 		},
 		set: function() {
 			invariant(false, "@action decorated fields cannot be overwritten");


### PR DESCRIPTION
After applying `@action` decorator `this` is equal to the first class instance of method, that this decorator was applied to.

For example:

```js
class Component {
  constructor(componentNum) {
    this.name = `component-${componentNum}`;
  }

  @action execAction = () => {
    console.log(this.componentNumber);
  }
}

const c1 = new Component(1);
const c2 = new Component(2);

c1.execAction(); // logs: "component-1"
c2.execAction(); // logs: "component-1" instead of "component-2"
```

This used to happen because of memoization in `babelActionValueDecorator`. This PR removes that memoization.