### PR TITLE
Add react mobx examples

### DIFF
--- a/docs/faq/examples.md
+++ b/docs/faq/examples.md
@@ -33,3 +33,4 @@
 * [Github Note Taker in MobX](https://github.com/eswat2/egghead-mobx)
 * SoundCloud client, in MobX and React: [React-MobX-SoundCloud](https://github.com/rwieruch/react-mobx-soundcloud)
 * Lightweight support service via ReactJS, Mobx, Grape (ruby) and Mongodb: [support-service](https://github.com/ifokeev/support-service)
+* [A simple Tetris using React + MobX](https://github.com/1984weed/mobx-react-tetris) 


### PR DESCRIPTION
Hi I created React + mobx example project.

So I want to add my project to examples list.

Thank you.

* [ ] Implementation
* [ ] Added tests
* [ ] Verified that there is no significant performance drop (`npm run perf`)
* [x] Updated (either in the description of this PR as markdown, or as seperate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added type annotations (if you are unfamiliar with typescript, untyped, `:any` based PR's are welcome as well
