### PR TITLE
731 improve errorhandling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,16 @@ Using `computed` to create boxed observables has been simplified, and `computed`
 * `computed(expr, setter)`
 * `computed(expr, options)`, where options is an object that can specify one or more of the following fields: `name`, `setter`, `compareStructural` or `context` (the "this").
 
+### `reaction` api has been simplified
+
+The signature of `reaction` is now `reaction(dataFunc, effectFunc, options?)`, where the following options are accepted:
+
+* `context`: The `this` to be used in the functions
+* `fireImmediately`
+* `delay`: Number in milliseconds that can be used to debounce the effect function.
+* `compareStructural`: `false` by default. If `true`, the return value of the *data* function is structurally compared to it's previous return value, and the *effect* function will only be invoked if there is a structural change in the output.
+* `name`: String
+
 ### Bound actions
 
 It is now possible to create actions and bind them in one go using `action.bound`. See [#699](https://github.com/mobxjs/mobx/issues/699).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,16 @@ Since this behavior is probably not used outside Mendix, it has been deprecated 
 
 See [#621](https://github.com/mobxjs/mobx/issues/621)
 
+### Removed error handling, improved error recovery
+
+MobX always printed a warning when an exception was thrown from a computed value, reaction or react component: `[mobx] An uncaught exception occurred while calculating....`.
+This warning was often confusing for people because they either had the impression that this was a mobx exception, while it actually is just informing about an exception that happened in userland code.
+And sometimes, the actual exception was silently caught somewhere else.
+MobX now does not print any warnings anymore, and just makes sure it's internal state is still stable.
+Not throwing or handling an exception is now entirely the responsibility of the user.
+
+Throwing an exception doesn't revert the causing mutation, but it does reset tracking information, which makes it possible to recover from exceptions by changing the state in such a way that a next run of the derivation doesn't throw.
+
 ### Flow-Types Support 🎉🎉🎉
 
 Flow typings have been added by [A-gambit](https://github.com/A-gambit).

--- a/src/api/autorun.ts
+++ b/src/api/autorun.ts
@@ -1,6 +1,6 @@
 import {Lambda, getNextId, invariant, valueDidChange, fail} from "../utils/utils";
 import {isModifierDescriptor} from "../types/modifiers";
-import {Reaction, IReactionPublic} from "../core/reaction";
+import {Reaction, IReactionPublic, IReactionDisposer} from "../core/reaction";
 import {untrackedStart, untrackedEnd} from "../core/derivation";
 import {action, isAction} from "../api/action";
 
@@ -11,7 +11,7 @@ import {action, isAction} from "../api/action";
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(view: (r: IReactionPublic) => void, scope?: any): Lambda;
+export function autorun(view: (r: IReactionPublic) => void, scope?: any): IReactionDisposer;
 
 /**
  * Creates a named reactive view and keeps it alive, so that the view is always
@@ -21,7 +21,7 @@ export function autorun(view: (r: IReactionPublic) => void, scope?: any): Lambda
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(name: string, view: (r: IReactionPublic) => void, scope?: any): Lambda;
+export function autorun(name: string, view: (r: IReactionPublic) => void, scope?: any): IReactionDisposer;
 export function autorun(arg1: any, arg2: any, arg3?: any) {
 	let name: string,
 		view: (r: IReactionPublic) => void,
@@ -67,7 +67,7 @@ export function autorun(arg1: any, arg2: any, arg3?: any) {
  * @param scope (optional)
  * @returns disposer function to prematurely end the observer.
  */
-export function when(name: string, predicate: () => boolean, effect: Lambda, scope?: any): Lambda;
+export function when(name: string, predicate: () => boolean, effect: Lambda, scope?: any): IReactionDisposer;
 
 /**
  * Similar to 'observer', observes the given predicate until it returns true.
@@ -104,8 +104,8 @@ export function when(arg1: any, arg2: any, arg3?: any, arg4?: any) {
 	return disposer;
 }
 
-export function autorunAsync(name: string, func: (r: IReactionPublic) => void, delay?: number, scope?: any): Lambda;
-export function autorunAsync(func: (r: IReactionPublic) => void, delay?: number, scope?: any): Lambda;
+export function autorunAsync(name: string, func: (r: IReactionPublic) => void, delay?: number, scope?: any): IReactionDisposer;
+export function autorunAsync(func: (r: IReactionPublic) => void, delay?: number, scope?: any): IReactionDisposer;
 export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
 	let name: string, func: (r: IReactionPublic) => void, delay: number, scope: any;
 	if (typeof arg1 === "string") {
@@ -163,8 +163,8 @@ export interface IReactionOptions {
  * or
  * autorun(() => action(effect)(expr));
  */
-export function reaction<T>(expression: (r: IReactionPublic) => T, effect: (arg: T, r: IReactionPublic) => void, opts?: IReactionOptions): Lambda;
-export function reaction<T>(expression: (r: IReactionPublic) => T, effect: (arg: T, r: IReactionPublic) => void, fireImmediately?: boolean): Lambda;
+export function reaction<T>(expression: (r: IReactionPublic) => T, effect: (arg: T, r: IReactionPublic) => void, opts?: IReactionOptions): IReactionDisposer;
+export function reaction<T>(expression: (r: IReactionPublic) => T, effect: (arg: T, r: IReactionPublic) => void, fireImmediately?: boolean): IReactionDisposer;
 export function reaction<T>(expression: (r: IReactionPublic) => T, effect: (arg: T, r: IReactionPublic) => void, arg3: any) {
 	if (arguments.length > 3) {
 		fail("reaction only accepts 2 or 3 arguments. If migrating from MobX 2, please provide an options object");

--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -24,7 +24,7 @@ export function createTransformer<A, B>(transformer: ITransformer<A, B>, onClean
 			super.onBecomeUnobserved();
 			delete objectCache[this.sourceIdentifier];
 			if (onCleanup)
-				onCleanup(lastValue, this.sourceObject);
+				onCleanup(lastValue as any, this.sourceObject);
 		}
 	}
 

--- a/src/core/derivation.ts
+++ b/src/core/derivation.ts
@@ -114,7 +114,7 @@ export function checkIfStateModificationsAreAllowed() {
  * The tracking information is stored on the `derivation` object and the derivation is registered
  * as observer of any of the accessed observables.
  */
-export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T) {
+export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T, context) {
 	// pre allocate array allocation + room for variation in deps
 	// array will be trimmed by bindDependencies
 	changeDependenciesStateTo0(derivation);
@@ -125,7 +125,7 @@ export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T) {
 	globalState.trackingDerivation = derivation;
 	let result;
 	try {
-		result = f.call(derivation);
+		result = f.call(context);
 	} catch (e) {
 		result = new CaughtException(e);
 	}

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -74,6 +74,11 @@ export class MobXGlobals {
 	 * Spy callbacks
 	 */
 	spyListeners: {(change: any): void}[] = [];
+
+	/**
+	 * Globally attached error handlers that react specifically to errors in reactions
+	 */
+	globalReactionErrorHandlers: ((error: any, derivation: IDerivation) => void)[] = [];
 }
 
 export let globalState: MobXGlobals = new MobXGlobals();

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -50,10 +50,9 @@ export class MobXGlobals {
 	pendingReactions: Reaction[] = [];
 
 	/**
-	 * This exceptions where caught when runinng a reaction, and will be thrown at the next safe
-	 * opportunity, that is, at the end of the reaction scheduler
+	 * Are we currently processing reactions?
 	 */
-	pendingExceptions: { derivation: IDerivation, cause: any }[] = [];
+	isRunningReactions = false;
 
 	/**
 	 * Is it allowed to change observables at this point?

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -1,5 +1,5 @@
 import {getGlobal} from "../utils/utils";
-import {IDerivation} from "./derivation";
+import {IDerivation, CaughtException} from "./derivation";
 import {Reaction} from "./reaction";
 import {IObservable} from "./observable";
 
@@ -59,6 +59,12 @@ export class MobXGlobals {
 	 * List of scheduled, not yet executed, reactions.
 	 */
 	pendingReactions: Reaction[] = [];
+
+	/**
+	 * This exceptions where caught when runinng a reaction, and will be thrown at the next safe
+	 * opportunity, that is, at the end of the reaction scheduler
+	 */
+	pendingExceptions: { derivation: IDerivation, cause: any }[] = [];
 
 	/**
 	 * Is it allowed to change observables at this point?

--- a/src/core/observable.ts
+++ b/src/core/observable.ts
@@ -1,7 +1,7 @@
 import {IDerivation, IDerivationState} from "./derivation";
 import {globalState} from "./globalstate";
 import {invariant} from "../utils/utils";
-import {throwPendingExceptions, runReactions} from "./reaction";
+import {runReactions} from "./reaction";
 
 export interface IDepTreeNode {
 	name: string;
@@ -127,7 +127,6 @@ export function endBatch() {
 			}
 		}
 		globalState.pendingUnobservations = [];
-		throwPendingExceptions();
 	}
 }
 

--- a/src/core/observable.ts
+++ b/src/core/observable.ts
@@ -1,6 +1,7 @@
 import {IDerivation, IDerivationState} from "./derivation";
 import {globalState} from "./globalstate";
 import {invariant} from "../utils/utils";
+import {throwPendingExceptions} from "./reaction";
 
 export interface IDepTreeNode {
 	name: string;
@@ -125,6 +126,7 @@ export function endBatch() {
 			}
 		}
 		globalState.pendingUnobservations = [];
+		throwPendingExceptions();
 	}
 	globalState.inBatch--;
 }

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -94,7 +94,7 @@ export class Reaction implements IDerivation, IReactionPublic {
 			});
 		}
 		this._isRunning = true;
-		const result = trackDerivedFunction(this, fn);
+		const result = trackDerivedFunction(this, fn, undefined);
 		this._isRunning = false;
 		this._isTrackPending = false;
 		if (this.isDisposed) {

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -114,10 +114,10 @@ export class Reaction implements IDerivation, IReactionPublic {
 
 	reportExceptionInDerivation(derivation: IDerivation, cause: Error) {
 		const message = `[mobx] Detected an uncaught exception that was thrown by computed value, reaction or observer '${derivation}`;
-		console.error(cause);
-		if (cause.stack)
-			console.error(cause.stack);
-		console.error(message);
+		// console.error(cause);
+		// if (cause.stack)
+		// 	console.error(cause.stack);
+		// console.error(message);
 		if (isSpyEnabled()) {
 			spyReport({
 				type: "error",
@@ -125,6 +125,11 @@ export class Reaction implements IDerivation, IReactionPublic {
 				cause
 			});
 		}
+		// TODO: instead of immediate, rethrow add end of run reactions
+		setImmediate(() => {
+			console.warn("Rethrowing earlier caught exception:");
+			throw cause;
+		});
 	}
 
 	dispose() {

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -158,6 +158,8 @@ export class Reaction implements IDerivation, IReactionPublic {
 				object: this
 			});
 		}
+
+		globalState.globalReactionErrorHandlers.forEach(f => f(error, this));
 	}
 
 	dispose() {
@@ -203,6 +205,15 @@ function registerErrorHandler(handler) {
 	invariant(this && this.$mobx && isReaction(this.$mobx), "Invalid `this`");
 	invariant(!this.$mobx.errorHandler, "Only one onErrorHandler can be registered");
 	this.$mobx.errorHandler = handler;
+}
+
+export function onReactionError(handler: (error: any, derivation: IDerivation) => void): () => void {
+	globalState.globalReactionErrorHandlers.push(handler);
+	return () => {
+		const idx = globalState.globalReactionErrorHandlers.indexOf(handler);
+		if (idx >= 0)
+			globalState.globalReactionErrorHandlers.splice(idx, 1);
+	};
 }
 
 /**

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -111,16 +111,42 @@ export class Reaction implements IDerivation, IReactionPublic {
 		endBatch();
 	}
 
-	reportExceptionInDerivation(derivation: IDerivation, cause: Error) {
+	reportExceptionInDerivation(derivation: IDerivation, error: any) {
 		const message = `[mobx] Catched uncaught exception that was thrown by a reaction or observer component, in: '${derivation}`;
-		console.error(message, cause);
+		const messageToUser = `
+		Hi there! I'm sorry you have just run into an exception.
+
+		If your debugger ends up here, know that some reaction (like the render() of an observer component, autorun or reaction)
+		threw an exception and that mobx catched it, too avoid that it brings the rest of your application down.
+
+		The original cause of the exception (the code that caused this reaction to run (again)), is still in the stack.
+
+		However, more interesting is the actual stack trace of the error itself.
+		Hopefully the error is an instanceof Error, because in that case you can inspect the original stack of the error from where it was thrown.
+		See \`error.stack\` property, or press the very subtle "(...)" link you see near the console.error message that probably brought you here.
+		That stack is more interesting than the stack of this console.error itself.
+
+		If the exception you see is an exception you created yourself, make sure to use \`throw new Error("Oops")\` instead of \`throw "Oops"\`,
+		because the javascript environment will only preserve the original stack trace in the first form.
+
+		You can also make sure the debugger pauses the next time this very same exception is thrown by enabling "Pause on caught exception".
+		(Note that it might pause on many other, unrelated exception as well).
+
+		If that all doesn't help you out, feel free to open an issue https://github.com/mobxjs/mobx/issues!
+		`;
+
+		console.error(message || messageToUser /* latter will not be true, make sure uglify doesn't remove */, error);
+			/** If debugging brough you here, please, read the above message :-). Tnx! */
+
 		if (isSpyEnabled()) {
 			spyReport({
 				type: "error",
 				message,
-				cause
+				error,
+				object: derivation
 			});
 		}
+		// TODO: introduce per reaction handler
 		// TODO: introduce global handler
 	}
 

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -102,7 +102,7 @@ export class Reaction implements IDerivation, IReactionPublic {
 			clearObserving(this);
 		}
 		if (isCaughtException(result))
-			this.reportExceptionInDerivation(this, result.cause);
+			this.reportExceptionInDerivation(result.cause);
 		if (notify) {
 			spyReportEnd({
 				time: Date.now() - startTime
@@ -111,8 +111,8 @@ export class Reaction implements IDerivation, IReactionPublic {
 		endBatch();
 	}
 
-	reportExceptionInDerivation(derivation: IDerivation, error: any) {
-		const message = `[mobx] Catched uncaught exception that was thrown by a reaction or observer component, in: '${derivation}`;
+	reportExceptionInDerivation(error: any) {
+		const message = `[mobx] Catched uncaught exception that was thrown by a reaction or observer component, in: '${this}`;
 		const messageToUser = `
 		Hi there! I'm sorry you have just run into an exception.
 
@@ -143,11 +143,9 @@ export class Reaction implements IDerivation, IReactionPublic {
 				type: "error",
 				message,
 				error,
-				object: derivation
+				object: this
 			});
 		}
-		// TODO: introduce per reaction handler
-		// TODO: introduce global handler
 	}
 
 	dispose() {
@@ -214,8 +212,8 @@ function runReactionsHelper() {
 	// we converge to no remaining reactions after a while.
 	while (allReactions.length > 0) {
 		if (++iterations === MAX_REACTION_ITERATIONS) {
-			resetGlobalState();
-			throw new Error(`Reaction doesn't converge to a stable state after ${MAX_REACTION_ITERATIONS} iterations.`
+			allReactions.splice(0); // clear reactions
+			console.error(`Reaction doesn't converge to a stable state after ${MAX_REACTION_ITERATIONS} iterations.`
 				+ ` Probably there is a cycle in the reactive function: ${allReactions[0]}`);
 		}
 		let remainingReactions = allReactions.splice(0);

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -21,7 +21,7 @@ registerGlobals();
 
 export { IAtom, Atom, BaseAtom                                } from "./core/atom";
 export { IObservable, IDepTreeNode                            } from "./core/observable";
-export { Reaction, IReactionPublic                            } from "./core/reaction";
+export { Reaction, IReactionPublic, IReactionDisposer         } from "./core/reaction";
 export { IDerivation, untracked, IDerivationState             } from "./core/derivation";
 export { useStrict, isStrictModeEnabled                       } from "./core/action";
 export { spy                                                  } from "./core/spy";

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -58,7 +58,7 @@ export { Iterator                                             } from "./utils/it
 export { IObserverTree, IDependencyTree                       } from "./api/extras";
 
 import { resetGlobalState, shareGlobalState, getGlobalState } from "./core/globalstate";
-
+import { IDerivation } from "./core/derivation";
 import { IDepTreeNode } from "./core/observable";
 import { IObserverTree, IDependencyTree, getDependencyTree, getObserverTree } from "./api/extras";
 import { getDebugName, getAtom, getAdministration } from "./types/type-utils";
@@ -66,7 +66,7 @@ import { allowStateChanges } from "./core/action";
 import { spyReport, spyReportEnd, spyReportStart, isSpyEnabled } from "./core/spy";
 import { Lambda } from "./utils/utils";
 import { isComputingDerivation } from "./core/derivation";
-import { setReactionScheduler } from "./core/reaction";
+import { setReactionScheduler, onReactionError } from "./core/reaction";
 
 export const extras = {
 	allowStateChanges,
@@ -78,6 +78,7 @@ export const extras = {
 	getObserverTree,
 	isComputingDerivation,
 	isSpyEnabled,
+	onReactionError,
 	resetGlobalState,
 	shareGlobalState,
 	spyReport,

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -73,6 +73,7 @@ export const extras = {
 	getAtom,
 	getDebugName,
 	getDependencyTree,
+	getAdministration,
 	getGlobalState,
 	getObserverTree,
 	isComputingDerivation,
@@ -83,12 +84,6 @@ export const extras = {
 	spyReportEnd,
 	spyReportStart,
 	setReactionScheduler
-};
-
-// Experimental or internal api's (exposed for testing for example)
-export const _ = {
-	getAdministration,
-	resetGlobalState
 };
 
 declare var __MOBX_DEVTOOLS_GLOBAL_HOOK__: { injectMobx: ((any) => void)};

--- a/test/action.js
+++ b/test/action.js
@@ -2,6 +2,7 @@
 
 var test = require('tape');
 var mobx = require('../');
+var utils = require('./utils/test-utils');
 
 test('action should wrap in transaction', t => {
 	var values = [];
@@ -181,7 +182,7 @@ test('should not be possible to invoke action in a computed block', t => {
 		return a.get();
 	});
 
-	t.throws(() => {
+	utils.consoleError(t, () => {
 		mobx.autorun(() => c.get());
 	}, /Computed values or transformers should not invoke actions or trigger other side effects/, 'expected throw');
 	mobx.extras.resetGlobalState();

--- a/test/api.js
+++ b/test/api.js
@@ -9,7 +9,6 @@ test('correct api should be exposed', function(t) {
 		'IObservableFactories',
 		'ObservableMap',
 		'Reaction',
-		'_',
 		'action',
 		'asFlat',
 		'asMap',
@@ -50,16 +49,9 @@ test('correct api should be exposed', function(t) {
 		return mobx[key] == undefined;
 	}).length, 0);
 
-	t.deepEquals(Object.keys(mobx._).sort(), [
-		'getAdministration',
-		'resetGlobalState'
-	]);
-	t.equals(Object.keys(mobx._).filter(function(key) {
-		return mobx._[key] == undefined;
-	}).length, 0);
-
 	t.deepEquals(Object.keys(mobx.extras).sort(), [
 			'allowStateChanges',
+			'getAdministration',
 			'getAtom',
 			'getDebugName',
 			'getDependencyTree',

--- a/test/api.js
+++ b/test/api.js
@@ -59,6 +59,7 @@ test('correct api should be exposed', function(t) {
 			'getObserverTree',
 			'isComputingDerivation',
 			'isSpyEnabled',
+			'onReactionError',
 			'resetGlobalState',
 			'setReactionScheduler',
 			'shareGlobalState',

--- a/test/errorhandling.js
+++ b/test/errorhandling.js
@@ -670,7 +670,7 @@ test('peeking inside autorun doesn\'t bork (global) state', t => {
 		t.end()
 	})
 
-	test.skip("it should be possible to handle exceptions in reaction", t => {
+	test("it should be possible to handle exceptions in reaction", t => {
 
 		const a = mobx.observable(1)
 		const d = mobx.autorun(function() {
@@ -686,7 +686,7 @@ test('peeking inside autorun doesn\'t bork (global) state', t => {
 		t.deepEqual(errors, [2, 3])
 		d()
 
-		checkGlobalState()
+		checkGlobalState(t)
 		t.end()
 	})
 

--- a/test/errorhandling.js
+++ b/test/errorhandling.js
@@ -47,6 +47,115 @@ test('exception1', function(t) {
     t.end();
 })
 
+test('exceptions in computed values can be recovered from', t => {
+	var a = observable({
+		x: 1,
+		get y() {
+			if (this.x === 2)
+				throw "Uhoh"
+			return this.x * 2
+		}
+	})
+
+	t.equal(a.y, 2)
+	a.x = 2
+
+	t.throws(() => a.y, /Uhoh/)
+
+	checkGlobalState(t)
+
+	a.x = 3
+	t.equal(a.y, 6)
+	checkGlobalState(t)
+	t.end()
+})
+
+test('exception when starting autorun cannot be recovered from', t => {
+	var b = undefined
+	var a = observable({
+		x: 2,
+		get y() {
+			if (this.x === 2)
+				throw "Uhoh"
+			return this.x * 2
+		}
+	})
+
+	t.throws(() => {
+		mobx.autorun(() => { b = a.y })
+	}, /Uhoh/)
+	t.equal(b, undefined)
+	checkGlobalState(t)
+	a.x = 3
+	t.equal(b, undefined) // tracking never started..
+	checkGlobalState(t)
+	t.equal(mobx.extras.getAtom(a, "y").observers.length, 0)
+	t.end()
+})
+
+test('exception in autorun can be recovered from', t => {
+	var b = undefined
+	var a = observable({
+		x: 1,
+		get y() {
+			if (this.x === 2)
+				throw "Uhoh"
+			return this.x * 2
+		}
+	})
+
+	var d = mobx.autorun(() => { b = a.y })
+	t.equal(a.y, 2)
+	t.equal(b, 2)
+	t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
+
+	t.throws(() => {
+		a.x = 2
+	}, /Uhoh/)
+	t.equal(a.y, 2) // old cached value!
+	t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
+
+	t.equal(b, 2)
+	checkGlobalState(t)
+
+	a.x = 3
+	t.equal(a.y, 6)
+	t.equal(b, 6)
+	checkGlobalState(t)
+	t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
+	d()
+	t.equal(mobx.extras.getAtom(a, "y").observers.length, 0)
+	t.end()
+})
+
+test('multiple autoruns with exceptions are handled correctly', t => {
+	var a = mobx.observable(1)
+	var values = []
+	var d1 = mobx.autorun(() => values.push("a" + a.get()))
+	var d2 = mobx.autorun(() => {
+		if (a.get() === 2)
+			throw /Uhoh/
+		values.push("b" + a.get())
+	})
+	var d3 = mobx.autorun(() => values.push("c" + a.get()))
+
+	t.deepEqual(values, ["a1", "b1", "c1"])
+	values.splice(0)
+
+	t.throws(() => a.set(2), /Uhoh/)
+	checkGlobalState(t)
+
+	t.deepEqual(values.sort(), ["a2", "c2"]) // order is irrelevant
+	values.splice(0)
+
+	a.set(3)
+	t.deepEqual(values.sort(), ["a3", "b3", "c3"]) // order is irrelevant
+
+	checkGlobalState(t)
+	d1(); d2(); d3()
+	t.end()
+})
+
 test('deny state changes in views', function(t) {
     var x = observable(3);
     var z = observable(5);
@@ -290,7 +399,7 @@ test('error handling assistence ', function(t) {
 
         t.deepEqual(values, [6, 4, 14, 8]);
         t.equal(errors.length, 0);
-		t.equal(warns.length, 2);
+		t.equal(warns.length, 0); // since mobx 3 no warnings are printed anymore
         t.equal(thrown.length, 2);
 
         console.error = baseError;
@@ -370,7 +479,7 @@ test('peeking inside erroring computed value doesn\'t bork (global) state', t =>
 	t.equal(a.hasUnreportedChange, false)
 	t.equal(a.value, 1)
 
-	t.equal(b.dependenciesState, 0)
+	t.equal(b.dependenciesState, -1)
 	t.equal(b.observing.length, 0)
 	t.equal(b.newObserving, null)
 	t.equal(b.isPendingUnobservation, false)

--- a/test/errorhandling.js
+++ b/test/errorhandling.js
@@ -691,11 +691,11 @@ test('peeking inside autorun doesn\'t bork (global) state', t => {
 	})
 
 
-	test.skip("it should be possible to handle global errors in reactions", t => {
+	test("it should be possible to handle global errors in reactions", t => {
 
 		const a = mobx.observable(1)
 		const errors = []
-		const d2 = mobx.extras.onError (e => errors.push(e))
+		const d2 = mobx.extras.onReactionError(e => errors.push(e))
 
 		const d = mobx.autorun(function() {
 			throw a.get()
@@ -707,10 +707,10 @@ test('peeking inside autorun doesn\'t bork (global) state', t => {
 		d2()
 		a.set(4)
 
-		t.deepEqual(errors, [2, 3])
+		t.deepEqual(errors, [1, 2, 3])
 		d()
 
-		checkGlobalState()
+		checkGlobalState(t)
 		t.end()
 	})
 

--- a/test/extras.js
+++ b/test/extras.js
@@ -3,7 +3,7 @@ var mobx = require('..');
 var m = mobx;
 
 test('treeD', function(t) {
-    m._.resetGlobalState();
+    m.extras.resetGlobalState();
     mobx.extras.getGlobalState().mobxGuid = 0;
     var a = m.observable(3);
     var aName = 'ObservableValue@1';
@@ -71,7 +71,7 @@ test('treeD', function(t) {
 })
 
 test('names', function(t) {
-    m._.resetGlobalState();
+    m.extras.resetGlobalState();
     mobx.extras.getGlobalState().mobxGuid = 0;
 
     var struct = {
@@ -136,7 +136,7 @@ function stripTrackerOutput(output) {
 }
 
 test('spy 1', function(t) {
-    m._.resetGlobalState();
+    m.extras.resetGlobalState();
     var lines = [];
 
     var a = m.observable(3);
@@ -299,7 +299,7 @@ test('get administration', function(t) {
 	var g = new Clazz();
 
 	function adm(thing, prop) {
-		return mobx._.getAdministration(thing, prop).constructor.name;
+		return mobx.extras.getAdministration(thing, prop).constructor.name;
 	}
 
 	var ovClassName = mobx.observable(3).constructor.name;

--- a/test/makereactive.js
+++ b/test/makereactive.js
@@ -68,7 +68,7 @@ test('isObservable', function(t) {
 })
 
 test('observable1', function(t) {
-    m._.resetGlobalState();
+    m.extras.resetGlobalState();
 
     // recursive structure
     var x = m.observable({

--- a/test/observables.js
+++ b/test/observables.js
@@ -896,7 +896,7 @@ function stripSpyOutput(events) {
 }
 
 test('issue 50', function(t) {
-    m._.resetGlobalState();
+    m.extras.resetGlobalState();
     mobx.extras.getGlobalState().mobxGuid = 0;
     var x = observable({
         a: true,
@@ -952,7 +952,7 @@ test('issue 50', function(t) {
 });
 
 test('verify transaction events', function(t) {
-    m._.resetGlobalState();
+    m.extras.resetGlobalState();
     mobx.extras.getGlobalState().mobxGuid = 0;
 
     var x = observable({
@@ -1023,7 +1023,7 @@ test("verify array in transaction", function(t) {
 })
 
 test('delay autorun until end of transaction', function(t) {
-    m._.resetGlobalState();
+    m.extras.resetGlobalState();
     mobx.extras.getGlobalState().mobxGuid = 0;
     var events = [];
     var x = observable({

--- a/test/reaction.js
+++ b/test/reaction.js
@@ -255,22 +255,3 @@ test("#278 do not rerun if expr output doesn't change structurally", t => {
 	]);
 	t.end();
 })
-
-test("throws when the max iterations over reactions are done", t => {
-	var foo = mobx.observable({
-		a: 1,
-	});
-
-	mobx.autorun("bar", () => {
-		var x = foo.a;
-		foo.a = Math.random();
-	});
-
-	 t.throws(
-		() => foo.a++,
-		new RegExp("Reaction doesn't converge to a stable state after 100 iterations\\. "
-			+ "Probably there is a cycle in the reactive function: Reaction\\[bar\\]")
-	);
-	mobx.extras.resetGlobalState();
-	t.end();
-})

--- a/test/spy.js
+++ b/test/spy.js
@@ -161,7 +161,7 @@ test("spy error", t => {
 		{ name: 'x', newValue: 3, oldValue: 2, spyReportStart: true, type: 'update' },
 			{ type: 'compute' },
 			{ spyReportStart: true, type: 'reaction' },
-				{ cause: 'Oops', message: '[mobx] Catched uncaught exception that was thrown by a reaction or observer component, in: \'Reaction[autorun]', type: 'error' },
+				{ error: 'Oops', message: '[mobx] Catched uncaught exception that was thrown by a reaction or observer component, in: \'Reaction[autorun]', type: 'error' },
 			{ spyReportEnd: true },
 		{ spyReportEnd: true }
 	]);

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -1,0 +1,25 @@
+"use strict";
+
+exports.consoleError = function(t, block, regex) {
+	let messages = "";
+	const orig = console.error;
+	console.error = function() {
+		Object.keys(arguments).forEach(key => {
+			messages += ", " + arguments[key];
+		})
+		messages += "\n";
+	}
+	try {
+		block();
+	} finally {
+		console.error = orig;
+	}
+	if (!messages)
+		t.ok(false, "Expected error, but nothing was logged");
+	else if (regex.test(messages))
+		t.ok(true, "console.error");
+	else
+		t.ok(false, "Expected " + regex +  ", got: " + messages);
+}
+
+// TODO: move check globalState, cleanSpyEvents to here.


### PR DESCRIPTION
Fixes #731 

* computed values that throw, store the exception and throw it to the next consumer(s). They keep tracking their data, so they are able to recover
* reactions will always catch their exceptions, and just log the error. They will keep tracking their data, so they are able to recover
* the disposer of a reaction exposes an `onError(handler)`  function to be able to attach custom error handling logic to an reaction (this intercepts the default behavior)
* `extras.onReactionError` can be used to register a global onError handler for reactions (will fire after spy `"error"` event