### PR TITLE
make autorun available as decorator

### DIFF
--- a/src/api/autorun.ts
+++ b/src/api/autorun.ts
@@ -23,9 +23,13 @@ export function autorun(view: (r: IReactionPublic) => void, scope?: any);
  */
 export function autorun(name: string, view: (r: IReactionPublic) => void, scope?: any);
 
-export function autorun(arg1: any, arg2: any, arg3?: any) {
+export function autorun(customName: string): (target: Object, key: string, baseDescriptor?: PropertyDescriptor) => void;
+export function autorun(target: Object, propertyKey: string, descriptor?: PropertyDescriptor): void;
+
+
+export function autorun(arg1: any, arg2?: any, arg3?: any) {
 	let name: string, view: (r: IReactionPublic) => void, scope: any;
-	if (typeof arg1 === "string") {
+	if (typeof arg1 === "string" && typeof arg2 !== "undefined") {
 		name = arg1;
 		view = arg2;
 		scope = arg3;
@@ -33,6 +37,14 @@ export function autorun(arg1: any, arg2: any, arg3?: any) {
 		name = arg1.name || ("Autorun@" + getNextId());
 		view = arg1;
 		scope = arg2;
+	} else if (typeof arg1 === "object" && typeof arg2 === "string" && "value" in arg3) { // unnamed decorator
+		name = arg2;
+		view = arg3.value;
+		scope = arg1;
+	} else if (typeof arg1 === "string") { // named decorator
+		console.log("args", arguments)
+		name = arg1;
+		invariant(false, "sorry, named autorun decorators are not supported yet")
 	}
 
 	assertUnwrapped(view, "autorun methods cannot have modifiers");

--- a/test/typescript-tests.ts
+++ b/test/typescript-tests.ts
@@ -962,3 +962,43 @@ test('computed getter / setter for plan objects should succeed (typescript)', fu
 
 	t.end();
 });
+
+test('autorun as (unnamed) decorator', function(t) {
+	var autorunResult:number = 0;
+	var noAutoResult: number = 0;
+	class SomeClass {
+		@observable foo:number = 1;
+
+		@autorun auto() {
+			autorunResult = this.foo;
+		}
+
+		noauto() {
+			noAutoResult = this.foo;
+		}
+	}
+
+	const a = new SomeClass();
+	t.equal(autorunResult, 1);
+	a.foo = 2;
+	t.equal(autorunResult, 2);
+	t.equal(noAutoResult, 0);
+	t.end();
+});
+
+test.skip('autorun as named decorator', function(t) {
+	var autorunResult:number = 0;
+	class SomeClass {
+		@observable foo:number = 1;
+
+		@autorun("autoRunMethodCustomName") auto() {
+			autorunResult = this.foo;
+		}
+	}
+
+	const a = new SomeClass();
+	t.equal(autorunResult, 1);
+	a.foo = 2;
+	t.equal(autorunResult, 2);
+	t.end();
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "sourceMap": false,
         "declaration": true,
         "module": "commonjs",
+        "experimentalDecorators": true,
         "removeComments": false
     },
     "exclude": [


### PR DESCRIPTION
Inspired by the discussion on https://mobxjs.github.io/mobx/refguide/autorun.html / http://disq.us/p/1bthagx why autorun is not usable as decorator, I thought I'd give it a try.

This is by no means complete yet, only decorator without custom name is supported. No docs yet, either. If someone wants to complete that feature: go ahead.

I'm looking for feedback if this approach is going in the right direction or what should be changed/improved before proceeding.
