### PR TITLE
Keep custom props declared on arrays

### DIFF
--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -245,6 +245,10 @@ export class ObservableArray<T> extends StubArray {
 			// defined on the instance. After that it works fine, even if this property is deleted.
 			Object.defineProperty(adm.array, "0", ENTRY_0);
 		}
+        Object.getOwnPropertyNames(initialValues).forEach(prop => {
+            if (prop == 'length' || !isNaN(prop)) return;
+            this[prop] = initialValues[prop];
+        })
 	}
 
 	intercept<T>(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda {


### PR DESCRIPTION
In my projects I also have objects that extend Array. Currently mobx ignores all custom props for arrays when it converts them to observable.

That is a very simple change at least to copy over concrete methods and props.