### PR TITLE
gh-pages: fix typo

### DIFF
--- a/refguide/transaction.html
+++ b/refguide/transaction.html
@@ -5,7 +5,7 @@
         
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>transactoin | MobX</title>
+        <title>transaction | MobX</title>
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
         <meta name="description" content="">
         <meta name="generator" content="GitBook 2.2.0">


### PR DESCRIPTION
"transactoin" -> "transaction" in title