### PR TITLE
Fix toJS flowtype definition

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -330,7 +330,7 @@ declare module 'mobx' {
     object: any, property: string, listener: (newValue: any, oldValue?: any) => void, fireImmediately?: boolean
   ): Lambda
 
-  declare function toJS(source: any, detectCycles: boolean, ___alreadySeen: [any, any][]): any
+  declare function toJS(source: any, detectCycles?: boolean, ___alreadySeen?: [any, any][]): any
   declare function toJSlegacy(source: any, detectCycles?: boolean, ___alreadySeen?: [any, any][]): any
   declare function whyRun(thing?: any, prop?: string): string
   declare function useStrict(strict: boolean): any


### PR DESCRIPTION
Fixes the flowtype definition for toJS. The original source code allows `detectCycles` and `___alreadySeen` to be null.

PR checklist:

* [ ] Implementation
* [ ] Added tests
* [x] Verified that there is no significant performance drop (`npm run perf`)
* [ ] Updated (either in the description of this PR as markdown, or as seperate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [x] Added type annotations (if you are unfamiliar with typescript, untyped, `:any` based PR's are welcome as well
