### PR TITLE
Fix broken markdown for @inject documentation.

### DIFF
--- a/docs/refguide/api.md
+++ b/docs/refguide/api.md
@@ -132,7 +132,7 @@ Can be used to pass stores to child components using React's context mechanism. 
 Higher order component and counterpart of `Provider`. Can be used to pick stores from React's context and pass it as props to the target component. Usage:
 * `inject("store1", "store2")(observer(MyComponent))`
 * `@inject("store1", "store2") @observer MyComponent`
-* `@inject((stores, props, context) => props) @observer MyComponent
+* `@inject((stores, props, context) => props) @observer MyComponent`
 * `@observer(["store1", "store2"]) MyComponent` is a shorthand for the the `@inject() @observer` combo.
 
 ### `toJS`


### PR DESCRIPTION
Due to a missing char, the `@inject` doc at line 135 was not rendering properly in markdown. I let it be a few times and figured someone else might create a PR for it but I might as well do it. :)

Cheers!