### PR TITLE
Update docs

### DIFF
--- a/docs/refguide/observer-component.md
+++ b/docs/refguide/observer-component.md
@@ -164,7 +164,6 @@ import {observer} from "mobx-react";
 
 * `componentWillReact` doesn't take arguments
 * `componentWillReact` won't fire before the initial render (use `componentWillMount` instead)
-* `componentWillReact` won't fire when receiving new props or after `setState` calls (use `componentWillUpdate` instead)
 
 ## Optimizing components
 


### PR DESCRIPTION
Remove obsolete not about componentWillReact mobx-react@4 has changed semantic of `props` and `state`, which became observables. So, this not became obsolete too.

