### PR TITLE
suggestion for verbose error reporting as per #721

### DIFF
--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -75,14 +75,12 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
 	};
 
 	peekUntracked() {
-		let hasError = true;
 		try {
 			const res = this.peek();
-			hasError = false;
 			return res;
-		} finally {
-			if (hasError)
-				handleExceptionInDerivation(this);
+		} catch(e) {
+			handleExceptionInDerivation(this, e);
+			throw e;
 		}
 
 	}


### PR DESCRIPTION
I didn't find the right place to add tests for the new field in spy error message, would love a point to the right direction :)

time report in `npm run perf` seems the same with +-10% range of error , also this change should only slightly affect behavior of systems already in error mode (as the catch blocks were added to already non optimizable functions)