### PR TITLE
Add note about babel-plugin-mobx-deep-action

### DIFF
--- a/docs/refguide/action.md
+++ b/docs/refguide/action.md
@@ -17,7 +17,7 @@ It is advised to use them on any function that modifies observables or has side 
 Using the `@action` decorator with [ES 5.1 setters](http://www.ecma-international.org/ecma-262/5.1/#sec-11.1.5) (i.e. `@action set propertyName`) is not supported, however setters of [computed properties are automatically actions](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/computed-decorator.md#setters-for-computed-values).
 
 
-Note: using `action` is mandatory when *strict mode* is enabled, see [`useStrict`](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md#usestrict). 
+Note: using `action` is mandatory when *strict mode* is enabled, see [`useStrict`](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md#usestrict).
 
 For an extensive introduction to `action` see also the [MobX 2.2 release notes](https://medium.com/p/45cdc73c7c8d/).
 
@@ -66,3 +66,5 @@ Example:
 ```
 
 The usage of `runInAction` is: `runInAction(name?, fn, scope?)`.
+
+If you use babel, this plugin could help you to handle your async actions: [mobx-deep-action](https://github.com/mobxjs/babel-plugin-mobx-deep-action).


### PR DESCRIPTION
This PR adds a note about our new [babel-plugin-mobx-deep-action](https://github.com/mobxjs/babel-plugin-mobx-deep-action).
