### PR TITLE
Make observable decorator define instance properties

### DIFF
--- a/src/api/observabledecorator.ts
+++ b/src/api/observabledecorator.ts
@@ -11,7 +11,7 @@ const decoratorImpl = createClassPropertyDecorator(
 		if (typeof baseValue === "function")
 			baseValue = asReference(baseValue);
 		const adm = asObservableObject(target, undefined, ValueMode.Recursive);
-		defineObservableProperty(adm, name, baseValue, false);
+		defineObservableProperty(adm, name, baseValue, true);
 		allowStateChangesEnd(prevA);
 	},
 	function (name) {


### PR DESCRIPTION
Since v2.3.1 `@observable` Typescript decorator does't define instance property, so, for example:
```
class Store {
   @observable cats = 5;
}
var store = new Store();
store.hasOwnProperty('cats'); // returns false
Object.assign({}, store); // returns {}
```

Note, that it didn't define instance property before v2.3.1 in Babel version, only in Typescript one.

@mweststrate, if this is expected behaviour, please close my pr.
