### PR TITLE
Add Symbol.iterator to maps

### DIFF
--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -203,7 +203,11 @@ export class ObservableMap<V> implements IInterceptable<IMapWillChange<V>>, ILis
 	values(): V[] {
 		return this.keys().map(this.get, this);
 	}
-
+	
+	[Symbol.iterator](): IMapEntries<V> {
+		return this.entries();
+	}
+	
 	entries(): IMapEntries<V> {
 		return this.keys().map(key => <[string, V]>[key, this.get(key)]);
 	}


### PR DESCRIPTION
support iteration protocol, this lets libraries and `for...of` loops directly consume 
maps like native maps.

Note that a more correct type would be an iterator, something like:

```js
    entries(): Iterator<[string, V]>;
    keys(): Iterator<V>;
    values(): Iterator<V>;
```