### PR TITLE
Typescript: Add granular overloads for `action`, which fixes "Parameter XXX implicitly has an 'any' type"

### DIFF
--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -18,6 +18,14 @@ const actionFieldDecorator = createClassPropertyDecorator(
 	true
 );
 
+export function action<A1, R, T extends (a1: A1) => R>(fn: T): T;
+export function action<A1, A2, R, T extends (a1: A1, a2: A2) => R>(fn: T): T;
+export function action<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(fn: T): T;
+export function action<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(fn: T): T;
+export function action<A1, R, T extends (a1: A1) => R>(name: string, fn: T): T;
+export function action<A1, A2, R, T extends (a1: A1, a2: A2) => R>(name: string, fn: T): T;
+export function action<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(name: string, fn: T): T;
+export function action<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(name: string, fn: T): T;
 export function action<T extends Function>(fn: T): T;
 export function action<T extends Function>(name: string, fn: T): T;
 export function action(customName: string): (target: Object, key: string, baseDescriptor?: PropertyDescriptor) => void;


### PR DESCRIPTION
Trying to use action as a function wrapper on promises, like this:
```ts
import {action} from "mobx"

fetch().then(action(result => {

}))
```
Produces "Parameter 'result' implicitly has an 'any' type", if compiled with `noImplicitAny` option.
This PR adds some overloads for `action` declaration, which fixes this issue.