### PR TITLE
Fix observable array in Safari

### DIFF
--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -5,6 +5,7 @@ import {checkIfStateModificationsAreAllowed} from "../core/derivation";
 import {IInterceptable, IInterceptor, hasInterceptors, registerInterceptor, interceptChange} from "./intercept-utils";
 import {IListenable, registerListener, hasListeners, notifyListeners} from "./listen-utils";
 import {isSpyEnabled, spyReportStart, spyReportEnd} from "../core/spy";
+
 /**
  * Detects bug in some browsers, when instance doesn't use prototype setter,
  * if property name looks like number. See https://github.com/mobxjs/mobx/issues/364
@@ -507,7 +508,6 @@ function reserveArrayBuffer(target: any, min: number, max: number) {
 		});
 }
 
-debugger;
 if (canUsePrototypeSetter) {
 	reserveArrayBuffer(ObservableArray.prototype, 0, SHARED_BUFFER_LENGTH);
 }

--- a/test/action.js
+++ b/test/action.js
@@ -175,7 +175,6 @@ test('should not be possible to invoke action in a computed block', t => {
 	var noopAction = mobx.action(() => {});
 
 	var c = mobx.computed(() => {
-		debugger;
 		noopAction();
 		return a.get();
 	});

--- a/test/array.js
+++ b/test/array.js
@@ -259,7 +259,7 @@ test('new fast array values won\'t be observable', function(t) {
     t.equal(mobx.isObservable(booksA[0], "name"), false);
     var removed = booksA.splice(0, 1);
     t.equal(mobx.isObservable(removed[0], "name"), false);
-    t.end(); 
+    t.end();
 });
 
 test('is array', function(t) {
@@ -276,7 +276,7 @@ test('peek', function(t) {
     var x = mobx.observable([1, 2, 3]);
     t.deepEqual(x.peek(), [1, 2, 3]);
     t.equal(x.$mobx.values, x.peek());
-    
+
     x.peek().push(4); //noooo!
     t.throws(function() {
         x.push(5); // detect alien change
@@ -290,11 +290,11 @@ test('react to sort changes', function(t) {
         return x.sort();
     });
     var sorted;
-    
+
     mobx.autorun(function() {
         sorted = sortedX.get();
     });
-    
+
     t.deepEqual(x.slice(), [4,2,3]);
     t.deepEqual(sorted, [2,3,4]);
     x.push(1);
@@ -305,3 +305,18 @@ test('react to sort changes', function(t) {
     t.deepEqual(sorted, [1,2,3]);
     t.end();
 })
+
+test('autoextend buffer length', function(t) {
+	var bufferLength = observable([]).$mobx.getBufferLength();
+	var ar = observable(new Array(bufferLength))
+	var changesCount = 0;
+	ar.observe(changes => ++changesCount);
+
+	ar[ar.length] = 0;
+	ar.push(0);
+
+	t.equal(changesCount, 2);
+
+	t.end();
+})
+

--- a/test/cycles.js
+++ b/test/cycles.js
@@ -169,15 +169,15 @@ test('efficient selection', function(t) {
     }
     
     var store = new Store();
-    
+
     t.equal(store.selection, null);
     t.equal(store.items.filter(function (i) { return i.selected }).length, 0);
-    
+
     store.selection = store.items[1];
     t.equal(store.items.filter(function (i) { return i.selected }).length, 1);
     t.equal(store.selection, store.items[1]);
     t.equal(store.items[1].selected, true);
-    
+
     store.selection = store.items[2];
     t.equal(store.items.filter(function (i) { return i.selected }).length, 1);
     t.equal(store.selection, store.items[2]);

--- a/test/extras.js
+++ b/test/extras.js
@@ -14,20 +14,14 @@ test('treeD', function(t) {
     });
 
 
-    var bFunc =function () {
-        return a.get() * a.get();
-    };
-    var b = m.observable(bFunc);
+    var b = m.observable(() => a.get() * a.get());
     var bName = 'ComputedValue@2';
     t.deepEqual(dtree(b), {
         name: bName
         // no dependencies yet, since it isn't observed yet
     });
 
-    var cFunc =function() {
-        return b.get();
-    };
-    var c = m.autorun(cFunc);
+    var c = m.autorun(() => b.get());
     var cName = 'Autorun@3';
     t.deepEqual(dtree(c.$mobx), {
         name: cName,

--- a/test/spy.js
+++ b/test/spy.js
@@ -6,7 +6,6 @@ test('spy output', t => {
 	
 	var stop = mobx.spy(c => events.push(c));
 	
-	debugger;
 	doStuff();
 	
 	stop();


### PR DESCRIPTION
More info: #364

All the tests are now passing in Safari, Chrome, Firefox.

+ fixed buffer autoincrease:
```js
var i = observable(new Array(1000))
i.observe(a => console.log(a))
i[999] = "v" // Ok, triggers reaction
i[1000] = "v" // Fail, nothing happen
i[1001] = "v" // Fail, nothing happen
i[1002] = "v" // Fail, nothing happen
i.length // Fail, 1000
``` 