### PR TITLE
Fix inconsistent title/desc in getting-started doc

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <meta name="description" content="Five minute introduction to MobX + React">
+    <meta name="description" content="Ten minute introduction to MobX + React">
 
     <link rel="stylesheet" href="getting-started-assets/style.css" />
     <link href='https://fonts.googleapis.com/css?family=PT+Serif' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Makes it consistent with the title tag, which says ten. 

Not normally an issue except when shared on social networks. e.g. facebook messenger:

![image](https://cloud.githubusercontent.com/assets/502412/16027207/13417618-31cc-11e6-9932-584538334fa7.png)

Is it five? Or ten? 😀 