### PR TITLE
Fix ObservableArray setters in Safari and buffer autoincreace

### DIFF
--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -124,8 +124,8 @@ class ObservableArrayAdministration<T> implements IInterceptable<IArrayWillChang
 		if (oldLength !== this.lastKnownLength)
 			throw new Error("[mobx] Modification exception: the internal structure of an observable array was changed. Did you use peek() to change it?");
 		this.lastKnownLength += delta;
-		if (delta > 0 && oldLength + delta > OBSERVABLE_ARRAY_BUFFER_SIZE)
-			reserveArrayBuffer(oldLength + delta);
+		if (delta > 0 && oldLength + delta + 1 > OBSERVABLE_ARRAY_BUFFER_SIZE)
+			reserveArrayBuffer(oldLength + delta + 1);
 		if (delta > 0)
 			for (let i = 0; i < delta; i++)
 				Object.defineProperty(this.array, "" + (oldLength + i), ENUMERABLE_ENTRIES[oldLength + i]);

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -126,6 +126,12 @@ class ObservableArrayAdministration<T> implements IInterceptable<IArrayWillChang
 		this.lastKnownLength += delta;
 		if (delta > 0 && oldLength + delta > OBSERVABLE_ARRAY_BUFFER_SIZE)
 			reserveArrayBuffer(oldLength + delta);
+		if (delta > 0)
+			for (let i = 0; i < delta; i++)
+				Object.defineProperty(this.array, "" + (oldLength + i), ENUMERABLE_ENTRIES[oldLength + i]);
+		else if (delta < 0)
+			for (let i = 0; i > delta; i--)
+				delete this.array["" + (oldLength + i)];
 	}
 
 	spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[] {
@@ -415,12 +421,20 @@ Object.defineProperty(ObservableArray.prototype, "length", {
 	});
 });
 
+const ENUMERABLE_ENTRIES = [];
+
 function createArrayBufferItem(index: number) {
+	const set = createArraySetter(index);
+	const get = createArrayGetter(index);
+	ENUMERABLE_ENTRIES[index] = {
+		enumerable: true,
+		configurable: true,
+		set, get
+	};
 	Object.defineProperty(ObservableArray.prototype, "" + index, {
 		enumerable: false,
-		configurable: false,
-		set: createArraySetter(index),
-		get: createArrayGetter(index)
+		configurable: true,
+		set, get
 	});
 }
 

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -250,7 +250,7 @@ export class ObservableArray<T> extends StubArray {
 			adm.values = [];
 		}
 
-		if (safariPrototypeSetterInheritanceBug) {
+		if (safariPrototypeSetterInheritanceBug && initialValues.length === 0) {
 			// Seems that Safari won't use numeric prototype setter untill any * numeric property is
 			// defined on the instance. After that it works fine, even if this property is deleted.
 			const { get, set } = ENUMERABLE_ENTRIES[0];

--- a/test/action.js
+++ b/test/action.js
@@ -175,7 +175,6 @@ test('should not be possible to invoke action in a computed block', t => {
 	var noopAction = mobx.action(() => {});
 
 	var c = mobx.computed(() => {
-		debugger;
 		noopAction();
 		return a.get();
 	});

--- a/test/array.js
+++ b/test/array.js
@@ -85,6 +85,8 @@ test('test1', function(t) {
 
 	t.equal(JSON.stringify(a), "[3,1,2]");
 
+	t.deepEqual(Object.keys(a), ['0', '1', '2']);
+
     t.end();
 })
 

--- a/test/array.js
+++ b/test/array.js
@@ -261,7 +261,7 @@ test('new fast array values won\'t be observable', function(t) {
     t.equal(mobx.isObservable(booksA[0], "name"), false);
     var removed = booksA.splice(0, 1);
     t.equal(mobx.isObservable(removed[0], "name"), false);
-    t.end(); 
+    t.end();
 });
 
 test('is array', function(t) {
@@ -278,7 +278,7 @@ test('peek', function(t) {
     var x = mobx.observable([1, 2, 3]);
     t.deepEqual(x.peek(), [1, 2, 3]);
     t.equal(x.$mobx.values, x.peek());
-    
+
     x.peek().push(4); //noooo!
     t.throws(function() {
         x.push(5); // detect alien change
@@ -292,11 +292,11 @@ test('react to sort changes', function(t) {
         return x.sort();
     });
     var sorted;
-    
+
     mobx.autorun(function() {
         sorted = sortedX.get();
     });
-    
+
     t.deepEqual(x.slice(), [4,2,3]);
     t.deepEqual(sorted, [2,3,4]);
     x.push(1);

--- a/test/array.js
+++ b/test/array.js
@@ -307,3 +307,16 @@ test('react to sort changes', function(t) {
     t.deepEqual(sorted, [1,2,3]);
     t.end();
 })
+
+test('autoextend buffer length', function(t) {
+	var ar = observable(new Array(1000));
+	var changesCount = 0;
+	ar.observe(changes => ++changesCount);
+
+	ar[ar.length] = 0;
+	ar.push(0);
+
+	t.equal(changesCount, 2);
+
+	t.end();
+})

--- a/test/cycles.js
+++ b/test/cycles.js
@@ -169,15 +169,15 @@ test('efficient selection', function(t) {
     }
     
     var store = new Store();
-    
+
     t.equal(store.selection, null);
     t.equal(store.items.filter(function (i) { return i.selected }).length, 0);
-    
+
     store.selection = store.items[1];
     t.equal(store.items.filter(function (i) { return i.selected }).length, 1);
     t.equal(store.selection, store.items[1]);
     t.equal(store.items[1].selected, true);
-    
+
     store.selection = store.items[2];
     t.equal(store.items.filter(function (i) { return i.selected }).length, 1);
     t.equal(store.selection, store.items[2]);

--- a/test/extras.js
+++ b/test/extras.js
@@ -14,20 +14,14 @@ test('treeD', function(t) {
     });
 
 
-    var bFunc =function () {
-        return a.get() * a.get();
-    };
-    var b = m.observable(bFunc);
+    var b = m.observable(() => a.get() * a.get());
     var bName = 'ComputedValue@2';
     t.deepEqual(dtree(b), {
         name: bName
         // no dependencies yet, since it isn't observed yet
     });
 
-    var cFunc =function() {
-        return b.get();
-    };
-    var c = m.autorun(cFunc);
+    var c = m.autorun(() => b.get());
     var cName = 'Autorun@3';
     t.deepEqual(dtree(c.$mobx), {
         name: cName,

--- a/test/spy.js
+++ b/test/spy.js
@@ -6,7 +6,6 @@ test('spy output', t => {
 	
 	var stop = mobx.spy(c => events.push(c));
 	
-	debugger;
 	doStuff();
 	
 	stop();


### PR DESCRIPTION
More info: #364

All the tests are now passing in Safari, Chrome, Firefox.

Chrome & FF assign variable name to function name when assigned to variable, so some test were failing.
```js
var myAnonymous = () => {};
myAnonymous.name // 'myAnonymous'
```

fixed buffer autoincrease bug:
```js
var i = observable(new Array(1000))
i.observe(a => console.log(a))
i[999] = "v" // Ok, triggers reaction
i[1000] = "v" // Fail, nothing happen
i[1001] = "v" // Fail, nothing happen
i[1002] = "v" // Fail, nothing happen
i.length // Fail, 1000
```