### PR TITLE
Added asStructure definition accepting function to use with reaction.

### DIFF
--- a/src/types/modifiers.ts
+++ b/src/types/modifiers.ts
@@ -57,7 +57,9 @@ export function asReference<T>(value: T): T {
 	* Future assignments to the same property will inherit this behavior.
 	* @param value initial value of the reactive property that is being defined.
 	*/
-export function asStructure<T>(value: T): T {
+export function asStructure<T>(value: () => T): () => T;
+export function asStructure<T>(value: T): T;
+export function asStructure<T>(value) {
 	return withModifier(ValueMode.Structure, value) as any as T;
 }
 (asStructure as any).mobxModifier = ValueMode.Structure;


### PR DESCRIPTION
Currently in cases like this

```
reaction(asStructure(() => ({a: 1, b: '1'})), d => ...)
```

type of `d` is `any` while it can be inferred. Another type definition for `asStructure` is added to cover this particular case (which is quite often, at least for me).

Didn't add test because don't know how to test it. Declaration covers very small set of use cases. When it doesn't work, `d` type is `any` which can't be tested against. Playing in VSCode shown positive results.

Certainly it can cause a lot of compilation errors in existing code because of type mismatch (which is good i guess).