### PR TITLE
Make `isObservableArray` and `isObservableMap` type guards.

### DIFF
--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -512,6 +512,6 @@ export function fastArray<V>(initialValues?: V[]): IObservableArray<V> {
 	return createObservableArray(initialValues, ValueMode.Flat, null);
 }
 
-export function isObservableArray(thing): boolean {
+export function isObservableArray(thing): thing is IObservableArray<any> {
 	return thing instanceof ObservableArray;
 }

--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -301,6 +301,6 @@ export function map<V>(initialValues?: IMapEntries<V> | IKeyValueMap<V>, valueMo
 	return new ObservableMap(initialValues, valueModifier);
 }
 
-export function isObservableMap(thing): boolean {
+export function isObservableMap(thing): thing is ObservableMap<any> {
 	return thing instanceof ObservableMap;
 }


### PR DESCRIPTION
Typescript has a cool feature called `user type guard functions`, which helps to
narrow type of variable. This PR makes `isObservableArray` and `isObservableMap`
user type guard functions.