### PR TITLE
Fix decorators

### DIFF
--- a/src/api/computeddecorator.ts
+++ b/src/api/computeddecorator.ts
@@ -1,36 +1,15 @@
 import {ValueMode, getValueModeFromValue, asStructure} from "../types/modifiers";
 import {IObservableValue} from "./observable";
-import {asObservableObject, setObservableObjectInstanceProperty, defineObservableProperty} from "../types/observableobject";
-import {invariant, assertPropertyConfigurable} from "../utils/utils";
+import {asObservableObject, defineObservableProperty} from "../types/observableobject";
+import {invariant} from "../utils/utils";
 import {createClassPropertyDecorator} from "../utils/decorators";
 import {ComputedValue} from "../core/computedvalue";
-import {getDebugName} from "../types/type-utils";
 
 export interface IComputedValueOptions {
 	asStructure: boolean;
 }
 
-/**
- * Decorator for class properties: @computed get value() { return expr; }.
- * For legacy purposes also invokable as ES5 observable created: `computed(() => expr)`;
- */
-export function computed<T>(func: () => T, scope?: any): IObservableValue<T>;
-export function computed(opts: IComputedValueOptions): (target: Object, key: string, baseDescriptor?: PropertyDescriptor) => void;
-export function computed(target: Object, key: string | symbol, baseDescriptor?: PropertyDescriptor): void;
-export function computed(targetOrExpr: any, keyOrScope?: any, baseDescriptor?: PropertyDescriptor, options?: IComputedValueOptions) {
-	if (arguments.length < 3 && typeof targetOrExpr === "function")
-		return computedExpr(targetOrExpr, keyOrScope);
-	invariant(!baseDescriptor || !baseDescriptor.set, `@observable properties cannot have a setter: ${keyOrScope}`);
-	return computedDecoratorImpl.apply(null, arguments);
-//	return computedDecorator.apply(null, arguments);
-}
-
-function computedExpr<T>(expr: () => T, scope?: any) {
-	const [mode, value] = getValueModeFromValue(expr, ValueMode.Recursive);
-	return new ComputedValue(value, scope, mode === ValueMode.Structure, value.name);
-}
-
-const computedDecoratorImpl = createClassPropertyDecorator(
+const computedDecorator = createClassPropertyDecorator(
 	(target, name, _, decoratorArgs, originalDescriptor) => {
 		const baseValue = originalDescriptor.get;
 		invariant(typeof baseValue === "function", "@computed can only be used on getter functions, like: '@computed get myProps() { return ...; }'");
@@ -45,50 +24,28 @@ const computedDecoratorImpl = createClassPropertyDecorator(
 	function (name) {
 		return this.$mobx.values[name].get();
 	},
-	function (name) {
-		invariant(false, `It is not allowed to assign new values to @computed properties: ${getDebugName(this)}.${name}`);
-	},
+	throwingComputedValueSetter,
 	false,
-	true,
 	true
 );
 
+/**
+ * Decorator for class properties: @computed get value() { return expr; }.
+ * For legacy purposes also invokable as ES5 observable created: `computed(() => expr)`;
+ */
+export function computed<T>(func: () => T, scope?: any): IObservableValue<T>;
+export function computed(opts: IComputedValueOptions): (target: Object, key: string, baseDescriptor?: PropertyDescriptor) => void;
+export function computed(target: Object, key: string | symbol, baseDescriptor?: PropertyDescriptor): void;
+export function computed(targetOrExpr: any, keyOrScope?: any, baseDescriptor?: PropertyDescriptor, options?: IComputedValueOptions) {
+	if (arguments.length < 3 && typeof targetOrExpr === "function")
+		return computedExpr(targetOrExpr, keyOrScope);
+	invariant(!baseDescriptor || !baseDescriptor.set, `@observable properties cannot have a setter: ${keyOrScope}`);
+	return computedDecorator.apply(null, arguments);
+}
 
-function computedDecorator(target: any, key?: any, baseDescriptor?: PropertyDescriptor, options?: IComputedValueOptions): any {
-	// invoked as decorator factory with options
-	if (arguments.length === 1) {
-		const options = target;
-		return (target, key, baseDescriptor) => computedDecorator.call(null, target, key, baseDescriptor, options);
-	}
-	invariant(baseDescriptor && baseDescriptor.hasOwnProperty("get"), "@computed can only be used on getter functions, like: '@computed get myProps() { return ...; }'");
-	assertPropertyConfigurable(target, key);
-
-	const descriptor: PropertyDescriptor = {};
-	const getter = baseDescriptor.get;
-
-	invariant(typeof target === "object", `The @observable decorator can only be used on objects`, key);
-	invariant(typeof getter === "function", `@observable expects a getter function if used on a property.`, key);
-	invariant(!baseDescriptor.set, `@observable properties cannot have a setter.`, key);
-	invariant(getter.length === 0, `@observable getter functions should not take arguments.`, key);
-
-	descriptor.configurable = true;
-	descriptor.enumerable = false;
-	descriptor.get = function() {
-		setObservableObjectInstanceProperty(
-			asObservableObject(this, undefined, ValueMode.Recursive),
-			key,
-			options && options.asStructure === true ? asStructure(getter) : getter
-		);
-		return this[key];
-	};
-
-	// by default, assignments to properties without setter are ignored. Let's fail fast instead.
-	descriptor.set = throwingComputedValueSetter;
-	if (!baseDescriptor) {
-		Object.defineProperty(target, key, descriptor); // For typescript
-	} else {
-		return descriptor;
-	}
+function computedExpr<T>(expr: () => T, scope?: any) {
+	const [mode, value] = getValueModeFromValue(expr, ValueMode.Recursive);
+	return new ComputedValue(value, scope, mode === ValueMode.Structure, value.name);
 }
 
 export function throwingComputedValueSetter() {

--- a/src/api/computeddecorator.ts
+++ b/src/api/computeddecorator.ts
@@ -31,7 +31,8 @@ function computedExpr<T>(expr: () => T, scope?: any) {
 }
 
 const computedDecoratorImpl = createClassPropertyDecorator(
-	(target, name, baseValue, decoratorArgs) => {
+	(target, name, _, decoratorArgs, originalDescriptor) => {
+		const baseValue = originalDescriptor.get;
 		invariant(typeof baseValue === "function", "@computed can only be used on getter functions, like: '@computed get myProps() { return ...; }'");
 
 		let compareStructural = false;

--- a/src/api/extendobservable.ts
+++ b/src/api/extendobservable.ts
@@ -1,6 +1,6 @@
 import {ValueMode} from "../types/modifiers";
 import {ObservableMap} from "../types/observablemap";
-import {asObservableObject, setObservableObjectProperty} from "../types/observableobject";
+import {asObservableObject, setObservableObjectInstanceProperty} from "../types/observableobject";
 import {invariant, isPropertyConfigurable} from "../utils/utils";
 
 /**
@@ -25,7 +25,7 @@ export function extendObservableHelper(target, properties, mode: ValueMode, name
 	for (let key in properties) if (properties.hasOwnProperty(key)) {
 		if (target === properties && !isPropertyConfigurable(target, key))
 			continue; // see #111, skip non-configurable or non-writable props for `observable(object)`.
-		setObservableObjectProperty(adm, key, properties[key]);
+		setObservableObjectInstanceProperty(adm, key, properties[key]);
 	}
 	return target;
 }

--- a/src/api/observabledecorator.ts
+++ b/src/api/observabledecorator.ts
@@ -4,9 +4,49 @@ import {computed} from "../api/computeddecorator";
 import {asObservableObject, setObservableObjectProperty} from "../types/observableobject";
 import {invariant, assertPropertyConfigurable, deprecated} from "../utils/utils";
 import {checkIfStateModificationsAreAllowed} from "../core/derivation";
+import {decoratorFactory2, decoratorFactory3} from "../utils/decorators";
+import {ObservableValue} from "../types/observablevalue";
+
+const decoratorImpl = decoratorFactory2(
+	(target, name, baseValue) => {
+		allowStateChanges(true, () => {
+			if (typeof baseValue === "function")
+				baseValue = asReference(baseValue);
+			//setObservableObjectProperty(
+			const adm = asObservableObject(target, undefined, ValueMode.Recursive);
+			adm.values[name] =  new ObservableValue(baseValue, adm.mode, name, false)
+		});
+	},
+	true,
+	function (name) {
+		return this.$mobx.values[name].get(); 
+	},
+	function (name, value) {
+		this.$mobx.values[name].set(value);
+	},
+	false
+)
+
+const decoratorImpl3 = decoratorFactory3(
+	(target, name, baseValue) => {
+		allowStateChanges(true, () => {
+			if (typeof baseValue === "function")
+				baseValue = asReference(baseValue);
+			//setObservableObjectProperty(
+			const adm = asObservableObject(target, undefined, ValueMode.Recursive);
+			adm.values[name] =  new ObservableValue(baseValue, adm.mode, name, false)
+		});
+	},
+	function (name) {
+		return this.$mobx.values[name].get(); 
+	},
+	function (name, value) {
+		this.$mobx.values[name].set(value);
+	}
+)
 
 /**
- * ES6 / Typescript decorator which can to make class properties and getter functions reactive.
+ * ESNext / Typescript decorator which can to make class properties and getter functions reactive.
  * Use this annotation to wrap properties of an object in an observable, for example:
  * class OrderLine {
  *   @observable amount = 3;
@@ -19,12 +59,13 @@ import {checkIfStateModificationsAreAllowed} from "../core/derivation";
 export function observableDecorator(target: Object, key: string, baseDescriptor: PropertyDescriptor) {
 	invariant(arguments.length >= 2 && arguments.length <= 3, "Illegal decorator config", key);
 	assertPropertyConfigurable(target, key);
+	decoratorImpl3.apply(null, arguments);
 
 	// - In typescript, observable annotations are invoked on the prototype, not on actual instances,
 	// so upon invocation, determine the 'this' instance, and define a property on the
 	// instance as well (that hides the propotype property)
 	// - In babel, the initial value is passed as the closure baseDiscriptor.initializer'
-
+/*
 	if (baseDescriptor && baseDescriptor.hasOwnProperty("get")) {
 		deprecated("Using @observable on computed values is deprecated. Use @computed instead.");
 		return computed.apply(null, arguments);
@@ -55,4 +96,6 @@ export function observableDecorator(target: Object, key: string, baseDescriptor:
 	} else {
 		return descriptor;
 	}
+*/
 }
+

--- a/src/api/observabledecorator.ts
+++ b/src/api/observabledecorator.ts
@@ -1,11 +1,8 @@
 import {ValueMode, asReference} from "../types/modifiers";
 import {allowStateChanges} from "../core/action";
-import {computed} from "../api/computeddecorator";
 import {asObservableObject, defineObservableProperty, setPropertyValue} from "../types/observableobject";
-import {invariant, assertPropertyConfigurable, deprecated} from "../utils/utils";
-import {checkIfStateModificationsAreAllowed} from "../core/derivation";
+import {invariant, assertPropertyConfigurable} from "../utils/utils";
 import {createClassPropertyDecorator} from "../utils/decorators";
-import {ObservableValue} from "../types/observablevalue";
 
 const decoratorImpl = createClassPropertyDecorator(
 	(target, name, baseValue) => {
@@ -42,42 +39,4 @@ export function observableDecorator(target: Object, key: string, baseDescriptor:
 	assertPropertyConfigurable(target, key);
 	invariant(!baseDescriptor || !baseDescriptor.get, "@observable can not be used on getters, use @computed instead");
 	return decoratorImpl.apply(null, arguments);
-
-	// - In typescript, observable annotations are invoked on the prototype, not on actual instances,
-	// so upon invocation, determine the 'this' instance, and define a property on the
-	// instance as well (that hides the propotype property)
-	// - In babel, the initial value is passed as the closure baseDiscriptor.initializer'
-/*
-	if (baseDescriptor && baseDescriptor.hasOwnProperty("get")) {
-		deprecated("Using @observable on computed values is deprecated. Use @computed instead.");
-		return computed.apply(null, arguments);
-	}
-	const descriptor: PropertyDescriptor = {};
-
-	invariant(typeof target === "object", `The @observable decorator can only be used on objects`, key);
-	descriptor.configurable = true;
-	descriptor.enumerable = true;
-	descriptor.get = function() {
-		let baseValue = undefined;
-		if (baseDescriptor && (<any>baseDescriptor).initializer) { // For babel
-			baseValue = (<any>baseDescriptor).initializer();
-			if (typeof baseValue === "function")
-				baseValue = asReference(baseValue);
-		}
-		// the getter might create a reactive property lazily, so this might even happen during a view.
-		allowStateChanges(true, () => {
-			setObservableObjectProperty(asObservableObject(this, undefined, ValueMode.Recursive), key, baseValue);
-		});
-		return this[key];
-	};
-	descriptor.set = function(value) {
-		setObservableObjectProperty(asObservableObject(this, undefined, ValueMode.Recursive), key, typeof value === "function" ? asReference(value) : value);
-	};
-	if (!baseDescriptor) {
-		Object.defineProperty(target, key, descriptor); // For typescript
-	} else {
-		return descriptor;
-	}
-*/
 }
-

--- a/src/api/observabledecorator.ts
+++ b/src/api/observabledecorator.ts
@@ -4,7 +4,7 @@ import {computed} from "../api/computeddecorator";
 import {asObservableObject, setObservableObjectProperty} from "../types/observableobject";
 import {invariant, assertPropertyConfigurable, deprecated} from "../utils/utils";
 import {checkIfStateModificationsAreAllowed} from "../core/derivation";
-import {decoratorFactory2, decoratorFactory3} from "../utils/decorators";
+import {decoratorFactory2} from "../utils/decorators";
 import {ObservableValue} from "../types/observablevalue";
 
 const decoratorImpl = decoratorFactory2(
@@ -27,24 +27,6 @@ const decoratorImpl = decoratorFactory2(
 	false
 )
 
-const decoratorImpl3 = decoratorFactory3(
-	(target, name, baseValue) => {
-		allowStateChanges(true, () => {
-			if (typeof baseValue === "function")
-				baseValue = asReference(baseValue);
-			//setObservableObjectProperty(
-			const adm = asObservableObject(target, undefined, ValueMode.Recursive);
-			adm.values[name] =  new ObservableValue(baseValue, adm.mode, name, false)
-		});
-	},
-	function (name) {
-		return this.$mobx.values[name].get(); 
-	},
-	function (name, value) {
-		this.$mobx.values[name].set(value);
-	}
-)
-
 /**
  * ESNext / Typescript decorator which can to make class properties and getter functions reactive.
  * Use this annotation to wrap properties of an object in an observable, for example:
@@ -59,7 +41,7 @@ const decoratorImpl3 = decoratorFactory3(
 export function observableDecorator(target: Object, key: string, baseDescriptor: PropertyDescriptor) {
 	invariant(arguments.length >= 2 && arguments.length <= 3, "Illegal decorator config", key);
 	assertPropertyConfigurable(target, key);
-	decoratorImpl3.apply(null, arguments);
+	decoratorImpl.apply(null, arguments);
 
 	// - In typescript, observable annotations are invoked on the prototype, not on actual instances,
 	// so upon invocation, determine the 'this' instance, and define a property on the

--- a/src/api/observabledecorator.ts
+++ b/src/api/observabledecorator.ts
@@ -40,7 +40,7 @@ const decoratorImpl = decoratorFactory2(
 export function observableDecorator(target: Object, key: string, baseDescriptor: PropertyDescriptor) {
 	invariant(arguments.length >= 2 && arguments.length <= 3, "Illegal decorator config", key);
 	assertPropertyConfigurable(target, key);
-	decoratorImpl.apply(null, arguments);
+	return decoratorImpl.apply(null, arguments);
 
 	// - In typescript, observable annotations are invoked on the prototype, not on actual instances,
 	// so upon invocation, determine the 'this' instance, and define a property on the

--- a/src/api/observabledecorator.ts
+++ b/src/api/observabledecorator.ts
@@ -4,10 +4,10 @@ import {computed} from "../api/computeddecorator";
 import {asObservableObject, defineObservableProperty, setPropertyValue} from "../types/observableobject";
 import {invariant, assertPropertyConfigurable, deprecated} from "../utils/utils";
 import {checkIfStateModificationsAreAllowed} from "../core/derivation";
-import {decoratorFactory2} from "../utils/decorators";
+import {createClassPropertyDecorator} from "../utils/decorators";
 import {ObservableValue} from "../types/observablevalue";
 
-const decoratorImpl = decoratorFactory2(
+const decoratorImpl = createClassPropertyDecorator(
 	(target, name, baseValue) => {
 		allowStateChanges(true, () => {
 			if (typeof baseValue === "function")
@@ -16,13 +16,13 @@ const decoratorImpl = decoratorFactory2(
 			defineObservableProperty(adm, name, baseValue, false);
 		});
 	},
-	true,
 	function (name) {
 		return this.$mobx.values[name].get();
 	},
 	function (name, value) {
 		setPropertyValue(this, name, value);
 	},
+	true,
 	false
 );
 
@@ -40,6 +40,7 @@ const decoratorImpl = decoratorFactory2(
 export function observableDecorator(target: Object, key: string, baseDescriptor: PropertyDescriptor) {
 	invariant(arguments.length >= 2 && arguments.length <= 3, "Illegal decorator config", key);
 	assertPropertyConfigurable(target, key);
+	invariant(!baseDescriptor || !baseDescriptor.get, "@observable can not be used on getters, use @computed instead");
 	return decoratorImpl.apply(null, arguments);
 
 	// - In typescript, observable annotations are invoked on the prototype, not on actual instances,

--- a/src/api/observabledecorator.ts
+++ b/src/api/observabledecorator.ts
@@ -1,7 +1,7 @@
 import {ValueMode, asReference} from "../types/modifiers";
 import {allowStateChanges} from "../core/action";
 import {computed} from "../api/computeddecorator";
-import {asObservableObject, setObservableObjectProperty} from "../types/observableobject";
+import {asObservableObject, defineObservableProperty, setPropertyValue} from "../types/observableobject";
 import {invariant, assertPropertyConfigurable, deprecated} from "../utils/utils";
 import {checkIfStateModificationsAreAllowed} from "../core/derivation";
 import {decoratorFactory2} from "../utils/decorators";
@@ -12,20 +12,19 @@ const decoratorImpl = decoratorFactory2(
 		allowStateChanges(true, () => {
 			if (typeof baseValue === "function")
 				baseValue = asReference(baseValue);
-			//setObservableObjectProperty(
 			const adm = asObservableObject(target, undefined, ValueMode.Recursive);
-			adm.values[name] =  new ObservableValue(baseValue, adm.mode, name, false)
+			defineObservableProperty(adm, name, baseValue, false);
 		});
 	},
 	true,
 	function (name) {
-		return this.$mobx.values[name].get(); 
+		return this.$mobx.values[name].get();
 	},
 	function (name, value) {
-		this.$mobx.values[name].set(value);
+		setPropertyValue(this, name, value);
 	},
 	false
-)
+);
 
 /**
  * ESNext / Typescript decorator which can to make class properties and getter functions reactive.

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -6,7 +6,7 @@ import {ComputedValue} from "../core/computedvalue";
 import {globalState} from "../core/globalstate";
 import {createClassPropertyDecorator} from "../utils/decorators";
 
-const actionFieldDecorator = createClassPropertyDecorator(
+const actionDecorator = createClassPropertyDecorator(
 	function (target, key, value, args, originalDescriptor) {
 		const actionName = (args && args.length === 1) ? args[0] : (value.name || key || "<unnamed action>");
 		const wrappedAction = action(actionName, value);
@@ -44,7 +44,7 @@ export function action(arg1, arg2?, arg3?, arg4?): any {
 	if (arguments.length === 2  && typeof arg2 === "function")
 		return actionImplementation(arg1, arg2);
 
-	return actionFieldDecorator.apply(null, arguments);
+	return actionDecorator.apply(null, arguments);
 }
 
 export function actionImplementation(actionName: string, fn: Function): Function {

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -4,20 +4,20 @@ import {untracked} from "../core/derivation";
 import {isSpyEnabled, spyReportStart, spyReportEnd} from "../core/spy";
 import {ComputedValue} from "../core/computedvalue";
 import {globalState} from "../core/globalstate";
-import {decoratorFactory2} from "../utils/decorators";
+import {createClassPropertyDecorator} from "../utils/decorators";
 
-const actionDecoratorImpl = decoratorFactory2(
+const actionDecoratorImpl = createClassPropertyDecorator(
 	function (target, key, value, args) {
 		const actionName = (args && args.length === 1) ? args[0] : (value.name || key || "<unnamed action>");
 		addBoundAction(target, key, action(actionName, value));
 	},
-	false,
 	function (key) {
 		return this[key];
 	},
 	function () {
 		invariant(false, "It is not allowed to assign new values to @action fields");
 	},
+	false,
 	true
 );
 

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -10,7 +10,7 @@ const actionFieldDecorator = createClassPropertyDecorator(
 	function (target, key, value, args, originalDescriptor) {
 		const actionName = (args && args.length === 1) ? args[0] : (value.name || key || "<unnamed action>");
 		const wrappedAction = action(actionName, value);
-		if (originalDescriptor.value && target.constructor && target.constructor.prototype) {
+		if (originalDescriptor && originalDescriptor.value && target.constructor && target.constructor.prototype) {
 			// shared method, replace this very property on the prototype with the right value
 			Object.defineProperty(target.constructor.prototype, key, {
 				configurable: true, enumerable: false, writable: false,

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -8,15 +8,15 @@ import {decoratorFactory2} from "../utils/decorators";
 
 const actionDecoratorImpl = decoratorFactory2(
 	function (target, key, value, args) {
-		const actionName = (args && args.length === 1) ? args[0] : (value.name || "<unnamed action>"); 
+		const actionName = (args && args.length === 1) ? args[0] : (value.name || key || "<unnamed action>");
 		addBoundAction(target, key, action(actionName, value));
 	},
 	false,
 	function (key) {
-		return this[key]
+		return this[key];
 	},
-	function (key, value) {
-		this.key = value;
+	function () {
+		invariant(false, "It is not allowed to assign new values to @action fields");
 	},
 	true
 );

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -4,24 +4,22 @@ import {untracked} from "../core/derivation";
 import {isSpyEnabled, spyReportStart, spyReportEnd} from "../core/spy";
 import {ComputedValue} from "../core/computedvalue";
 import {globalState} from "../core/globalstate";
-import {decoratorFactory} from "../utils/decorators";
+import {decoratorFactory2} from "../utils/decorators";
 
-const actionDecoratorImpl = decoratorFactory(
-	true,
-	true,
-	(target, propName, method, args) => {
-		const name = (args && args.length === 1 && args[0]) || method.name || propName;
-		const implementation = action(name, method);
-
-		return {
-			enumerable: false,
-			configurable: false,
-			writable: false,
-			value: implementation
-		} as PropertyDescriptor;
-	}
+const actionDecoratorImpl = decoratorFactory2(
+	function (target, key, value, args) {
+		const actionName = (args && args.length === 1) ? args[0] : (value.name || "<unnamed action>"); 
+		addBoundAction(target, key, action(actionName, value));
+	},
+	false,
+	function (key) {
+		return this[key]
+	},
+	function (key, value) {
+		this.key = value;
+	},
+	true
 );
-
 
 
 export function action<T extends Function>(fn: T): T;

--- a/src/types/type-utils.ts
+++ b/src/types/type-utils.ts
@@ -1,5 +1,6 @@
 import {IDepTreeNode} from "../core/observable";
 import {invariant} from "../utils/utils";
+import {runLazyInitializers} from "../utils/decorators";
 import {Atom} from "../core/atom";
 import {ComputedValue} from "../core/computedvalue";
 import {Reaction} from "../core/reaction";
@@ -12,18 +13,23 @@ export function getAtom(thing: any, property?: string): IDepTreeNode {
 		if (isObservableArray(thing)) {
 			invariant(property === undefined, "It is not possible to get index atoms from arrays");
 			return thing.$mobx.atom;
-		} else if (isObservableMap(thing)) {
+		}
+		if (isObservableMap(thing)) {
 			if (property === undefined)
 				return getAtom(thing._keys);
 			const observable = thing._data[property] || thing._hasMap[property];
 			invariant(!!observable, `the entry '${property}' does not exist in the observable map '${getDebugName(thing)}'`);
 			return observable;
-		} else if (isObservableObject(thing)) {
+		}
+		// Initializers run lazily when transpiling to babel, so make sure they are run...
+		runLazyInitializers(thing);
+		if (isObservableObject(thing)) {
 			invariant(!!property, `please specify a property`);
 			const observable = thing.$mobx.values[property];
 			invariant(!!observable, `no observable property '${property}' found on the observable object '${getDebugName(thing)}'`);
 			return observable;
-		} else if (thing instanceof Atom || thing instanceof ComputedValue || thing instanceof Reaction) {
+		}
+		if (thing instanceof Atom || thing instanceof ComputedValue || thing instanceof Reaction) {
 			return thing;
 		}
 	} else if (typeof thing === "function") {
@@ -43,6 +49,8 @@ export function getAdministration(thing: any, property?: string) {
 		return thing;
 	if (isObservableMap(thing))
 		return thing;
+	// Initializers run lazily when transpiling to babel, so make sure they are run...
+	runLazyInitializers(thing);
 	if (thing.$mobx)
 		return thing.$mobx;
 	invariant(false, "Cannot obtain administration from " + thing);

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -1,0 +1,72 @@
+import {invariant} from "./utils";
+
+/** Given a decorator, construcs a decorator, that normalizes the differences between 
+ * TypeScript and Babel. Sigh
+ */
+
+// values on prototype: @action
+// fields on object: @observable
+// getters on object: @computed
+// enumerable (on protot and self!)
+// custom args
+
+export function decoratorFactory(
+	allowCustomArguments: boolean,
+	allowValuesOnPrototype: boolean,
+	getDescriptor: (target, propName, initialValue: any, customArgs: IArguments) => PropertyDescriptor
+): (target, prop: string, descriptor?) => PropertyDescriptor {
+	function theDecorator(target: Object, key: string, baseDescriptor, customArgs?: IArguments): any {
+		invariant(allowCustomArguments || quacksLikeADecorator(arguments), "This function is a decorator, but it wasn't invoked like a decorator");
+		const intermediateDescriptor = {
+			configurable: true,
+			enumerable: false,
+			get: illegalState,
+			set: illegalState
+		};
+		if (baseDescriptor === undefined) {
+			/* typescript */
+			// TODO: or return?
+			Object.defineProperty(baseDescriptor, key, intermediateDescriptor);
+		} else {
+			/* babel */
+			if (typeof baseDescriptor.initializer === "function") {
+				/* initializers are used for instance properties*/
+				(intermediateDescriptor as any).initializer = function () {
+					Object.defineProperty(this, key, getDescriptor(this, key, baseDescriptor.initializer(), customArgs));
+				};
+				return intermediateDescriptor;
+			} else if (baseDescriptor.hasOwnProperty("value")) {
+				/* values are used for values that can be defined on the prototype, e.g. methos */
+				invariant(allowValuesOnPrototype, "This decorator can only be used on field assignments");
+				/* prototype props cannot be reconfigured, so just set  a new value */
+				const _temp = getDescriptor(target, key, baseDescriptor.value, customArgs);
+				baseDescriptor.value = _temp.value;
+				// TODO: mweh? just return _temp?
+				return baseDescriptor;
+			} else {
+				invariant(false, "Illegal state while applying decorator");
+			}
+		}
+	}
+
+	if (allowCustomArguments) {
+		/** If custom arguments are allowed, we should return a function that returns a decorator */
+		return function() {
+			/** Direct invocation: @decorator bla */
+			if (quacksLikeADecorator(arguments))
+				return theDecorator.apply(null, arguments);
+			/** Indirect invocation: @decorator(args) bla */
+			const outerArgs = arguments;
+			return (target, key, descriptor) => theDecorator(target, key, descriptor, outerArgs);
+		};
+	}
+	return theDecorator;
+}
+
+function illegalState() {
+	invariant(false, "Illegal state while trying to apply decorator");
+}
+
+function quacksLikeADecorator(args: IArguments): boolean {
+	return (args.length === 2 || args.length === 3) && typeof args[1] === "string";
+}

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -26,12 +26,7 @@ export function createClassPropertyDecorator(
 	/**
 	 * Can this decorator invoked with arguments? e.g. @decorator(args)
 	 */
-	allowCustomArguments: boolean,
-	/**
-	 * Usually the initial value will be based on either the .value or .initializer or initial assignment to the property.
-	 * If this flag is set, the initial value will be the original defined get value. This is used by @computed.
-	 */
-	useGetterAsInitialValue: boolean = false
+	allowCustomArguments: boolean
 ): any {
 	function classPropertyDecorator(target: any, key: string, descriptor, customArgs?: IArguments) {
 		invariant(allowCustomArguments || quacksLikeADecorator(arguments), "This function is a decorator, but it wasn't invoked like a decorator");
@@ -63,12 +58,11 @@ export function createClassPropertyDecorator(
 			}
 
 			const {value, initializer} = descriptor;
-			const getter = descriptor.get;
 			target.__mobxLazyInitializers.push(instance => {
 				onInitialize(
 					instance,
 					key,
-					useGetterAsInitialValue ? getter : (initializer ? initializer.call(instance) : value),
+					(initializer ? initializer.call(instance) : value),
 					customArgs,
 					descriptor
 				);
@@ -115,16 +109,6 @@ function typescriptInitializeProperty(instance, key, v, onInitialize, customArgs
 	onInitialize(instance, key, v, customArgs, baseDescriptor);
 }
 
-function isPropInitialized(instance, prop) {
-	if (instance["__initialized" + prop] !== true) {
-		Object.defineProperty(instance, "__initialized" + prop, {
-			configurable: false, enumerable: false, writable: false, value: true
-		});
-		return false;
-	}
-	return true;
-}
-
 export function runLazyInitializers(instance) {
 	if (instance.__mobxDidRunLazyInitializers === true)
 		return;
@@ -137,68 +121,6 @@ export function runLazyInitializers(instance) {
 		});
 		instance.__mobxDidRunLazyInitializers && instance.__mobxLazyInitializers.forEach(initializer => initializer(instance));
 	}
-}
-
-// values on prototype: @action
-// fields on object: @observable
-// getters on object: @computed
-// enumerable (on protot and self!)
-// custom args
-export function decoratorFactory(
-	allowCustomArguments: boolean,
-	allowValuesOnPrototype: boolean,
-	getDescriptor: (target, propName, initialValue: any, customArgs: IArguments) => PropertyDescriptor
-): (target, prop: string, descriptor?) => PropertyDescriptor {
-	function theDecorator(target: Object, key: string, baseDescriptor, customArgs?: IArguments): any {
-		invariant(allowCustomArguments || quacksLikeADecorator(arguments), "This function is a decorator, but it wasn't invoked like a decorator");
-		const intermediateDescriptor = {
-			configurable: true,
-			enumerable: false,
-			get: illegalState,
-			set: illegalState
-		};
-		if (baseDescriptor === undefined) {
-			/* typescript */
-			// TODO: or return?
-			Object.defineProperty(baseDescriptor, key, intermediateDescriptor);
-		} else {
-			/* babel */
-			if (typeof baseDescriptor.initializer === "function") {
-				/* initializers are used for instance properties*/
-				(intermediateDescriptor as any).initializer = function () {
-					Object.defineProperty(this, key, getDescriptor(this, key, baseDescriptor.initializer(), customArgs));
-				};
-				return intermediateDescriptor;
-			} else if (baseDescriptor.hasOwnProperty("value")) {
-				/* values are used for values that can be defined on the prototype, e.g. methos */
-				invariant(allowValuesOnPrototype, "This decorator can only be used on field assignments");
-				/* prototype props cannot be reconfigured, so just set  a new value */
-				const _temp = getDescriptor(target, key, baseDescriptor.value, customArgs);
-				baseDescriptor.value = _temp.value;
-				// TODO: mweh? just return _temp?
-				return baseDescriptor;
-			} else {
-				invariant(false, "Illegal state while applying decorator");
-			}
-		}
-	}
-
-	if (allowCustomArguments) {
-		/** If custom arguments are allowed, we should return a function that returns a decorator */
-		return function() {
-			/** Direct invocation: @decorator bla */
-			if (quacksLikeADecorator(arguments))
-				return theDecorator.apply(null, arguments);
-			/** Indirect invocation: @decorator(args) bla */
-			const outerArgs = arguments;
-			return (target, key, descriptor) => theDecorator(target, key, descriptor, outerArgs);
-		};
-	}
-	return theDecorator;
-}
-
-function illegalState() {
-	invariant(false, "Illegal state while trying to apply decorator");
 }
 
 function quacksLikeADecorator(args: IArguments): boolean {

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -3,13 +3,116 @@ import {invariant} from "./utils";
 /** Given a decorator, construcs a decorator, that normalizes the differences between 
  * TypeScript and Babel. Sigh
  */
+export function decoratorFactory2(
+	onInitialize: (target, property, initialValue, customArgs?: IArguments) => void,
+	enumerable: boolean,
+	get: (name) => any,
+	set: (name, newValue) => void,
+	allowCustomArguments: boolean
+): any {
+	function theDecorator(target: any, key: string, descriptor, customArgs?: IArguments) {
+		// TODO: prebind get / set / onInitialize for faster results?
+		if (!target.hasOwnProperty("__mobxLazyInitializers")) {
+			Object.defineProperty(target, "__mobxLazyInitializers", {
+				writable: false, configurable: false, enumerable: false,
+				value: (target.__mobxDidRunLazyInitializers && target.__mobxLazyInitializers.slice()) || [] // support inheritance
+			});
+		}
+
+		if (!descriptor) {
+			// typescript
+			return {
+				enumerable,
+				configurable: true,
+				get: function() {
+					if (this.__mobxDidRunLazyInitializers !== true)
+						runLazyInitializers(this);
+					return get.call(this, key);
+				},
+				set: function(v) {
+				// 	if (this.__mobxDidRunLazyInitializers !== true) 
+				// 		if (this.__initialValuesLength < lazyInitializersLength) {
+				// 			push
+				// 		else
+				// 			run initailzers
+				// 	}
+					
+					set.call(this, key, v);
+				}
+			}
+		} else {
+			// babel
+			const {value, initializer} = descriptor;
+			target.__mobxLazyInitializers.push(instance => {
+				onInitialize(
+					instance,
+					key,
+					initializer ? initializer.call(instance) : value,
+					customArgs
+				);
+			});
+
+			delete descriptor.value;
+			delete descriptor.initializer;
+			delete descriptor.writable;
+			descriptor.enumerable = enumerable;
+			descriptor.configurable = true;
+			descriptor.get = function() {
+				if (this.__mobxDidRunLazyInitializers !== true)
+					runLazyInitializers(this);
+				return get.call(this, key);
+			};
+			descriptor.set =  function(v) {
+				if (this.__mobxDidRunLazyInitializers !== true)
+					runLazyInitializers(this);
+				set.call(this, key, v);
+			};
+		}
+	}
+
+	if (allowCustomArguments) {
+		/** If custom arguments are allowed, we should return a function that returns a decorator */
+		return function() {
+			/** Direct invocation: @decorator bla */
+			if (quacksLikeADecorator(arguments))
+				return theDecorator.apply(null, arguments);
+			/** Indirect invocation: @decorator(args) bla */
+			const outerArgs = arguments;
+			return (target, key, descriptor) => theDecorator(target, key, descriptor, outerArgs);
+		};
+	}
+	return theDecorator;
+}
+
+function isPropInitialized(instance, prop) {
+	if (instance["__initialized" + prop] !== true) {
+		Object.defineProperty(instance, "__initialized" + prop, {
+			configurable: false, enumerable: false, writable: false, value: true
+		});
+		return false;
+	}
+	return true;
+}
+
+export function runLazyInitializers(instance) {
+	if (instance.__mobxDidRunLazyInitializers === true)
+		return;
+	if (instance.__mobxLazyInitializers) {
+		Object.defineProperty(instance, "__mobxDidRunLazyInitializers", {
+			enumerable: false,
+			configurable: false,
+			writable: false,
+			value: true
+		});
+		instance.__mobxLazyInitializers.forEach(initializer => initializer(instance));
+	}
+}
 
 // values on prototype: @action
 // fields on object: @observable
 // getters on object: @computed
 // enumerable (on protot and self!)
 // custom args
-
 export function decoratorFactory(
 	allowCustomArguments: boolean,
 	allowValuesOnPrototype: boolean,

--- a/test/babel/babel-tests.js
+++ b/test/babel/babel-tests.js
@@ -314,8 +314,7 @@ test("288 atom not detected for object property", t => {
 })
 
 test("observable performance", t => {
-	//const AMOUNT = 100000;
-	const AMOUNT = 1;
+	const AMOUNT = 100000;
 
 	class A {
 		@observable a = 1;

--- a/test/babel/babel-tests.js
+++ b/test/babel/babel-tests.js
@@ -151,6 +151,7 @@ function normalizeSpyEvents(events) {
 }
 
 test("action decorator (babel)", function(t) {
+	debugger;
 	class Store {
 		constructor(multiplier) {
 			this.multiplier = multiplier;
@@ -297,3 +298,22 @@ test("267 (babel) should be possible to declare properties observable outside st
 	mobx.useStrict(false);
 	t.end();
 })
+
+test("288 atom not detected for object property", t => {
+	debugger;
+	class Store {
+		@mobx.observable foo = '';
+	}
+
+	const store = new Store();
+
+	mobx.observe(store, 'foo', () => {
+		console.log('Change observed');
+	}, true);
+
+	t.end()
+})
+
+// TODO: test unbound methods
+
+// TODO: test sharing of methods, test non sharing of bound methods

--- a/test/babel/babel-tests.js
+++ b/test/babel/babel-tests.js
@@ -357,3 +357,5 @@ test("observable performance", t => {
 // TODO: test inheritance
 
 // TODO: test inherited observables
+
+// TODO: test initializers that use each other

--- a/test/babel/babel-tests.js
+++ b/test/babel/babel-tests.js
@@ -87,10 +87,11 @@ class Order {
 }
 
 test('decorators', function(t) {
+	debugger;
 	var o = new Order();
-	t.equal(o.total, 6); // hmm this is required to initialize the props which are made reactive lazily..
 	t.equal(isObservableObject(o), true);
 	t.equal(isObservable(o, 'amount'), true);
+	t.equal(o.total, 6); // TODO: remove hmm this is required to initialize the props which are made reactive lazily..
 	t.equal(isObservable(o, 'total'), true);
 	
 	var events = [];

--- a/test/babel/babel-tests.js
+++ b/test/babel/babel-tests.js
@@ -301,15 +301,15 @@ test("267 (babel) should be possible to declare properties observable outside st
 })
 
 test("288 atom not detected for object property", t => {
-	// class Store {
-	// 	@mobx.observable foo = '';
-	// }
+	class Store {
+		@mobx.observable foo = '';
+	}
 
-	// const store = new Store();
+	const store = new Store();
 
-	// mobx.observe(store, 'foo', () => {
-	// 	console.log('Change observed');
-	// }, true);
+	mobx.observe(store, 'foo', () => {
+		console.log('Change observed');
+	}, true);
 
 	t.end()
 })

--- a/test/babel/babel-tests.js
+++ b/test/babel/babel-tests.js
@@ -4,8 +4,10 @@ import {
     default as mobx
 } from "../";
 
+var test = require('tape')
+
 class Box {
-    @observable uninitialized;
+    //@observable uninitialized;
     @observable height = 20;
     @observable sizes = [2];
     @observable someFunc = function () { return 2; };
@@ -22,7 +24,6 @@ autorun(() => {
     ar.push(box.width);
 });
 
-var test = require('tape')
 
 test('babel', function (t) {
   var s = ar.slice()
@@ -42,276 +43,310 @@ test('babel', function (t) {
   t.end()
 })
 
-test('babel: parameterized computed decorator', (t) => {
-	class TestClass {
-		@observable x = 3;
-		@observable y = 3;
-		@computed({ asStructure: true }) get boxedSum() {
-			return { sum: Math.round(this.x) + Math.round(this.y) };
-		}
-	}
+// test('babel: parameterized computed decorator', (t) => {
+// 	class TestClass {
+// 		@observable x = 3;
+// 		@observable y = 3;
+// 		@computed({ asStructure: true }) get boxedSum() {
+// 			return { sum: Math.round(this.x) + Math.round(this.y) };
+// 		}
+// 	}
 	
-	const t1 = new TestClass();
-	const changes: { sum: number}[] = [];
-	const d = autorun(() => changes.push(t1.boxedSum));
+// 	const t1 = new TestClass();
+// 	const changes: { sum: number}[] = [];
+// 	const d = autorun(() => changes.push(t1.boxedSum));
 	
-	t1.y = 4; // change
-	t.equal(changes.length, 2);
-	t1.y = 4.2; // no change
-	t.equal(changes.length, 2);
-	transaction(() => {
-		t1.y = 3;
-		t1.x = 4;
-	}); // no change
-	t.equal(changes.length, 2);
-	t1.x = 6; // change
-	t.equal(changes.length, 3);
-	d();
+// 	t1.y = 4; // change
+// 	t.equal(changes.length, 2);
+// 	t1.y = 4.2; // no change
+// 	t.equal(changes.length, 2);
+// 	transaction(() => {
+// 		t1.y = 3;
+// 		t1.x = 4;
+// 	}); // no change
+// 	t.equal(changes.length, 2);
+// 	t1.x = 6; // change
+// 	t.equal(changes.length, 3);
+// 	d();
 	
-	t.deepEqual(changes, [{ sum: 6 }, { sum: 7 }, { sum: 9 }]);
+// 	t.deepEqual(changes, [{ sum: 6 }, { sum: 7 }, { sum: 9 }]);
 	
-	t.end();
-});
+// 	t.end();
+// });
 
-class Order {
-    @observable price = 3;
-    @observable amount = 2;
-    @observable orders = [];
-    @observable aFunction = function(a) { };
-    @observable someStruct = asStructure({ x: 1, y: 2});
+// class Order {
+//     @observable price = 3;
+//     @observable amount = 2;
+//     @observable orders = [];
+//     @observable aFunction = function(a) { };
+//     @observable someStruct = asStructure({ x: 1, y: 2});
 
-    @computed get total() {
-        return this.amount * this.price * (1 + this.orders.length);
-    }
-}
+//     @computed get total() {
+//         return this.amount * this.price * (1 + this.orders.length);
+//     }
+// }
 
-test('decorators', function(t) {
-	var o = new Order();
-	t.equal(o.total, 6); // hmm this is required to initialize the props which are made reactive lazily..
-	t.equal(isObservableObject(o), true);
-	t.equal(isObservable(o, 'amount'), true);
-	t.equal(isObservable(o, 'total'), true);
+// test('decorators', function(t) {
+// 	var o = new Order();
+// 	t.equal(o.total, 6); // hmm this is required to initialize the props which are made reactive lazily..
+// 	t.equal(isObservableObject(o), true);
+// 	t.equal(isObservable(o, 'amount'), true);
+// 	t.equal(isObservable(o, 'total'), true);
 	
-	var events = [];
-	var d1 = observe(o, (ev) => events.push(ev.name, ev.oldValue));
-	var d2 = observe(o, 'price', (newValue, oldValue) => events.push(newValue, oldValue));
-	var d3 = observe(o, 'total', (newValue, oldValue) => events.push(newValue, oldValue));
+// 	var events = [];
+// 	var d1 = observe(o, (ev) => events.push(ev.name, ev.oldValue));
+// 	var d2 = observe(o, 'price', (newValue, oldValue) => events.push(newValue, oldValue));
+// 	var d3 = observe(o, 'total', (newValue, oldValue) => events.push(newValue, oldValue));
 	
-	o.price = 4;
+// 	o.price = 4;
 	
-	d1();
-	d2();
-	d3();
+// 	d1();
+// 	d2();
+// 	d3();
 	
-	o.price = 5;
+// 	o.price = 5;
 	
-	t.deepEqual(events, [
-		8, // new total
-		6, // old total
-		4, // new price
-		3, // old price
-		"price", // event name
-		3, // event oldValue
-	]);
+// 	t.deepEqual(events, [
+// 		8, // new total
+// 		6, // old total
+// 		4, // new price
+// 		3, // old price
+// 		"price", // event name
+// 		3, // event oldValue
+// 	]);
 	
-	t.end();
-})
+// 	t.end();
+// })
 
-test('issue 191 - shared initializers (babel)', function(t) {
-	class Test {
-		@observable obj = { a: 1 };
-		@observable array = [2];
-	}
+// test('issue 191 - shared initializers (babel)', function(t) {
+// 	class Test {
+// 		@observable obj = { a: 1 };
+// 		@observable array = [2];
+// 	}
 	
-	var t1 = new Test();
-	t1.obj.a = 2;
-	t1.array.push(3);
+// 	var t1 = new Test();
+// 	t1.obj.a = 2;
+// 	t1.array.push(3);
 	
-	var t2 = new Test();
-	t2.obj.a = 3;
-	t2.array.push(4);
+// 	var t2 = new Test();
+// 	t2.obj.a = 3;
+// 	t2.array.push(4);
 	
-	t.notEqual(t1.obj, t2.obj);
-	t.notEqual(t1.array, t2.array);
-	t.equal(t1.obj.a, 2);
-	t.equal(t2.obj.a, 3);
+// 	t.notEqual(t1.obj, t2.obj);
+// 	t.notEqual(t1.array, t2.array);
+// 	t.equal(t1.obj.a, 2);
+// 	t.equal(t2.obj.a, 3);
 	
-	t.deepEqual(t1.array.slice(), [2,3]);
-	t.deepEqual(t2.array.slice(), [2,4]);
+// 	t.deepEqual(t1.array.slice(), [2,3]);
+// 	t.deepEqual(t2.array.slice(), [2,4]);
 	
-	t.end();
-})
+// 	t.end();
+// })
 
-function normalizeSpyEvents(events) {
-	events.forEach(ev => {
-		delete ev.fn;
-		delete ev.time;
-	});
-	return events;
-}
+// function normalizeSpyEvents(events) {
+// 	events.forEach(ev => {
+// 		delete ev.fn;
+// 		delete ev.time;
+// 	});
+// 	return events;
+// }
 
-test("action decorator (babel)", function(t) {
-	debugger;
-	class Store {
-		constructor(multiplier) {
-			this.multiplier = multiplier;
-		}
+// // test("action decorator (babel)", function(t) {
+// // 	debugger;
+// // 	class Store {
+// // 		constructor(multiplier) {
+// // 			this.multiplier = multiplier;
+// // 		}
 		
-		@action
-		add(a, b) {
-			return (a + b) * this.multiplier;
-		}
-	}
+// // 		@action
+// // 		add(a, b) {
+// // 			return (a + b) * this.multiplier;
+// // 		}
+// // 	}
 
-	const store1 =  new Store(2);
-	const store2 =  new Store(3);
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(3, 4), 21);
-	t.equal(store1.add(1, 1), 4);
+// // 	const store1 =  new Store(2);
+// // 	const store2 =  new Store(3);
+// // 	const events: any[] = [];
+// // 	const d = spy(events.push.bind(events));
+// // 	t.equal(store1.add(3, 4), 14);
+// // 	t.equal(store2.add(3, 4), 21);
+// // 	t.equal(store1.add(1, 1), 4);
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 1, 1 ], name: "add", spyReportStart: true, target: store1, type: "action" },
-		{ spyReportEnd: true }
-	]);
+// // 	t.deepEqual(normalizeSpyEvents(events),	[
+// // 		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store1, type: "action" },
+// // 		{ spyReportEnd: true },
+// // 		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store2, type: "action" },
+// // 		{ spyReportEnd: true },
+// // 		{ arguments: [ 1, 1 ], name: "add", spyReportStart: true, target: store1, type: "action" },
+// // 		{ spyReportEnd: true }
+// // 	]);
 
-	d();
-	t.end();
-});
+// // 	d();
+// // 	t.end();
+// // });
 
-test("custom action decorator (babel)", function(t) {
-	class Store {
-		constructor(multiplier) {
-			this.multiplier = multiplier;
-		}
+// // test("custom action decorator (babel)", function(t) {
+// // 	class Store {
+// // 		constructor(multiplier) {
+// // 			this.multiplier = multiplier;
+// // 		}
 
-		@action("zoem zoem")
-		add(a, b) {
-			return (a + b) * this.multiplier;
-		}
-	}
+// // 		@action("zoem zoem")
+// // 		add(a, b) {
+// // 			return (a + b) * this.multiplier;
+// // 		}
+// // 	}
 
-	const store1 =  new Store(2);
-	const store2 =  new Store(3);
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(3, 4), 21);
-	t.equal(store1.add(1, 1), 4);
+// // 	const store1 =  new Store(2);
+// // 	const store2 =  new Store(3);
+// // 	const events: any[] = [];
+// // 	const d = spy(events.push.bind(events));
+// // 	t.equal(store1.add(3, 4), 14);
+// // 	t.equal(store2.add(3, 4), 21);
+// // 	t.equal(store1.add(1, 1), 4);
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 1, 1 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
-		{ spyReportEnd: true },
-	]);
+// // 	t.deepEqual(normalizeSpyEvents(events),	[
+// // 		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
+// // 		{ spyReportEnd: true },
+// // 		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store2, type: "action" },
+// // 		{ spyReportEnd: true },
+// // 		{ arguments: [ 1, 1 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
+// // 		{ spyReportEnd: true },
+// // 	]);
 
-	d();
-	t.end();
-});
-
-
-test("action decorator on field (babel)", function(t) {
-	class Store {
-		constructor(multiplier) {
-			this.multiplier = multiplier;
-		}
+// // 	d();
+// // 	t.end();
+// // });
 
 
-		@action
-		add = (a, b) => {
-			return (a + b) * this.multiplier;
-		};
-	}
+// // test("action decorator on field (babel)", function(t) {
+// // 	class Store {
+// // 		constructor(multiplier) {
+// // 			this.multiplier = multiplier;
+// // 		}
 
-	const store1 =  new Store(2);
-	const store2 =  new Store(7);
+
+// // 		@action
+// // 		add = (a, b) => {
+// // 			return (a + b) * this.multiplier;
+// // 		};
+// // 	}
+
+// // 	const store1 =  new Store(2);
+// // 	const store2 =  new Store(7);
 	
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(5, 4), 63);
-	t.equal(store1.add(2, 2), 8);
+// // 	const events: any[] = [];
+// // 	const d = spy(events.push.bind(events));
+// // 	t.equal(store1.add(3, 4), 14);
+// // 	t.equal(store2.add(5, 4), 63);
+// // 	t.equal(store1.add(2, 2), 8);
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 5, 4 ], name: "add", spyReportStart: true, target: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 2, 2 ], name: "add", spyReportStart: true, target: store1, type: "action" },
-		{ spyReportEnd: true }
-	]);
+// // 	t.deepEqual(normalizeSpyEvents(events),	[
+// // 		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store1, type: "action" },
+// // 		{ spyReportEnd: true },
+// // 		{ arguments: [ 5, 4 ], name: "add", spyReportStart: true, target: store2, type: "action" },
+// // 		{ spyReportEnd: true },
+// // 		{ arguments: [ 2, 2 ], name: "add", spyReportStart: true, target: store1, type: "action" },
+// // 		{ spyReportEnd: true }
+// // 	]);
 
-	d();
-	t.end();
-});
+// // 	d();
+// // 	t.end();
+// // });
 
-test("custom action decorator on field (babel)", function(t) {
-	class Store {
-		constructor(multiplier) {
-			this.multiplier = multiplier;
-		}
+// // test("custom action decorator on field (babel)", function(t) {
+// // 	class Store {
+// // 		constructor(multiplier) {
+// // 			this.multiplier = multiplier;
+// // 		}
 
 
-		@action("zoem zoem")
-		add = (a, b) => {
-			return (a + b) * this.multiplier;
-		};
-	}
+// // 		@action("zoem zoem")
+// // 		add = (a, b) => {
+// // 			return (a + b) * this.multiplier;
+// // 		};
+// // 	}
 
-	const store1 =  new Store(2);
-	const store2 =  new Store(7);
+// // 	const store1 =  new Store(2);
+// // 	const store2 =  new Store(7);
 	
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(5, 4), 63);
-	t.equal(store1.add(2, 2), 8);
+// // 	const events: any[] = [];
+// // 	const d = spy(events.push.bind(events));
+// // 	t.equal(store1.add(3, 4), 14);
+// // 	t.equal(store2.add(5, 4), 63);
+// // 	t.equal(store1.add(2, 2), 8);
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 5, 4 ], name: "zoem zoem", spyReportStart: true, target: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 2, 2 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
-		{ spyReportEnd: true }
-	]);
+// // 	t.deepEqual(normalizeSpyEvents(events),	[
+// // 		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
+// // 		{ spyReportEnd: true },
+// // 		{ arguments: [ 5, 4 ], name: "zoem zoem", spyReportStart: true, target: store2, type: "action" },
+// // 		{ spyReportEnd: true },
+// // 		{ arguments: [ 2, 2 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
+// // 		{ spyReportEnd: true }
+// // 	]);
 
-	d();
-	t.end();
-});
+// // 	d();
+// // 	t.end();
+// // });
 
-test("267 (babel) should be possible to declare properties observable outside strict mode", t => {
-	mobx.useStrict(true);
+// test("267 (babel) should be possible to declare properties observable outside strict mode", t => {
+// 	mobx.useStrict(true);
 
-	class Store {
-		@observable timer;
+// 	class Store {
+// 		@observable timer;
+// 	}
+
+// 	mobx.useStrict(false);
+// 	t.end();
+// })
+
+// test("288 atom not detected for object property", t => {
+// 	// class Store {
+// 	// 	@mobx.observable foo = '';
+// 	// }
+
+// 	// const store = new Store();
+
+// 	// mobx.observe(store, 'foo', () => {
+// 	// 	console.log('Change observed');
+// 	// }, true);
+
+// 	t.end()
+// })
+
+test("observable performance", t => {
+	const AMOUNT = 100000;
+
+	class A {
+		@observable a = 1;
+		@observable b = 2;
+		@observable c = 3;
+		@computed get d() {
+			return this.a + this.b + this.c;
+		}
 	}
 
-	mobx.useStrict(false);
+	const objs = [];
+	const start = Date.now();
+
+	for (var i = 0; i < AMOUNT; i++)
+		objs.push(new A());
+	
+	console.log("created in ", Date.now() - start);
+
+	for (var j = 0; j < 4; j++) {
+		for (var i = 0; i < AMOUNT; i++) {
+			const obj = objs[i]
+			obj.a += 3;
+			obj.b *= 4;
+			obj.c = obj.b - obj.a;
+			obj.d;
+		}
+	} 
+
+	console.log("changed in ", Date.now() - start);
+
 	t.end();
-})
-
-test("288 atom not detected for object property", t => {
-	debugger;
-	class Store {
-		@mobx.observable foo = '';
-	}
-
-	const store = new Store();
-
-	mobx.observe(store, 'foo', () => {
-		console.log('Change observed');
-	}, true);
-
-	t.end()
 })
 
 // TODO: test unbound methods

--- a/test/babel/babel-tests.js
+++ b/test/babel/babel-tests.js
@@ -463,3 +463,58 @@ test("reusing initializers", t => {
 
 	t.end();
 })
+
+test("enumerability", t => {
+	class A {
+		@observable a = 1; // enumerable, on proto
+		@computed get b () { return this.a } // non-enumerable, on proto
+		@action m() {} // non-enumerable, on proto
+		@action m2 = () => {}; // non-enumerable, on self
+	}
+
+	const a = new A();
+	
+	// not initialized yet
+	let ownProps = Object.keys(a);
+	let props = [];
+	for (var key in a)
+		props.push(key);
+
+	t.deepEqual(ownProps, [
+	]);
+
+	t.deepEqual(props, [ // also 'a' would be ok
+		"a"
+	]);
+
+	t.equal(a.hasOwnProperty("a"), false); // true would be ok as well
+	t.equal(a.hasOwnProperty("b"), false);
+	t.equal(a.hasOwnProperty("m"), false);
+	t.equal(a.hasOwnProperty("m2"), false); // true would be ok as well
+
+	// after initialization
+	a.a;
+	a.b;
+	a.m;
+	a.m2;
+	
+	ownProps = Object.keys(a);
+	props = [];
+	for (var key in a)
+		props.push(key);
+
+	t.deepEqual(ownProps, [ // also 'a' would be ok
+	]);
+
+	t.deepEqual(props, [
+		"a"
+	]);
+
+	t.equal(a.hasOwnProperty("a"), false); // true would be ok as well
+	t.equal(a.hasOwnProperty("b"), false);
+	t.equal(a.hasOwnProperty("m"), false);
+	t.equal(a.hasOwnProperty("m2"), true);
+
+
+	t.end();
+})

--- a/test/babel/babel-tests.js
+++ b/test/babel/babel-tests.js
@@ -7,7 +7,7 @@ import {
 var test = require('tape')
 
 class Box {
-    //@observable uninitialized;
+    @observable uninitialized;
     @observable height = 20;
     @observable sizes = [2];
     @observable someFunc = function () { return 2; };
@@ -43,276 +43,276 @@ test('babel', function (t) {
   t.end()
 })
 
-// test('babel: parameterized computed decorator', (t) => {
-// 	class TestClass {
-// 		@observable x = 3;
-// 		@observable y = 3;
-// 		@computed({ asStructure: true }) get boxedSum() {
-// 			return { sum: Math.round(this.x) + Math.round(this.y) };
-// 		}
-// 	}
+test('babel: parameterized computed decorator', (t) => {
+	class TestClass {
+		@observable x = 3;
+		@observable y = 3;
+		@computed({ asStructure: true }) get boxedSum() {
+			return { sum: Math.round(this.x) + Math.round(this.y) };
+		}
+	}
 	
-// 	const t1 = new TestClass();
-// 	const changes: { sum: number}[] = [];
-// 	const d = autorun(() => changes.push(t1.boxedSum));
+	const t1 = new TestClass();
+	const changes: { sum: number}[] = [];
+	const d = autorun(() => changes.push(t1.boxedSum));
 	
-// 	t1.y = 4; // change
-// 	t.equal(changes.length, 2);
-// 	t1.y = 4.2; // no change
-// 	t.equal(changes.length, 2);
-// 	transaction(() => {
-// 		t1.y = 3;
-// 		t1.x = 4;
-// 	}); // no change
-// 	t.equal(changes.length, 2);
-// 	t1.x = 6; // change
-// 	t.equal(changes.length, 3);
-// 	d();
+	t1.y = 4; // change
+	t.equal(changes.length, 2);
+	t1.y = 4.2; // no change
+	t.equal(changes.length, 2);
+	transaction(() => {
+		t1.y = 3;
+		t1.x = 4;
+	}); // no change
+	t.equal(changes.length, 2);
+	t1.x = 6; // change
+	t.equal(changes.length, 3);
+	d();
 	
-// 	t.deepEqual(changes, [{ sum: 6 }, { sum: 7 }, { sum: 9 }]);
+	t.deepEqual(changes, [{ sum: 6 }, { sum: 7 }, { sum: 9 }]);
 	
-// 	t.end();
-// });
+	t.end();
+});
 
-// class Order {
-//     @observable price = 3;
-//     @observable amount = 2;
-//     @observable orders = [];
-//     @observable aFunction = function(a) { };
-//     @observable someStruct = asStructure({ x: 1, y: 2});
+class Order {
+    @observable price = 3;
+    @observable amount = 2;
+    @observable orders = [];
+    @observable aFunction = function(a) { };
+    @observable someStruct = asStructure({ x: 1, y: 2});
 
-//     @computed get total() {
-//         return this.amount * this.price * (1 + this.orders.length);
-//     }
-// }
+    @computed get total() {
+        return this.amount * this.price * (1 + this.orders.length);
+    }
+}
 
-// test('decorators', function(t) {
-// 	var o = new Order();
-// 	t.equal(o.total, 6); // hmm this is required to initialize the props which are made reactive lazily..
-// 	t.equal(isObservableObject(o), true);
-// 	t.equal(isObservable(o, 'amount'), true);
-// 	t.equal(isObservable(o, 'total'), true);
+test('decorators', function(t) {
+	var o = new Order();
+	t.equal(o.total, 6); // hmm this is required to initialize the props which are made reactive lazily..
+	t.equal(isObservableObject(o), true);
+	t.equal(isObservable(o, 'amount'), true);
+	t.equal(isObservable(o, 'total'), true);
 	
-// 	var events = [];
-// 	var d1 = observe(o, (ev) => events.push(ev.name, ev.oldValue));
-// 	var d2 = observe(o, 'price', (newValue, oldValue) => events.push(newValue, oldValue));
-// 	var d3 = observe(o, 'total', (newValue, oldValue) => events.push(newValue, oldValue));
+	var events = [];
+	var d1 = observe(o, (ev) => events.push(ev.name, ev.oldValue));
+	var d2 = observe(o, 'price', (newValue, oldValue) => events.push(newValue, oldValue));
+	var d3 = observe(o, 'total', (newValue, oldValue) => events.push(newValue, oldValue));
 	
-// 	o.price = 4;
+	o.price = 4;
 	
-// 	d1();
-// 	d2();
-// 	d3();
+	d1();
+	d2();
+	d3();
 	
-// 	o.price = 5;
+	o.price = 5;
 	
-// 	t.deepEqual(events, [
-// 		8, // new total
-// 		6, // old total
-// 		4, // new price
-// 		3, // old price
-// 		"price", // event name
-// 		3, // event oldValue
-// 	]);
+	t.deepEqual(events, [
+		8, // new total
+		6, // old total
+		4, // new price
+		3, // old price
+		"price", // event name
+		3, // event oldValue
+	]);
 	
-// 	t.end();
-// })
+	t.end();
+})
 
-// test('issue 191 - shared initializers (babel)', function(t) {
-// 	class Test {
-// 		@observable obj = { a: 1 };
-// 		@observable array = [2];
-// 	}
+test('issue 191 - shared initializers (babel)', function(t) {
+	class Test {
+		@observable obj = { a: 1 };
+		@observable array = [2];
+	}
 	
-// 	var t1 = new Test();
-// 	t1.obj.a = 2;
-// 	t1.array.push(3);
+	var t1 = new Test();
+	t1.obj.a = 2;
+	t1.array.push(3);
 	
-// 	var t2 = new Test();
-// 	t2.obj.a = 3;
-// 	t2.array.push(4);
+	var t2 = new Test();
+	t2.obj.a = 3;
+	t2.array.push(4);
 	
-// 	t.notEqual(t1.obj, t2.obj);
-// 	t.notEqual(t1.array, t2.array);
-// 	t.equal(t1.obj.a, 2);
-// 	t.equal(t2.obj.a, 3);
+	t.notEqual(t1.obj, t2.obj);
+	t.notEqual(t1.array, t2.array);
+	t.equal(t1.obj.a, 2);
+	t.equal(t2.obj.a, 3);
 	
-// 	t.deepEqual(t1.array.slice(), [2,3]);
-// 	t.deepEqual(t2.array.slice(), [2,4]);
+	t.deepEqual(t1.array.slice(), [2,3]);
+	t.deepEqual(t2.array.slice(), [2,4]);
 	
-// 	t.end();
-// })
+	t.end();
+})
 
-// function normalizeSpyEvents(events) {
-// 	events.forEach(ev => {
-// 		delete ev.fn;
-// 		delete ev.time;
-// 	});
-// 	return events;
-// }
+function normalizeSpyEvents(events) {
+	events.forEach(ev => {
+		delete ev.fn;
+		delete ev.time;
+	});
+	return events;
+}
 
-// // test("action decorator (babel)", function(t) {
-// // 	debugger;
-// // 	class Store {
-// // 		constructor(multiplier) {
-// // 			this.multiplier = multiplier;
-// // 		}
+test("action decorator (babel)", function(t) {
+	debugger;
+	class Store {
+		constructor(multiplier) {
+			this.multiplier = multiplier;
+		}
 		
-// // 		@action
-// // 		add(a, b) {
-// // 			return (a + b) * this.multiplier;
-// // 		}
-// // 	}
+		@action
+		add(a, b) {
+			return (a + b) * this.multiplier;
+		}
+	}
 
-// // 	const store1 =  new Store(2);
-// // 	const store2 =  new Store(3);
-// // 	const events: any[] = [];
-// // 	const d = spy(events.push.bind(events));
-// // 	t.equal(store1.add(3, 4), 14);
-// // 	t.equal(store2.add(3, 4), 21);
-// // 	t.equal(store1.add(1, 1), 4);
+	const store1 =  new Store(2);
+	const store2 =  new Store(3);
+	const events: any[] = [];
+	const d = spy(events.push.bind(events));
+	t.equal(store1.add(3, 4), 14);
+	t.equal(store2.add(3, 4), 21);
+	t.equal(store1.add(1, 1), 4);
 
-// // 	t.deepEqual(normalizeSpyEvents(events),	[
-// // 		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store1, type: "action" },
-// // 		{ spyReportEnd: true },
-// // 		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store2, type: "action" },
-// // 		{ spyReportEnd: true },
-// // 		{ arguments: [ 1, 1 ], name: "add", spyReportStart: true, target: store1, type: "action" },
-// // 		{ spyReportEnd: true }
-// // 	]);
+	t.deepEqual(normalizeSpyEvents(events),	[
+		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store1, type: "action" },
+		{ spyReportEnd: true },
+		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store2, type: "action" },
+		{ spyReportEnd: true },
+		{ arguments: [ 1, 1 ], name: "add", spyReportStart: true, target: store1, type: "action" },
+		{ spyReportEnd: true }
+	]);
 
-// // 	d();
-// // 	t.end();
-// // });
+	d();
+	t.end();
+});
 
-// // test("custom action decorator (babel)", function(t) {
-// // 	class Store {
-// // 		constructor(multiplier) {
-// // 			this.multiplier = multiplier;
-// // 		}
+test("custom action decorator (babel)", function(t) {
+	class Store {
+		constructor(multiplier) {
+			this.multiplier = multiplier;
+		}
 
-// // 		@action("zoem zoem")
-// // 		add(a, b) {
-// // 			return (a + b) * this.multiplier;
-// // 		}
-// // 	}
+		@action("zoem zoem")
+		add(a, b) {
+			return (a + b) * this.multiplier;
+		}
+	}
 
-// // 	const store1 =  new Store(2);
-// // 	const store2 =  new Store(3);
-// // 	const events: any[] = [];
-// // 	const d = spy(events.push.bind(events));
-// // 	t.equal(store1.add(3, 4), 14);
-// // 	t.equal(store2.add(3, 4), 21);
-// // 	t.equal(store1.add(1, 1), 4);
+	const store1 =  new Store(2);
+	const store2 =  new Store(3);
+	const events: any[] = [];
+	const d = spy(events.push.bind(events));
+	t.equal(store1.add(3, 4), 14);
+	t.equal(store2.add(3, 4), 21);
+	t.equal(store1.add(1, 1), 4);
 
-// // 	t.deepEqual(normalizeSpyEvents(events),	[
-// // 		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
-// // 		{ spyReportEnd: true },
-// // 		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store2, type: "action" },
-// // 		{ spyReportEnd: true },
-// // 		{ arguments: [ 1, 1 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
-// // 		{ spyReportEnd: true },
-// // 	]);
+	t.deepEqual(normalizeSpyEvents(events),	[
+		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
+		{ spyReportEnd: true },
+		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store2, type: "action" },
+		{ spyReportEnd: true },
+		{ arguments: [ 1, 1 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
+		{ spyReportEnd: true },
+	]);
 
-// // 	d();
-// // 	t.end();
-// // });
-
-
-// // test("action decorator on field (babel)", function(t) {
-// // 	class Store {
-// // 		constructor(multiplier) {
-// // 			this.multiplier = multiplier;
-// // 		}
+	d();
+	t.end();
+});
 
 
-// // 		@action
-// // 		add = (a, b) => {
-// // 			return (a + b) * this.multiplier;
-// // 		};
-// // 	}
+test("action decorator on field (babel)", function(t) {
+	class Store {
+		constructor(multiplier) {
+			this.multiplier = multiplier;
+		}
 
-// // 	const store1 =  new Store(2);
-// // 	const store2 =  new Store(7);
+
+		@action
+		add = (a, b) => {
+			return (a + b) * this.multiplier;
+		};
+	}
+
+	const store1 =  new Store(2);
+	const store2 =  new Store(7);
 	
-// // 	const events: any[] = [];
-// // 	const d = spy(events.push.bind(events));
-// // 	t.equal(store1.add(3, 4), 14);
-// // 	t.equal(store2.add(5, 4), 63);
-// // 	t.equal(store1.add(2, 2), 8);
+	const events: any[] = [];
+	const d = spy(events.push.bind(events));
+	t.equal(store1.add(3, 4), 14);
+	t.equal(store2.add(5, 4), 63);
+	t.equal(store1.add(2, 2), 8);
 
-// // 	t.deepEqual(normalizeSpyEvents(events),	[
-// // 		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store1, type: "action" },
-// // 		{ spyReportEnd: true },
-// // 		{ arguments: [ 5, 4 ], name: "add", spyReportStart: true, target: store2, type: "action" },
-// // 		{ spyReportEnd: true },
-// // 		{ arguments: [ 2, 2 ], name: "add", spyReportStart: true, target: store1, type: "action" },
-// // 		{ spyReportEnd: true }
-// // 	]);
+	t.deepEqual(normalizeSpyEvents(events),	[
+		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, target: store1, type: "action" },
+		{ spyReportEnd: true },
+		{ arguments: [ 5, 4 ], name: "add", spyReportStart: true, target: store2, type: "action" },
+		{ spyReportEnd: true },
+		{ arguments: [ 2, 2 ], name: "add", spyReportStart: true, target: store1, type: "action" },
+		{ spyReportEnd: true }
+	]);
 
-// // 	d();
-// // 	t.end();
-// // });
+	d();
+	t.end();
+});
 
-// // test("custom action decorator on field (babel)", function(t) {
-// // 	class Store {
-// // 		constructor(multiplier) {
-// // 			this.multiplier = multiplier;
-// // 		}
+test("custom action decorator on field (babel)", function(t) {
+	class Store {
+		constructor(multiplier) {
+			this.multiplier = multiplier;
+		}
 
 
-// // 		@action("zoem zoem")
-// // 		add = (a, b) => {
-// // 			return (a + b) * this.multiplier;
-// // 		};
-// // 	}
+		@action("zoem zoem")
+		add = (a, b) => {
+			return (a + b) * this.multiplier;
+		};
+	}
 
-// // 	const store1 =  new Store(2);
-// // 	const store2 =  new Store(7);
+	const store1 =  new Store(2);
+	const store2 =  new Store(7);
 	
-// // 	const events: any[] = [];
-// // 	const d = spy(events.push.bind(events));
-// // 	t.equal(store1.add(3, 4), 14);
-// // 	t.equal(store2.add(5, 4), 63);
-// // 	t.equal(store1.add(2, 2), 8);
+	const events: any[] = [];
+	const d = spy(events.push.bind(events));
+	t.equal(store1.add(3, 4), 14);
+	t.equal(store2.add(5, 4), 63);
+	t.equal(store1.add(2, 2), 8);
 
-// // 	t.deepEqual(normalizeSpyEvents(events),	[
-// // 		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
-// // 		{ spyReportEnd: true },
-// // 		{ arguments: [ 5, 4 ], name: "zoem zoem", spyReportStart: true, target: store2, type: "action" },
-// // 		{ spyReportEnd: true },
-// // 		{ arguments: [ 2, 2 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
-// // 		{ spyReportEnd: true }
-// // 	]);
+	t.deepEqual(normalizeSpyEvents(events),	[
+		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
+		{ spyReportEnd: true },
+		{ arguments: [ 5, 4 ], name: "zoem zoem", spyReportStart: true, target: store2, type: "action" },
+		{ spyReportEnd: true },
+		{ arguments: [ 2, 2 ], name: "zoem zoem", spyReportStart: true, target: store1, type: "action" },
+		{ spyReportEnd: true }
+	]);
 
-// // 	d();
-// // 	t.end();
-// // });
+	d();
+	t.end();
+});
 
-// test("267 (babel) should be possible to declare properties observable outside strict mode", t => {
-// 	mobx.useStrict(true);
+test("267 (babel) should be possible to declare properties observable outside strict mode", t => {
+	mobx.useStrict(true);
 
-// 	class Store {
-// 		@observable timer;
-// 	}
+	class Store {
+		@observable timer;
+	}
 
-// 	mobx.useStrict(false);
-// 	t.end();
-// })
+	mobx.useStrict(false);
+	t.end();
+})
 
-// test("288 atom not detected for object property", t => {
-// 	// class Store {
-// 	// 	@mobx.observable foo = '';
-// 	// }
+test("288 atom not detected for object property", t => {
+	// class Store {
+	// 	@mobx.observable foo = '';
+	// }
 
-// 	// const store = new Store();
+	// const store = new Store();
 
-// 	// mobx.observe(store, 'foo', () => {
-// 	// 	console.log('Change observed');
-// 	// }, true);
+	// mobx.observe(store, 'foo', () => {
+	// 	console.log('Change observed');
+	// }, true);
 
-// 	t.end()
-// })
+	t.end()
+})
 
 test("observable performance", t => {
 	const AMOUNT = 100000;
@@ -352,3 +352,7 @@ test("observable performance", t => {
 // TODO: test unbound methods
 
 // TODO: test sharing of methods, test non sharing of bound methods
+
+// TODO: test inheritance
+
+// TODO: test inherited observables

--- a/test/typescript-tests.ts
+++ b/test/typescript-tests.ts
@@ -735,3 +735,59 @@ test("reusing initializers", t => {
 
 	t.end();
 })
+
+test("enumerability", t => {
+	class A {
+		@observable a = 1; // enumerable, on proto
+		@computed get b () { return this.a } // non-enumerable, on proto
+		@action m() {} // non-enumerable, on proto
+		@action m2 = () => {}; // non-enumerable, on self
+	}
+
+	const a = new A();
+	
+	// not initialized yet
+	let ownProps = Object.keys(a);
+	let props: string[] = [];
+	for (var key in a)
+		props.push(key);
+
+	t.deepEqual(ownProps, [
+	]);
+
+	t.deepEqual(props, [ // also 'a' would be ok
+		"a"
+	]);
+
+	t.equal(a.hasOwnProperty("a"), false); // true would be ok as well
+	t.equal(a.hasOwnProperty("b"), false);
+	t.equal(a.hasOwnProperty("m"), false);
+	t.equal(a.hasOwnProperty("m2"), true); // false would be ok as well
+
+	// after initialization
+	a.a;
+	a.b;
+	a.m;
+	a.m2;
+	
+	ownProps = Object.keys(a);
+	props = [];
+	for (var key in a)
+		props.push(key);
+
+	t.deepEqual(ownProps, [ // also 'a' would be ok
+	]);
+
+	t.deepEqual(props, [
+		"a"
+	]);
+
+	t.equal(a.hasOwnProperty("a"), false); // true would be ok as well
+	t.equal(a.hasOwnProperty("b"), false);
+	t.equal(a.hasOwnProperty("m"), false);
+	t.equal(a.hasOwnProperty("m2"), true);
+
+
+	t.end();
+})
+

--- a/test/typescript-tests.ts
+++ b/test/typescript-tests.ts
@@ -32,7 +32,6 @@ class Order {
 
 test('decorators', function(t) {
 	var o = new Order();
-	t.equal(o.total, 6); // hmm this is required to initialize the props which are made reactive lazily..
 	t.equal(isObservableObject(o), true);
 	t.equal(isObservable(o, 'amount'), true);
 	t.equal(isObservable(o, 'total'), true);

--- a/test/typescript-tests.ts
+++ b/test/typescript-tests.ts
@@ -180,34 +180,23 @@ const state:any = observable({
     authToken: null
 });
 
-class LoginStoreTest {
-    loggedIn2: boolean;
-    constructor() {
-        extendObservable(this, {
-            loggedIn2: () => !!state.authToken
-        });
-    }
-
-    @observable get loggedIn() {
-        return !!state.authToken;
-    }
-}
 
 test('issue8', function(t){
-    var fired = 0;
+	t.throws(() => {
+		class LoginStoreTest {
+			loggedIn2: boolean;
+			constructor() {
+				extendObservable(this, {
+					loggedIn2: () => !!state.authToken
+				});
+			}
 
-    const store = new LoginStoreTest();
-
-    autorun(() => {
-        fired++;
-        store.loggedIn;
-    });
-
-    t.equal(fired, 1);
-    state.authToken = 'a';
-    state.authToken = 'b';
-
-    t.equal(fired, 2);
+			@observable get loggedIn() {
+				return !!state.authToken;
+			}
+		}
+		const store = new LoginStoreTest();
+	}, /@computed/);
     t.end();
 })
 

--- a/test/typescript-tests.ts
+++ b/test/typescript-tests.ts
@@ -571,7 +571,7 @@ test("custom action decorator on field (typescript)", function(t) {
 	t.end();
 });
 
-test("267 (babel) should be possible to declare properties observable outside strict mode", t => {
+test("267 (typescript) should be possible to declare properties observable outside strict mode", t => {
 	useStrict(true);
 
 	class Store {


### PR DESCRIPTION
* decorators are now stored on prototype if possible: gives significant perfomance improvements in CPU and MEM usage (30-50% in benchmarks)
* subtle differences between typescript and babel are now largely gone
* Object.keys(instance) will no longer report observable properties, in contrast to for .. in ...
* more code reuse between decorators
* improved test coverage
* This PR also fixes #288 and makes it a lot easier to make decorators configurable (see also #211)

Benchmark of creating and modifying 100K objects:

language | instantiating (ms) | modifying(ms) | peak mem
---- | --- | ---- | ---
ts (before PR) |  1308 |  7491 | 360MB
ts | 938 | 2222 | 198MB
babel (before PR) | 14 | 5348 | 374MB
babel | 19 | 2046 | 194MB

