### PR TITLE
Improve error msg when wrongly using `@computed`

### DIFF
--- a/src/api/computeddecorator.ts
+++ b/src/api/computeddecorator.ts
@@ -11,6 +11,7 @@ export interface IComputedValueOptions {
 
 const computedDecorator = createClassPropertyDecorator(
 	(target, name, _, decoratorArgs, originalDescriptor) => {
+		invariant(typeof originalDescriptor !== "undefined", "@computed can only be used on getter functions, like: '@computed get myProps() { return ...; }'. It looks like it was used on a property.");
 		const baseValue = originalDescriptor.get;
 		invariant(typeof baseValue === "function", "@computed can only be used on getter functions, like: '@computed get myProps() { return ...; }'");
 


### PR DESCRIPTION
When using `@computed` on a property, `originalDescriptor` is undefined thus the access to `get` failed before the invariant was reached.

I just (stupidly) wrote a `@computed` decorator in front of a property like this:

    @computed urls: string[] = [];

The error message I saw in browser console was

    mobx.js:180 Uncaught TypeError: Cannot read property 'get' of undefined

With this change a nice error message will be shown instead.