### PR TITLE
add debug and scope info

### DIFF
--- a/docs/refguide/autorun-async.md
+++ b/docs/refguide/autorun-async.md
@@ -8,7 +8,12 @@ However, instead of running the action immediately when the values it observes h
 
 If observed values are changed multiple times while waiting, the action is still triggered only once, so in a sense it achieves a similar effect than a transaction.
 This might be useful for stuff that is expensive and doesn't need to happen synchronously; such as debouncing server communication.
-If a string is passed as first argument to `autorun`, it will be used as debug name.
+
+If a scope is given, the action will be bound to this scope object.
+
+`autorunAsync(debugName: string, action: () => void, minimumDelay?: number, scope?)`
+
+If a string is passed as first argument to `autorunAsync`, it will be used as debug name.
 
 `autorunAsync` returns a disposer to cancel the autorun.
 


### PR DESCRIPTION
Added a tiny bit of documentation for autorunAsync.

BTW, is there a guideline regarding documentation improvements besides the short contribution note in the Readme file?

E.g. `scope` works same on many methods and does not need repeated explanation everywhere, however it is not mentioned anywhere in the docs yet.

Should the different method signatures be added at the top of each page? Or should the alternatives be mentioned below (as in this PR) or not at all?
