### PR TITLE
Fix decorator in typescript targeting ES3

### DIFF
--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -50,6 +50,8 @@ export function createClassPropertyDecorator(
 			};
 			if (arguments.length < 3) {
 				// Typescript target is ES3, so it won't define property for us
+				// or using Reflect.decorate polyfill, which will return no descriptor
+				// (see https://github.com/mobxjs/mobx/issues/333)
 				Object.defineProperty(target, key, descriptor);
 			}
 			return descriptor;

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -32,7 +32,7 @@ export function createClassPropertyDecorator(
 		invariant(allowCustomArguments || quacksLikeADecorator(arguments), "This function is a decorator, but it wasn't invoked like a decorator");
 		if (!descriptor) {
 			// typescript (except for getter / setters)
-			return {
+			const descriptor = {
 				enumerable,
 				configurable: true,
 				get: function() {
@@ -48,6 +48,11 @@ export function createClassPropertyDecorator(
 					}
 				}
 			};
+			if (arguments.length < 3) {
+				// Typescript target is ES3, so it won't define property for us
+				Object.defineProperty(target, key, descriptor);
+			}
+			return descriptor;
 		} else {
 			// babel and typescript getter / setter props
 			if (!target.hasOwnProperty("__mobxLazyInitializers")) {


### PR DESCRIPTION
When tsc target is set to ES3 (default), it won't add 3'rd argument for decorator https://github.com/Microsoft/TypeScript/blob/v1.8.10/src/compiler/emitter.ts#L5707
Then it won't use Object.defineProperty https://github.com/Microsoft/TypeScript/blob/v1.8.10/src/compiler/emitter.ts#L364

I don't know, whether we should care about this setup, because mobx itself is not usable under ES3 environment, but this fixes problem on updating from mobx 2.2.2