### PR TITLE
fix typo on api's page

### DIFF
--- a/best/react-performance.html
+++ b/best/react-performance.html
@@ -925,7 +925,7 @@ If this happens deeper in your component tree, less components have to re-render
 But a change in the <code>name</code> property will, in the first case, trigger the <code>DisplayName</code> to re-render, while in the latter, the owner of the component has to re-render.
 However, it is more important for your components to have a comprehensible API than applying this optimization.
 To have the best of both worlds, consider making smaller components:</p>
-<p><code>const PersonNameDispayer = observer(({ props }) =&gt; &lt;DisplayName name={props.person.name} /&gt;)</code></p>
+<p><code>const PersonNameDisplayer = observer(({ props }) =&gt; &lt;DisplayName name={props.person.name} /&gt;)</code></p>
 <h2 id="bind-functions-early">Bind functions early</h2>
 <p>This tip applies to React in general and libraries using <code>PureRenderMixin</code> especially, try to avoid creating new closures in render methods.</p>
 <p>See also these resources:</p>

--- a/docs/best/react-performance.md
+++ b/docs/best/react-performance.md
@@ -78,7 +78,7 @@ But a change in the `name` property will, in the first case, trigger the `Displa
 However, it is more important for your components to have a comprehensible API than applying this optimization.
 To have the best of both worlds, consider making smaller components:
 
-`const PersonNameDispayer = observer(({ props }) => <DisplayName name={props.person.name} />)`
+`const PersonNameDisplayer = observer(({ props }) => <DisplayName name={props.person.name} />)`
 
 ## Bind functions early
 

--- a/docs/refguide/api.md
+++ b/docs/refguide/api.md
@@ -161,7 +161,7 @@ Api that can be used to intercept changes before they are applied to an observab
 
 ### `observe`
 Usage: `observe(object, property?, listener, fireImmediately = false)`
-Low-level api that can be used be used to observe a single observable value.
+Low-level api that can be used to observe a single observable value.
 [&laquo;details&raquo;](observe.md)
 
 ### `useStrict`

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -12,7 +12,7 @@ Usage: `intercept(target, propertyName?, interceptor)`
 * `interceptor`: callback that will be invoked for *each* change that is made to the observable. Receives a single change object describing the mutation.
 
 The `intercept` should tell MobX what needs to happen with the current change.
-Therefor it should do one of the following things:
+Therefore it should do one of the following things:
 1. Return the received `change` object as-is from the function, in wich case the mutation will be applied.   
 2. Modify the `change` object and return it, for example to normalize the data. Not all fields are modifiable, see below.
 3. Return `null`, this indicates that the change can be ignored and shouldn't be applied. This is a powerful concept to make your objects for example temporarily immutable.

--- a/docs/refguide/observer-component.md
+++ b/docs/refguide/observer-component.md
@@ -131,7 +131,7 @@ The simple rule of thumb is: _all components that render observable data_.
 If you don't want to mark a component as observer, for example to reduce the dependencies of a generic component package, make sure you only pass it plain data.
 
 With `@observer` there is no need to distinguish 'smart' components from 'dumb' components for the purpose of rendering.
-It is stil a good separation of concerns for where to handle events, make requests etc.
+It is still a good separation of concerns for where to handle events, make requests etc.
 All components become responsible for updating when their _own_ dependencies change.
 Its overhead is neglectable and it makes sure that whenever you start using observable data the component will respond to it.
 See this [thread](https://www.reddit.com/r/reactjs/comments/4vnxg5/free_eggheadio_course_learn_mobx_react_in_30/d61oh0l) for more details.

--- a/refguide/api.html
+++ b/refguide/api.html
@@ -1004,7 +1004,7 @@ Api that can be used to intercept changes before they are applied to an observab
 <a href="observe.html">&#xAB;details&#xBB;</a></p>
 <h3 id="-observe"><code>observe</code></h3>
 <p>Usage: <code>observe(object, property?, listener, fireImmediately = false)</code>
-Low-level api that can be used be used to observe a single observable value.
+Low-level api that can be used to observe a single observable value.
 <a href="observe.html">&#xAB;details&#xBB;</a></p>
 <h3 id="-usestrict"><code>useStrict</code></h3>
 <p>Usage: <code>useStrict(boolean)</code>.

--- a/refguide/observe.html
+++ b/refguide/observe.html
@@ -879,7 +879,7 @@
 <li><code>interceptor</code>: callback that will be invoked for <em>each</em> change that is made to the observable. Receives a single change object describing the mutation.</li>
 </ul>
 <p>The <code>intercept</code> should tell MobX what needs to happen with the current change.
-Therefor it should do one of the following things:</p>
+Therefore it should do one of the following things:</p>
 <ol>
 <li>Return the received <code>change</code> object as-is from the function, in wich case the mutation will be applied.   </li>
 <li>Modify the <code>change</code> object and return it, for example to normalize the data. Not all fields are modifiable, see below.</li>

--- a/refguide/observer-component.html
+++ b/refguide/observer-component.html
@@ -970,7 +970,7 @@ colors.foreground = <span class="hljs-string">&apos;blue&apos;</span>;
 <p>The simple rule of thumb is: <em>all components that render observable data</em>.
 If you don&apos;t want to mark a component as observer, for example to reduce the dependencies of a generic component package, make sure you only pass it plain data.</p>
 <p>With <code>@observer</code> there is no need to distinguish &apos;smart&apos; components from &apos;dumb&apos; components for the purpose of rendering.
-It is stil a good separation of concerns for where to handle events, make requests etc.
+It is still a good separation of concerns for where to handle events, make requests etc.
 All components become responsible for updating when their <em>own</em> dependencies change.
 Its overhead is neglectable and it makes sure that whenever you start using observable data the component will respond to it.
 See this <a href="https://www.reddit.com/r/reactjs/comments/4vnxg5/free_eggheadio_course_learn_mobx_react_in_30/d61oh0l" target="_blank">thread</a> for more details.</p>


### PR DESCRIPTION
fix `be used be used` -> `be used`