### PR TITLE
Pass Reaction as an argument

### DIFF
--- a/src/api/autorun.ts
+++ b/src/api/autorun.ts
@@ -1,6 +1,6 @@
 import {Lambda, getNextId, deprecated, invariant, valueDidChange} from "../utils/utils";
 import {assertUnwrapped, ValueMode, getValueModeFromValue} from "../types/modifiers";
-import {Reaction} from "../core/reaction";
+import {Reaction, IReactionPublic} from "../core/reaction";
 import {untrackedStart, untrackedEnd} from "../core/derivation";
 import {action} from "../core/action";
 
@@ -11,7 +11,7 @@ import {action} from "../core/action";
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(view: (r: Reaction) => void, scope?: any);
+export function autorun(view: (r: IReactionPublic) => void, scope?: any);
 
 /**
  * Creates a named reactive view and keeps it alive, so that the view is always
@@ -21,10 +21,10 @@ export function autorun(view: (r: Reaction) => void, scope?: any);
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(name: string, view: (r: Reaction) => void, scope?: any);
+export function autorun(name: string, view: (r: IReactionPublic) => void, scope?: any);
 
 export function autorun(arg1: any, arg2: any, arg3?: any) {
-	let name: string, view: (r: Reaction) => void, scope: any;
+	let name: string, view: (r: IReactionPublic) => void, scope: any;
 	if (typeof arg1 === "string") {
 		name = arg1;
 		view = arg2;
@@ -99,17 +99,17 @@ export function when(arg1: any, arg2: any, arg3?: any, arg4?: any) {
 	return disposer;
 }
 
-export function autorunUntil(predicate: () => boolean, effect: (r: Reaction) => void, scope?: any) {
+export function autorunUntil(predicate: () => boolean, effect: (r: IReactionPublic) => void, scope?: any) {
 	deprecated("`autorunUntil` is deprecated, please use `when`.");
 	return when.apply(null, arguments);
 }
 
-export function autorunAsync(name: string, func: (r: Reaction) => void, delay?: number, scope?: any);
+export function autorunAsync(name: string, func: (r: IReactionPublic) => void, delay?: number, scope?: any);
 
-export function autorunAsync(func: (r: Reaction) => void, delay?: number, scope?: any);
+export function autorunAsync(func: (r: IReactionPublic) => void, delay?: number, scope?: any);
 
 export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
-	let name: string, func: (r: Reaction) => void, delay: number, scope: any;
+	let name: string, func: (r: IReactionPublic) => void, delay: number, scope: any;
 	if (typeof arg1 === "string") {
 		name = arg1;
 		func = arg2;
@@ -153,7 +153,7 @@ export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
  * or
  * autorun(() => action(effect)(expr));
  */
-export function reaction<T>(name: string, expression: () => T, effect: (arg: T, r: Reaction) => void, fireImmediately?: boolean, delay?: number, scope?: any);
+export function reaction<T>(name: string, expression: () => T, effect: (arg: T, r: IReactionPublic) => void, fireImmediately?: boolean, delay?: number, scope?: any);
 
 /**
  *
@@ -161,10 +161,10 @@ export function reaction<T>(name: string, expression: () => T, effect: (arg: T, 
  * or
  * autorun(() => action(effect)(expr));
  */
