### PR TITLE
Introduce dispose()

### DIFF
--- a/src/api/dispose.ts
+++ b/src/api/dispose.ts
@@ -1,0 +1,9 @@
+import {globalState} from "../core/globalstate";
+
+export function dispose() {
+	if (globalState.currentReaction) {
+		globalState.currentReaction.dispose();
+	} else {
+		console.error('mobx: dispose() must be called inside reaction');
+	}
+}

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -45,6 +45,12 @@ export class MobXGlobals {
 	isRunningReactions = false;
 
 	/**
+	 * Current reaction (if any is running).
+	 * Reactions are run after derivations using a trampoline.
+	 */
+	currentReaction: Reaction = undefined;
+
+	/**
 	 * List of observables that have changed in a transaction.
 	 * After completing the transaction(s) these atoms will notify their observers.
 	 */

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -157,9 +157,12 @@ export function runReactions() {
 		if (++iterations === MAX_REACTION_ITERATIONS)
 			throw new Error("Reaction doesn't converge to a stable state. Probably there is a cycle in the reactive function: " + allReactions[0].toString());
 		let remainingReactions = allReactions.splice(0);
-		for (let i = 0, l = remainingReactions.length; i < l; i++)
+		for (let i = 0, l = remainingReactions.length; i < l; i++) {
+			globalState.currentReaction = remainingReactions[i];
 			remainingReactions[i].runReaction();
+		}
 	}
+	globalState.currentReaction = undefined;
 	globalState.isRunningReactions = false;
 }
 

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -47,6 +47,7 @@ export { expr                                                 } from "./api/expr
 export { toJSON, toJS                                         } from "./api/tojs";
 export { ITransformer, createTransformer                      } from "./api/createtransformer";
 export { whyRun                                               } from "./api/whyrun";
+export { dispose                                              } from "./api/dispose";
 
 export { Lambda                                               } from "./utils/utils";
 export { SimpleEventEmitter, ISimpleEventListener             } from "./utils/simpleeventemitter";

--- a/test/api.js
+++ b/test/api.js
@@ -18,6 +18,7 @@ test('correct api should be exposed', function(t) {
 		'autorunUntil',
 		'computed',
 		'createTransformer',
+		'dispose',
 		'expr',
 		'extendObservable',
 		'extras',


### PR DESCRIPTION
How about having a function, that disposes reaction, that it was called in.

Before:
```js
const waitForDataLoadingDisposer = reaction(
  () => myStore.data,
  data => {
    if (data) {
      doSomethingWithData(data);
      waitForDataLoadingDisposer();
    }     
  }
)
```

After:
```js
reaction(
  () => myStore.data,
  data => {
    if (data) {
      doSomethingWithData(data);
      dispose();
    }     
  }
)
```


Before:
```js
const timerDisposer = autorun(() => {
   console.log(time.get(), 'seconds left')
   if (time.get() <= 0) timerDisposer();
})
```

After:
```js
autorun(() => {
   console.log(time.get(), 'seconds left')
   if (time.get() <= 0) dispose();
})
```


@mweststrate, I can add tests, if this idea is worth.
