### PR TITLE
Fixed #341 ObservableArray.find return null instead of undefined

### DIFF
--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -276,7 +276,7 @@ export class ObservableArray<T> extends StubArray {
 		for (let i = fromIndex; i < l; i++)
 			if (predicate.call(thisArg, items[i], i, this))
 				return items[i];
-		return null;
+		return undefined;
 	}
 
 	/*


### PR DESCRIPTION
 [MDN Array find](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) entry states:
> The find() method returns a value in the array, if an element in the array satisfies the provided testing function. Otherwise undefined is returned.