### PR TITLE
use created descriptor for defineProperty

### DIFF
--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -52,7 +52,7 @@ export function createClassPropertyDecorator(
 				// Typescript target is ES3, so it won't define property for us
 				// or using Reflect.decorate polyfill, which will return no descriptor
 				// (see https://github.com/mobxjs/mobx/issues/333)
-				Object.defineProperty(target, key, descriptor);
+				Object.defineProperty(target, key, descriptor || newDescriptor);
 			}
 			return newDescriptor;
 		} else {


### PR DESCRIPTION
If descriptor was falsy (line 33), a newDescriptor was created (line 35) but it was not actually used in line 55.

This broke Angular 2 zone.js for me with TypeError: desc is undefined and the proposed change fixes that.