### PR TITLE
Fix 571 no instanceof

### DIFF
--- a/src/api/extendobservable.ts
+++ b/src/api/extendobservable.ts
@@ -1,5 +1,5 @@
 import {ValueMode} from "../types/modifiers";
-import {ObservableMap} from "../types/observablemap";
+import {isObservableMap} from "../types/observablemap";
 import {asObservableObject, setObservableObjectInstanceProperty} from "../types/observableobject";
 import {invariant, isPropertyConfigurable, hasOwnProperty} from "../utils/utils";
 
@@ -12,7 +12,7 @@ import {invariant, isPropertyConfigurable, hasOwnProperty} from "../utils/utils"
 export function extendObservable<A extends Object, B extends Object>(target: A, ...properties: B[]): A & B {
 	invariant(arguments.length >= 2, "extendObservable expected 2 or more arguments");
 	invariant(typeof target === "object", "extendObservable expects an object as first argument");
-	invariant(!(target instanceof ObservableMap), "extendObservable should not be used on maps, use map.merge instead");
+	invariant(!(isObservableMap(target)), "extendObservable should not be used on maps, use map.merge instead");
 	properties.forEach(propSet => {
 		invariant(typeof propSet === "object", "all arguments of extendObservable should be objects");
 		extendObservableHelper(target, propSet, ValueMode.Recursive, null);

--- a/src/api/iscomputed.ts
+++ b/src/api/iscomputed.ts
@@ -1,6 +1,6 @@
 import {isObservableObject} from "../types/observableobject";
 import {getAtom} from "../types/type-utils";
-import {ComputedValue} from "../core/computedvalue";
+import {isComputedValue} from "../core/computedvalue";
 
 export function isComputed(value, property?: string): boolean {
 	if (value === null || value === undefined)
@@ -9,7 +9,7 @@ export function isComputed(value, property?: string): boolean {
 		if (isObservableObject(value) === false)
 			return false;
 		const atom = getAtom(value, property);
-		return atom instanceof ComputedValue;
+		return isComputedValue(atom)
 	}
-	return value instanceof ComputedValue;
+	return isComputedValue(value);
 }

--- a/src/api/isobservable.ts
+++ b/src/api/isobservable.ts
@@ -1,9 +1,9 @@
-import {ObservableArray} from "../types/observablearray";
-import {ObservableMap} from "../types/observablemap";
+import {isObservableArray} from "../types/observablearray";
+import {isObservableMap} from "../types/observablemap";
 import {isObservableObject, ObservableObjectAdministration} from "../types/observableobject";
-import {BaseAtom} from "../core/atom";
-import {ComputedValue} from "../core/computedvalue";
-import {Reaction} from "../core/reaction";
+import {isAtom} from "../core/atom";
+import {isComputedValue} from "../core/computedvalue";
+import {isReaction} from "../core/reaction";
 
 /**
 	* Returns true if the provided value is reactive.
@@ -14,7 +14,7 @@ export function isObservable(value, property?: string): boolean {
 	if (value === null || value === undefined)
 		return false;
 	if (property !== undefined) {
-		if (value instanceof ObservableMap || value instanceof ObservableArray)
+		if (isObservableArray(value) || isObservableMap(value))
 			throw new Error("[mobx.isObservable] isObservable(object, propertyName) is not supported for arrays and maps. Use map.has or array.length instead.");
 		else if (isObservableObject(value)) {
 			const o = <ObservableObjectAdministration> value.$mobx;
@@ -22,5 +22,5 @@ export function isObservable(value, property?: string): boolean {
 		}
 		return false;
 	}
-	return !!value.$mobx || value instanceof BaseAtom || value instanceof Reaction || value instanceof ComputedValue;
+	return !!value.$mobx || isAtom(value) || isReaction(value) || isComputedValue(value);
 }

--- a/src/api/observable.ts
+++ b/src/api/observable.ts
@@ -5,7 +5,7 @@ import {isPlainObject, invariant, deprecated} from "../utils/utils";
 import {observableDecorator} from "./observabledecorator";
 import {isObservable} from "./isobservable";
 import {IObservableObject} from "../types/observableobject";
-import {IObservableArray, ObservableArray} from "../types/observablearray";
+import {IObservableArray, isObservableArray} from "../types/observablearray";
 
 /**
  * Turns an object, array or function into a reactive structure.
@@ -51,7 +51,7 @@ export function getTypeOfValue(value): ValueType {
 		return ValueType.Reference;
 	if (typeof value === "function")
 		return value.length ? ValueType.ComplexFunction : ValueType.ViewFunction;
-	if (Array.isArray(value) || value instanceof ObservableArray)
+	if (Array.isArray(value) || isObservableArray(value))
 		return ValueType.Array;
 	if (typeof value === "object")
 		return isPlainObject(value) ? ValueType.PlainObject : ValueType.ComplexObject;

--- a/src/api/tojs.ts
+++ b/src/api/tojs.ts
@@ -1,8 +1,7 @@
-import {ObservableArray} from "../types/observablearray";
-import {ObservableMap} from "../types/observablemap";
-import {ObservableValue} from "../types/observablevalue";
-import {isObservable} from "../api/isobservable";
-import {isPlainObject, deprecated} from "../utils/utils";
+import {isObservableArray} from "../types/observablearray";
+import {isObservableMap} from "../types/observablemap";
+import {isObservableValue} from "../types/observablevalue";
+import {deprecated} from "../utils/utils";
 
 /**
 	* Basically, a deep clone, so that no reactive property will exist anymore.
@@ -27,7 +26,7 @@ export function toJS(source, detectCycles: boolean = true, __alreadySeen: [any, 
 
 	if (!source)
 		return source;
-	if (Array.isArray(source) || source instanceof ObservableArray) {
+	if (Array.isArray(source) || isObservableArray(source)) {
 		const res = cache([]);
 		const toAdd = source.map(value => toJS(value, detectCycles, __alreadySeen));
 		res.length = toAdd.length;
@@ -35,16 +34,14 @@ export function toJS(source, detectCycles: boolean = true, __alreadySeen: [any, 
 			res[i] = toAdd[i];
 		return res;
 	}
-	if (source instanceof ObservableMap) {
+	if (isObservableMap(source)) {
 		const res = cache({});
 		source.forEach(
 			(value, key) => res[key] = toJS(value, detectCycles, __alreadySeen)
 		);
 		return res;
 	}
-	if (isObservable(source) && source.$mobx instanceof ObservableValue)
-		return toJS(source(), detectCycles, __alreadySeen);
-	if (source instanceof ObservableValue)
+	if (isObservableValue(source))
 		return toJS(source.get(), detectCycles, __alreadySeen);
 	if (typeof source === "object") {
 		const res = cache({});

--- a/src/api/whyrun.ts
+++ b/src/api/whyrun.ts
@@ -1,6 +1,6 @@
 import {globalState} from "../core/globalstate";
-import {ComputedValue} from "../core/computedvalue";
-import {Reaction} from "../core/reaction";
+import {isComputedValue} from "../core/computedvalue";
+import {isReaction} from "../core/reaction";
 import {getAtom} from "../types/type-utils";
 import {invariant} from "../utils/utils";
 
@@ -21,9 +21,9 @@ export function whyRun(thing?: any, prop?: string) {
 			break;
 	}
 	thing = getAtom(thing);
-	if (thing instanceof ComputedValue)
+	if (isComputedValue(thing))
 		return log(thing.whyRun());
-	else if (thing instanceof Reaction)
+	else if (isReaction(thing))
 		return log(thing.whyRun());
 	else
 		invariant(false, "whyRun can only be used on reactions and computed values");

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -2,7 +2,7 @@ import {transactionStart, transactionEnd} from "../core/transaction";
 import {invariant, deprecated} from "../utils/utils";
 import {untrackedStart, untrackedEnd} from "../core/derivation";
 import {isSpyEnabled, spyReportStart, spyReportEnd} from "../core/spy";
-import {ComputedValue} from "../core/computedvalue";
+import {isComputedValue} from "../core/computedvalue";
 import {globalState} from "../core/globalstate";
 
 export function createAction(actionName: string, fn: Function): Function {
@@ -17,7 +17,7 @@ export function createAction(actionName: string, fn: Function): Function {
 
 export function executeAction(actionName: string, fn: Function, scope: any, args: IArguments) {
 	// actions should not be called from computeds. check only works if the computed is actively observed, but that is fine enough as heuristic
-	invariant(!(globalState.trackingDerivation instanceof ComputedValue), "Computed values or transformers should not invoke actions or trigger other side effects");
+	invariant(!isComputedValue(globalState.trackingDerivation), "Computed values or transformers should not invoke actions or trigger other side effects");
 
 	const notifySpy = isSpyEnabled();
 	let startTime: number;

--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -81,8 +81,11 @@ export class Atom extends BaseAtom implements IAtom {
 	}
 }
 
+
 import {globalState} from "./globalstate";
 import {IObservable, propagateChanged, reportObserved, startBatch, endBatch} from "./observable";
 import {IDerivationState} from "./derivation";
 import {transactionStart, transactionEnd} from "../core/transaction";
-import {noop, getNextId} from "../utils/utils";
+import {createInstanceofPredicate, noop, getNextId, isObject} from "../utils/utils";
+
+export const isAtom = createInstanceofPredicate("Atom", BaseAtom);

--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -2,7 +2,7 @@ import {IObservable, reportObserved, propagateMaybeChanged, propagateChangeConfi
 import {IDerivation, IDerivationState, trackDerivedFunction, clearObserving, untrackedStart, untrackedEnd, shouldCompute, handleExceptionInDerivation} from "./derivation";
 import {globalState} from "./globalstate";
 import {allowStateChangesStart, allowStateChangesEnd, createAction} from "./action";
-import {getNextId, valueDidChange, invariant, Lambda, unique, joinStrings} from "../utils/utils";
+import {createInstanceofPredicate, getNextId, valueDidChange, invariant, Lambda, unique, joinStrings} from "../utils/utils";
 import {isSpyEnabled, spyReport} from "../core/spy";
 import {autorun} from "../api/autorun";
 
@@ -212,3 +212,4 @@ WhyRun? computation '${this.name}':
 	}
 }
 
+export const isComputedValue = createInstanceofPredicate("ComputedValue", ComputedValue);

--- a/src/core/derivation.ts
+++ b/src/core/derivation.ts
@@ -2,7 +2,7 @@ import {IObservable, IDepTreeNode, addObserver, removeObserver, endBatch} from "
 import {globalState, resetGlobalState} from "./globalstate";
 import {invariant} from "../utils/utils";
 import {isSpyEnabled, spyReport} from "./spy";
-import {ComputedValue} from "./computedvalue";
+import {isComputedValue} from "./computedvalue";
 
 export enum IDerivationState {
 	// before being run or (outside batch and not being observed)
@@ -68,7 +68,7 @@ export function shouldCompute(derivation: IDerivation): boolean {
 				const obs = derivation.observing, l = obs.length;
 				for (let i = 0; i < l; i++) {
 					const obj = obs[i];
-					if (obj instanceof ComputedValue) {
+					if (isComputedValue(obj)) {
 						obj.get();
 						// if ComputedValue `obj` actually changed it will be computed and propagated to its observers.
 						// and `derivation` is an observer of `obj`

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -1,6 +1,6 @@
 import {IDerivation, IDerivationState, trackDerivedFunction, clearObserving, shouldCompute} from "./derivation";
 import {globalState, resetGlobalState} from "./globalstate";
-import {getNextId, Lambda, unique, joinStrings} from "../utils/utils";
+import {createInstanceofPredicate, getNextId, Lambda, unique, joinStrings} from "../utils/utils";
 import {isSpyEnabled, spyReport, spyReportStart, spyReportEnd} from "./spy";
 import {startBatch, endBatch} from "./observable";
 
@@ -24,8 +24,8 @@ import {startBatch, endBatch} from "./observable";
  */
 
 export interface IReactionPublic {
-		dispose: () => void;
-	}
+	dispose: () => void;
+}
 
 export class Reaction implements IDerivation, IReactionPublic {
 	observing = []; // nodes we are looking at. Our value depends on these nodes
@@ -182,3 +182,5 @@ export function runReactions() {
 	}
 	globalState.isRunningReactions = false;
 }
+
+export const isReaction = createInstanceofPredicate("Reaction", Reaction);

--- a/src/core/spy.ts
+++ b/src/core/spy.ts
@@ -1,14 +1,12 @@
 import {globalState} from "./globalstate";
 import {objectAssign, deprecated, once, Lambda} from "../utils/utils";
 
-let spyEnabled = false;
-
 export function isSpyEnabled() {
-	return spyEnabled;
+	return !!globalState.spyListeners.length;
 }
 
 export function spyReport(event) {
-	if (!spyEnabled)
+	if (!globalState.spyListeners.length)
 		return false;
 	const listeners = globalState.spyListeners;
 	for (let i = 0, l = listeners.length; i < l; i++)
@@ -32,12 +30,10 @@ export function spyReportEnd(change?) {
 
 export function spy(listener: (change: any) => void): Lambda {
 	globalState.spyListeners.push(listener);
-	spyEnabled = globalState.spyListeners.length > 0;
 	return once(() => {
 		const idx = globalState.spyListeners.indexOf(listener);
 		if (idx !== -1)
 			globalState.spyListeners.splice(idx, 1);
-		spyEnabled = globalState.spyListeners.length > 0;
 	});
 }
 

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -1,4 +1,4 @@
-import {getNextId, deepEquals, makeNonEnumerable, Lambda, deprecated, EMPTY_ARRAY, addHiddenFinalProp, addHiddenProp, invariant} from "../utils/utils";
+import {isObject, createInstanceofPredicate, getNextId, deepEquals, makeNonEnumerable, Lambda, deprecated, EMPTY_ARRAY, addHiddenFinalProp, addHiddenProp, invariant} from "../utils/utils";
 import {BaseAtom} from "../core/atom";
 import {ValueMode, assertUnwrapped, makeChildObservable} from "./modifiers";
 import {checkIfStateModificationsAreAllowed} from "../core/derivation";
@@ -515,6 +515,8 @@ export function fastArray<V>(initialValues?: V[]): IObservableArray<V> {
 	return createObservableArray(initialValues, ValueMode.Flat, null);
 }
 
+const isObservableArrayAdministration = createInstanceofPredicate("ObservableArrayAdministration", ObservableArrayAdministration);
+
 export function isObservableArray(thing): thing is IObservableArray<any> {
-	return thing instanceof ObservableArray;
+	return isObject(thing) && isObservableArrayAdministration(thing.$mobx);
 }

--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -302,4 +302,5 @@ export function map<V>(initialValues?: IMapEntries<V> | IKeyValueMap<V>, valueMo
 	return new ObservableMap(initialValues, valueModifier);
 }
 
-export const isObservableMap = createInstanceofPredicate("ObservableMap", ObservableMap);
+/* 'var' fixes small-build issue */
+export var isObservableMap = createInstanceofPredicate("ObservableMap", ObservableMap);

--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -3,7 +3,7 @@ import {transaction} from "../core/transaction";
 import {untracked} from "../core/derivation";
 import {ObservableArray, IObservableArray} from "./observablearray";
 import {ObservableValue, UNCHANGED} from "./observablevalue";
-import {deprecated, isPlainObject, getNextId, Lambda, invariant} from "../utils/utils";
+import {createInstanceofPredicate, deprecated, isPlainObject, getNextId, Lambda, invariant} from "../utils/utils";
 import {allowStateChanges} from "../core/action";
 import {IInterceptable, IInterceptor, hasInterceptors, registerInterceptor, interceptChange} from "./intercept-utils";
 import {IListenable, registerListener, hasListeners, notifyListeners} from "./listen-utils";
@@ -218,7 +218,7 @@ export class ObservableMap<V> implements IInterceptable<IMapWillChange<V>>, ILis
 	/** Merge another object into this object, returns this. */
 	merge(other: ObservableMap<V> | IKeyValueMap<V>): ObservableMap<V> {
 		transaction(() => {
-			if (other instanceof ObservableMap)
+			if (isObservableMap(other))
 				other.keys().forEach(key => this.set(key, (other as ObservableMap<V>).get(key)));
 			else
 				Object.keys(other).forEach(key => this.set(key, other[key]));
@@ -302,6 +302,4 @@ export function map<V>(initialValues?: IMapEntries<V> | IKeyValueMap<V>, valueMo
 	return new ObservableMap(initialValues, valueModifier);
 }
 
-export function isObservableMap(thing): thing is ObservableMap<any> {
-	return thing instanceof ObservableMap;
-}
+export const isObservableMap = createInstanceofPredicate("ObservableMap", ObservableMap);

--- a/src/types/observableobject.ts
+++ b/src/types/observableobject.ts
@@ -1,7 +1,7 @@
-import {isObservableValue, ObservableValue, UNCHANGED} from "./observablevalue";
+import {ObservableValue, UNCHANGED} from "./observablevalue";
 import {isComputedValue, ComputedValue} from "../core/computedvalue";
 import {isAction} from "../api/action";
-import {ValueMode, AsStructure} from "./modifiers";
+import {ValueMode, getModifier} from "./modifiers";
 import {createInstanceofPredicate, isObject, Lambda, getNextId, invariant, assertPropertyConfigurable, isPlainObject, addHiddenFinalProp} from "../utils/utils";
 import {runLazyInitializers} from "../utils/decorators";
 import {hasInterceptors, IInterceptable, registerInterceptor, interceptChange} from "./intercept-utils";
@@ -101,7 +101,7 @@ export function defineObservableProperty(adm: ObservableObjectAdministration, pr
 		// TODO: add warning in 2.6, see https://github.com/mobxjs/mobx/issues/421
 		// TODO: remove in 3.0
 		observable = new ComputedValue(newValue, adm.target, false, name, setter);
-	} else if (newValue instanceof AsStructure && typeof newValue.value === "function" && newValue.value.length === 0) {
+	} else if (getModifier(newValue) === ValueMode.Structure && typeof newValue.value === "function" && newValue.value.length === 0) {
 		observable = new ComputedValue(newValue.value, adm.target, true, name, setter);
 	} else {
 		isComputed = false;

--- a/src/types/observableobject.ts
+++ b/src/types/observableobject.ts
@@ -1,8 +1,8 @@
-import {ObservableValue, UNCHANGED} from "./observablevalue";
-import {ComputedValue} from "../core/computedvalue";
+import {isObservableValue, ObservableValue, UNCHANGED} from "./observablevalue";
+import {isComputedValue, ComputedValue} from "../core/computedvalue";
 import {isAction} from "../api/action";
 import {ValueMode, AsStructure} from "./modifiers";
-import {Lambda, getNextId, invariant, assertPropertyConfigurable, isPlainObject, addHiddenFinalProp} from "../utils/utils";
+import {createInstanceofPredicate, isObject, Lambda, getNextId, invariant, assertPropertyConfigurable, isPlainObject, addHiddenFinalProp} from "../utils/utils";
 import {runLazyInitializers} from "../utils/decorators";
 import {hasInterceptors, IInterceptable, registerInterceptor, interceptChange} from "./intercept-utils";
 import {IListenable, registerListener, hasListeners, notifyListeners} from "./listen-utils";
@@ -89,7 +89,7 @@ export function defineObservableProperty(adm: ObservableObjectAdministration, pr
 	let name = `${adm.name}.${propName}`;
 	let isComputed = true;
 
-	if (newValue instanceof ComputedValue) {
+	if (isComputedValue(newValue)) {
 		// desugger computed(getter, setter)
 		// TODO: deprecate this and remove in 3.0, to keep them boxed
 		// get / set is now the idiomatic syntax for non-boxed computed values
@@ -217,11 +217,14 @@ function notifyPropertyAddition(adm, object, name: string, newValue) {
 		spyReportEnd();
 }
 
+
+const isObservableObjectAdministration = createInstanceofPredicate("ObservableObjectAdministration", ObservableObjectAdministration);
+
 export function isObservableObject<T>(thing: T): thing is T & IObservableObject {
-	if (typeof thing === "object" && thing !== null) {
+	if (isObject(thing)) {
 		// Initializers run lazily when transpiling to babel, so make sure they are run...
 		runLazyInitializers(thing);
-		return (thing as T & {$mobx: any}).$mobx instanceof ObservableObjectAdministration;
+		return isObservableObjectAdministration((thing as any).$mobx);
 	}
 	return false;
 }

--- a/src/types/observablevalue.ts
+++ b/src/types/observablevalue.ts
@@ -1,7 +1,7 @@
 import {BaseAtom} from "../core/atom";
 import {checkIfStateModificationsAreAllowed} from "../core/derivation";
 import {ValueMode, getValueModeFromValue, makeChildObservable, assertUnwrapped} from "./modifiers";
-import {valueDidChange, Lambda, getNextId} from "../utils/utils";
+import {valueDidChange, Lambda, getNextId, createInstanceofPredicate} from "../utils/utils";
 import {hasInterceptors, IInterceptable, IInterceptor, registerInterceptor, interceptChange} from "./intercept-utils";
 import {IListenable, registerListener, hasListeners, notifyListeners} from "./listen-utils";
 import {isSpyEnabled, spyReportStart, spyReportEnd, spyReport} from "../core/spy";
@@ -114,3 +114,5 @@ export class ObservableValue<T> extends BaseAtom implements IObservableValue<T>,
 		return `${this.name}[${this.value}]`;
 	}
 }
+
+export const isObservableValue = createInstanceofPredicate("ObservableValue", ObservableValue);

--- a/src/types/type-utils.ts
+++ b/src/types/type-utils.ts
@@ -1,9 +1,9 @@
 import {IDepTreeNode} from "../core/observable";
 import {invariant} from "../utils/utils";
 import {runLazyInitializers} from "../utils/decorators";
-import {BaseAtom} from "../core/atom";
-import {ComputedValue} from "../core/computedvalue";
-import {Reaction} from "../core/reaction";
+import {isAtom} from "../core/atom";
+import {isComputedValue} from "../core/computedvalue";
+import {isReaction} from "../core/reaction";
 import {isObservableArray} from "../types/observablearray";
 import {isObservableMap} from "../types/observablemap";
 import {isObservableObject} from "../types/observableobject";
@@ -29,11 +29,11 @@ export function getAtom(thing: any, property?: string): IDepTreeNode {
 			invariant(!!observable, `no observable property '${property}' found on the observable object '${getDebugName(thing)}'`);
 			return observable;
 		}
-		if (thing instanceof BaseAtom || thing instanceof ComputedValue || thing instanceof Reaction) {
+		if (isAtom(thing) || isComputedValue(thing) || isReaction(thing)) {
 			return thing;
 		}
 	} else if (typeof thing === "function") {
-		if (thing.$mobx instanceof Reaction) {
+		if (isReaction(thing.$mobx)) {
 			// disposer function
 			return thing.$mobx;
 		}
@@ -45,7 +45,7 @@ export function getAdministration(thing: any, property?: string) {
 	invariant(thing, "Expection some object");
 	if (property !== undefined)
 		return getAdministration(getAtom(thing, property));
-	if (thing instanceof BaseAtom || thing instanceof ComputedValue || thing instanceof Reaction)
+	if (isAtom(thing) || isComputedValue(thing) || isReaction(thing))
 		return thing;
 	if (isObservableMap(thing))
 		return thing;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -167,6 +167,7 @@ export function deepEquals(a, b) {
 }
 
 export function createInstanceofPredicate<T>(name: string, clazz: new (...args:any[]) => T): (x: any) => x is T {
+	// TODO: this is quite a slow aproach, find something faster?
 	const propName = "isMobX" + name;
 	clazz.prototype[propName] = true;
 	return function (x) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -54,6 +54,10 @@ export function joinStrings(things: string[], limit: number = 100, separator = "
 	return `${sliced.join(separator)}${things.length > limit ? " (... and " + (things.length - limit) + "more)" : ""}`;
 }
 
+export function isObject(value: any): boolean {
+	return value !== null && typeof value === "object";
+}
+
 export function isPlainObject(value) {
 	if (value === null || typeof value !== "object")
 		return false;
@@ -160,6 +164,14 @@ export function deepEquals(a, b) {
 		return true;
 	}
 	return a === b;
+}
+
+export function createInstanceofPredicate<T>(name: string, clazz: new (...args:any[]) => T): (x: any) => x is T {
+	const propName = "isMobX" + name;
+	clazz.prototype[propName] = true;
+	return function (x) {
+		return isObject(x) && x[propName] === true;
+	} as any;
 }
 
 import {globalState} from "../core/globalstate";


### PR DESCRIPTION
eliminate `instanceof` checks by introducing on the prototype to identify the type. Note that different property names are used so that inheritance based checks work (actually only applicable for `ObservableValue` I think, so could be skipped)

@amir-arad / @andykog up for a review?