-export function reaction<T>(expression: () => T, effect: (arg: T, r: Reaction) => void, fireImmediately?: boolean, delay?: number, scope?: any);
+export function reaction<T>(expression: () => T, effect: (arg: T, r: IReactionPublic) => void, fireImmediately?: boolean, delay?: number, scope?: any);
 
 export function reaction<T>(arg1: any, arg2: any, arg3: any, arg4?: any, arg5?: any, arg6?: any) {
-	let name: string, expression: () => T, effect: (arg: T, r: Reaction) => void, fireImmediately: boolean, delay: number, scope: any;
+	let name: string, expression: () => T, effect: (arg: T, r: IReactionPublic) => void, fireImmediately: boolean, delay: number, scope: any;
 	if (typeof arg1 === "string") {
 		name = arg1;
 		expression = arg2;

--- a/src/api/autorun.ts
+++ b/src/api/autorun.ts
@@ -11,7 +11,7 @@ import {action} from "../core/action";
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(view: Lambda, scope?: any);
+export function autorun(view: (r?: Reaction) => void, scope?: any);
 
 /**
  * Creates a named reactive view and keeps it alive, so that the view is always
@@ -21,10 +21,10 @@ export function autorun(view: Lambda, scope?: any);
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(name: string, view: Lambda, scope?: any);
+export function autorun(name: string, view: (r?: Reaction) => void, scope?: any);
 
 export function autorun(arg1: any, arg2: any, arg3?: any) {
-	let name: string, view: Lambda, scope: any;
+	let name: string, view: (r?: Reaction) => void, scope: any;
 	if (typeof arg1 === "string") {
 		name = arg1;
 		view = arg2;
@@ -37,13 +37,17 @@ export function autorun(arg1: any, arg2: any, arg3?: any) {
 
 	assertUnwrapped(view, "autorun methods cannot have modifiers");
 	invariant(typeof view === "function", "autorun expects a function");
-	invariant(view.length === 0, "autorun expects a function without arguments");
 	if (scope)
 		view = view.bind(scope);
 
 	const reaction = new Reaction(name, function () {
-		this.track(view);
+		this.track(reactionRunner);
 	});
+
+	function reactionRunner() {
+		view(reaction);
+	}
+
 	reaction.schedule();
 
 	return reaction.getDisposer();
@@ -84,34 +88,28 @@ export function when(arg1: any, arg2: any, arg3?: any, arg4?: any) {
 		scope = arg3;
 	}
 
-	let disposeImmediately = false;
-	const disposer = autorun(name, () => {
+	const disposer = autorun(name, r => {
 		if (predicate.call(scope)) {
-			if (disposer)
-				disposer();
-			else
-				disposeImmediately = true;
+			r.dispose();
 			const prevUntracked = untrackedStart();
 			effect.call(scope);
 			untrackedEnd(prevUntracked);
 		}
 	});
-	if (disposeImmediately)
-		disposer();
 	return disposer;
 }
 
-export function autorunUntil(predicate: () => boolean, effect: Lambda, scope?: any) {
+export function autorunUntil(predicate: () => boolean, effect: (r?: Reaction) => void, scope?: any) {
 	deprecated("`autorunUntil` is deprecated, please use `when`.");
 	return when.apply(null, arguments);
 }
 
-export function autorunAsync(name: string, func: Lambda, delay?: number, scope?: any);
+export function autorunAsync(name: string, func: (r?: Reaction) => void, delay?: number, scope?: any);
 
-export function autorunAsync(func: Lambda, delay?: number, scope?: any);
+export function autorunAsync(func: (r?: Reaction) => void, delay?: number, scope?: any);
 
 export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
-	let name: string, func: Lambda, delay: number, scope: any;
+	let name: string, func: (r?: Reaction) => void, delay: number, scope: any;
 	if (typeof arg1 === "string") {
 		name = arg1;
 		func = arg2;
@@ -138,10 +136,12 @@ export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
 			setTimeout(() => {
 				isScheduled = false;
 				if (!r.isDisposed)
-					r.track(func);
+					r.track(reactionRunner);
 			}, delay);
 		}
 	});
+
+	function reactionRunner() { func(r); }
 
 	r.schedule();
 	return r.getDisposer();
@@ -153,7 +153,7 @@ export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
  * or
  * autorun(() => action(effect)(expr));
  */
-export function reaction<T>(name: string, expression: () => T, effect: (arg: T) => void, fireImmediately?: boolean, delay?: number, scope?: any);
+export function reaction<T>(name: string, expression: () => T, effect: (arg: T, r?: Reaction) => void, fireImmediately?: boolean, delay?: number, scope?: any);
 
 /**
  *
@@ -161,10 +161,10 @@ export function reaction<T>(name: string, expression: () => T, effect: (arg: T) 
  * or
  * autorun(() => action(effect)(expr));
  */
-export function reaction<T>(expression: () => T, effect: (arg: T) => void, fireImmediately?: boolean, delay?: number, scope?: any);
+export function reaction<T>(expression: () => T, effect: (arg: T, r?: Reaction) => void, fireImmediately?: boolean, delay?: number, scope?: any);
 
 export function reaction<T>(arg1: any, arg2: any, arg3: any, arg4?: any, arg5?: any, arg6?: any) {
-	let name: string, expression: () => T, effect: (arg: T) => void, fireImmediately: boolean, delay: number, scope: any;
+	let name: string, expression: () => T, effect: (arg: T, r?: Reaction) => void, fireImmediately: boolean, delay: number, scope: any;
 	if (typeof arg1 === "string") {
 		name = arg1;
 		expression = arg2;
@@ -199,23 +199,6 @@ export function reaction<T>(arg1: any, arg2: any, arg3: any, arg4?: any, arg5?: 
 	let isScheduled = false;
 	let nextValue = undefined;
 
-	function reactionRunner () {
-		if (r.isDisposed)
-			return;
-		let changed = false;
-		r.track(() => {
-			const v = unwrappedExpression();
-			changed = valueDidChange(compareStructural, nextValue, v);
-			nextValue = v;
-		});
-		if (firstTime && fireImmediately)
-			effect(nextValue);
-		if (!firstTime && changed === true)
-			effect(nextValue);
-		if (firstTime)
-			firstTime = false;
-	}
-
 	const r = new Reaction(name, () => {
 		if (delay < 1) {
 			reactionRunner();
@@ -227,6 +210,24 @@ export function reaction<T>(arg1: any, arg2: any, arg3: any, arg4?: any, arg5?: 
 			}, delay);
 		}
 	});
+
+	function reactionRunner () {
+		if (r.isDisposed)
+			return;
+		let changed = false;
+		r.track(() => {
+			const v = unwrappedExpression(r);
+			changed = valueDidChange(compareStructural, nextValue, v);
+			nextValue = v;
+		});
+		if (firstTime && fireImmediately)
+			effect(nextValue, r);
+		if (!firstTime && changed === true)
+			effect(nextValue, r);
+		if (firstTime)
+			firstTime = false;
+	}
+
 
 	r.schedule();
 	return r.getDisposer();

--- a/src/api/autorun.ts
+++ b/src/api/autorun.ts
@@ -11,7 +11,7 @@ import {action} from "../core/action";
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(view: (r?: Reaction) => void, scope?: any);
+export function autorun(view: (r: Reaction) => void, scope?: any);
 
 /**
  * Creates a named reactive view and keeps it alive, so that the view is always
@@ -21,10 +21,10 @@ export function autorun(view: (r?: Reaction) => void, scope?: any);
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(name: string, view: (r?: Reaction) => void, scope?: any);
+export function autorun(name: string, view: (r: Reaction) => void, scope?: any);
 
 export function autorun(arg1: any, arg2: any, arg3?: any) {
-	let name: string, view: (r?: Reaction) => void, scope: any;
+	let name: string, view: (r: Reaction) => void, scope: any;
 	if (typeof arg1 === "string") {
 		name = arg1;
 		view = arg2;
@@ -99,17 +99,17 @@ export function when(arg1: any, arg2: any, arg3?: any, arg4?: any) {
 	return disposer;
 }
 
-export function autorunUntil(predicate: () => boolean, effect: (r?: Reaction) => void, scope?: any) {
+export function autorunUntil(predicate: () => boolean, effect: (r: Reaction) => void, scope?: any) {
 	deprecated("`autorunUntil` is deprecated, please use `when`.");
 	return when.apply(null, arguments);
 }
 
-export function autorunAsync(name: string, func: (r?: Reaction) => void, delay?: number, scope?: any);
+export function autorunAsync(name: string, func: (r: Reaction) => void, delay?: number, scope?: any);
 
-export function autorunAsync(func: (r?: Reaction) => void, delay?: number, scope?: any);
+export function autorunAsync(func: (r: Reaction) => void, delay?: number, scope?: any);
 
 export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
-	let name: string, func: (r?: Reaction) => void, delay: number, scope: any;
+	let name: string, func: (r: Reaction) => void, delay: number, scope: any;
 	if (typeof arg1 === "string") {
 		name = arg1;
 		func = arg2;
@@ -153,7 +153,7 @@ export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
  * or
  * autorun(() => action(effect)(expr));
  */
-export function reaction<T>(name: string, expression: () => T, effect: (arg: T, r?: Reaction) => void, fireImmediately?: boolean, delay?: number, scope?: any);
+export function reaction<T>(name: string, expression: () => T, effect: (arg: T, r: Reaction) => void, fireImmediately?: boolean, delay?: number, scope?: any);
 
 /**
  *
@@ -161,10 +161,10 @@ export function reaction<T>(name: string, expression: () => T, effect: (arg: T, 
  * or
  * autorun(() => action(effect)(expr));
  */
-export function reaction<T>(expression: () => T, effect: (arg: T, r?: Reaction) => void, fireImmediately?: boolean, delay?: number, scope?: any);
+export function reaction<T>(expression: () => T, effect: (arg: T, r: Reaction) => void, fireImmediately?: boolean, delay?: number, scope?: any);
 
 export function reaction<T>(arg1: any, arg2: any, arg3: any, arg4?: any, arg5?: any, arg6?: any) {
-	let name: string, expression: () => T, effect: (arg: T, r?: Reaction) => void, fireImmediately: boolean, delay: number, scope: any;
+	let name: string, expression: () => T, effect: (arg: T, r: Reaction) => void, fireImmediately: boolean, delay: number, scope: any;
 	if (typeof arg1 === "string") {
 		name = arg1;
 		expression = arg2;

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -25,7 +25,11 @@ import {SimpleSet} from "../utils/set";
 
 let EMPTY_DERIVATION_SET: SimpleSet<IDerivation>;
 
-export class Reaction implements IDerivation {
+export interface IReactionPublic {
+	dispose: () => void,
+}
+
+export class Reaction implements IDerivation, IReactionPublic {
 	staleObservers:  IDerivation[] = EMPTY_ARRAY; // Won't change
 	observers = EMPTY_DERIVATION_SET || (EMPTY_DERIVATION_SET = new SimpleSet<IDerivation>());       // Won't change
 	observing = []; // nodes we are looking at. Our value depends on these nodes

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -21,7 +21,7 @@ registerGlobals();
 
 export { IAtom, Atom                                          } from "./core/atom";
 export { IObservable, IDepTreeNode                            } from "./core/observable";
-export { Reaction                                             } from "./core/reaction";
+export { Reaction, IReactionPublic                            } from "./core/reaction";
 export { IDerivation, untracked                               } from "./core/derivation";
 export { action, useStrict, isAction, runInAction             } from "./core/action";
 export { spy                                                  } from "./core/spy";

--- a/test/autorun.js
+++ b/test/autorun.js
@@ -1,0 +1,39 @@
+var test = require('tape');
+var m = require('..');
+
+test('autorun passes Reaction as an argument to view function', function(t) {
+	var a = m.observable(1);
+	var values = [];
+
+	m.autorun(r => {
+		t.equal(typeof r.dispose, 'function');
+		if (a.get() === 'pleaseDispose') r.dispose();
+		values.push(a.get());
+	});
+
+	a.set(2);
+	a.set(2);
+	a.set('pleaseDispose');
+	a.set(3);
+	a.set(4);
+
+	t.deepEqual(values, [1, 2, 'pleaseDispose']);
+
+	t.end()
+});
+
+test('autorun can be disposed on first run', function(t) {
+	var a = m.observable(1);
+	var values = [];
+
+	m.autorun(r => {
+		r.dispose();
+		values.push(a.get());
+	});
+
+	a.set(2);
+
+	t.deepEqual(values, [1]);
+
+	t.end()
+});

--- a/test/autorunAsync.js
+++ b/test/autorunAsync.js
@@ -103,3 +103,25 @@ test('autorun should not result in loop', function(t) {
 		d();
 	}, 100);
 });
+
+test('autorunAsync passes Reaction as an argument to view function', function(t) {
+	var a = m.observable(1);
+
+	var autoRunsCalled = 0;
+
+	m.autorunAsync(r => {
+		t.equal(typeof r.dispose, 'function');
+		autoRunsCalled++;
+		if (a.get() === 'pleaseDispose') r.dispose();
+	}, 10);
+
+	setTimeout(() => a.set(2), 25);
+	setTimeout(() => a.set('pleaseDispose'), 40);
+	setTimeout(() => a.set(3), 55);
+	setTimeout(() => a.set(4), 70);
+
+	setTimeout(function() {
+		t.equal(autoRunsCalled, 3);
+		t.end();
+	}, 100);
+});


### PR DESCRIPTION
@mweststrate, proposed this in https://github.com/mobxjs/mobx/pull/367/files#diff-b7cd2bd0ae3078ef83015cbfa3499bf6

Reaction instance is being passed to
 - mobx.reaction's expression and effect functions
 - mobx.autorun's view
 - mobx.autorunAsync's view

So you can do:
```js
autorun(r => {
   if (condition) r.dispose();
});

reaction(
  r => {
    if (condition) r.dispose();
    return something.get(); 
  },
  v => {}
)

reaction(
  () => something.get(),
  (v, r) => {
    if (condition) r.dispose();
  }
)
```

Will add this to docs in another PR.