### PR TITLE
Typescript: Add proper return type of `runInAction` function.

### DIFF
--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -49,8 +49,8 @@ function namedActionDecorator(name: string) {
 	};
 }
 
-export function runInAction<T>(block: () => T, scope?: any);
-export function runInAction<T>(name: string, block: () => T, scope?: any);
+export function runInAction<T>(block: () => T, scope?: any): T;
+export function runInAction<T>(name: string, block: () => T, scope?: any): T;
 export function runInAction<T>(arg1, arg2?, arg3?) {
 	const actionName = typeof arg1 === "string" ? arg1 : arg1.name || "<unnamed action>";
 	const fn = typeof arg1 === "function" ? arg1 : arg2;


### PR DESCRIPTION
The return type of `runInAction` actually is return type of wrapped function.