### PR TITLE
Fix typo in docs: observer -> observe.

### DIFF
--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -2,7 +2,7 @@
 
 `observe` and `intercept` can be used to monitor the changes of a single observable. 
 `intercept` can be used to detect and modify mutations before they are applied to the observable.
-`observer` allows you to intercept changes after they have been made.
+`observe` allows you to intercept changes after they have been made.
 
 ## Intercept
 Usage: `intercept(target, propertyName?, interceptor)`


### PR DESCRIPTION
The doc says `observer` when it means `observe`.