### PR TITLE
add ObservableArray.move method

### DIFF
--- a/test/array.js
+++ b/test/array.js
@@ -354,5 +354,57 @@ test('isArrayLike', t => {
 	t.equal(isArrayLike({}), false);
 
 	t.end();
-})
+});
+
+test('.move throws on invalid indices', t => {
+	const arr = [0, 1, 2];
+	const observableArr = observable(arr);
+
+	t.throws(() => observableArr.move(-1, 0), /Index out of bounds: -1 is negative/);
+	t.throws(() => observableArr.move(3, 0), /Index out of bounds: 3 is not smaller than 3/);
+	t.throws(() => observableArr.move(0, -1), /Index out of bounds: -1 is negative/);
+	t.throws(() => observableArr.move(0, 3), /Index out of bounds: 3 is not smaller than 3/);
+
+	t.end();
+});
+
+test('.move(i, i) does nothing', t => {
+	const arr = [0, 1, 2];
+	const observableArr = observable(arr);
+	var changesCount = 0;
+	observableArr.observe(changes => ++changesCount);
+
+	observableArr.move(0, 0);
+
+	t.equal(0, changesCount);
+
+	t.end();
+});
+
+test.only('.move works correctly', t => {
+	const arr = [0, 1, 2, 3];
+
+	function checkMove(fromIndex, toIndex, expected) {
+		const oa = observable(arr);
+		var changesCount = 0;
+		oa.observe(changes => ++changesCount);
+		oa.move(fromIndex, toIndex);
+		t.deepEqual(oa.slice(), expected, ".move(" + fromIndex + ", " + toIndex + ")");
+		t.equal(changesCount, 1);
+	}
+
+	checkMove(0, 1, [1, 0, 2, 3]);
+	checkMove(0, 2, [1, 2, 0, 3]);
+	checkMove(1, 2, [0, 2, 1, 3]);
+	checkMove(2, 3, [0, 1, 3, 2]);
+	checkMove(0, 3, [1, 2, 3, 0]);
+
+	checkMove(1, 0, [1, 0, 2, 3]);
+	checkMove(2, 0, [2, 0, 1, 3]);
+	checkMove(2, 1, [0, 2, 1, 3]);
+	checkMove(3, 1, [0, 3, 1, 2]);
+	checkMove(3, 0, [3, 0, 1, 2]);
+
+	t.end();
+});
 


### PR DESCRIPTION
Adds a .move method for moving individual elements around in an observable array. This is convenient to do that in an atomic way since otherwise a move can only be expressed by at least two splices. The resulting change is still one splice, but one that replace all array members: it's up to client to recognize this fact.

For documentation, add the following to https://mobxjs.github.io/mobx/refguide/array.html :

`move(fromIndex, toIndex)` Moves the element at index `fromIndex` to index `toIndex` in the array, with other array members shifting at most 1 position, and either all right or all left depending on the value of `toIndex - fromIndex`.
Examples: `observable([0, 1, 2, 3]).move(1, 2).slice()` yields `[0, 2, 1, 3]`, and `observable([0, 1, 2, 3]).move(3, 1).slice()` yields `[0, 3, 1, 2]`. (See unit tests for more examples.)
The method throws if indices are out of bounds, and does nothing when `fromIndex` equals `toIndex`.



Thanks for taking the effort to create a PR!

If you are creating an extensive issue, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted ;-).

PR checklist:

* [x] Implementation
* [x] Added tests
* [x] Verified that there is no significant performance drop (`npm run perf`)
* [ ] Updated (either in the description of this PR as markdown, or as seperate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [x] Added type annotations (if you are unfamiliar with typescript, untyped, `:any` based PR's are welcome as well
