### PR TITLE
Update action.md

### DIFF
--- a/docs/refguide/action.md
+++ b/docs/refguide/action.md
@@ -14,7 +14,7 @@ Actions help you to structure your code better.
 It takes a function and returns it after wrapping it with `untracked`, `transaction` and `allowStateChanges`.
 It is advised to use them on any function that modifies observables or has side effects.
 `action` also provides useful debugging information in combination with the devtools.
-Note: using `action` is mandatory when *strict mode* is enabled, see `useStrict`.
+Note: using `action` is mandatory when *strict mode* is enabled, see `useStrict`. Using the `@action` decorator with [ES 5.1 setters](http://www.ecma-international.org/ecma-262/5.1/#sec-11.1.5) (i.e. `@action set propertyName`) is not supported.
 
 For an extensive introduction to `action` see also the [MobX 2.2 release notes](https://medium.com/p/45cdc73c7c8d/).
 


### PR DESCRIPTION
not sure if this is the best way to decribe it, but it should be noted somewhere.

btw. annotating a setter as `@action set propertyName` produces an error message only if the getter is annotated as well (you have to say `@computed get propertyName` to get an error message that says setters cannot be actions).