### PR TITLE
Also publish flow typings to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,13 @@ And finally kudos for all the people that believed in, tried, validated and even
 
 > Note: Before testing, make sure to run `npm run small-build`.
 
+## Flow support
+MobX ships with flow typings. To use them in your project, add this to the `[libs]` section of your `.flowconfig`:
+```
+[libs]
+node_modules/mobx/lib/mobx.js.flow
+```
+
 ## Bower support
 
 Bower support is available through the infamous unpkg.com:

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "istanbul": "^0.3.21",
     "iterall": "^1.0.2",
     "lodash.intersection": "^3.2.0",
+    "ncp": "^2.0.0",
     "rimraf": "^2.5.4",
     "tape": "^4.2.2",
     "tape-run": "^2.1.0",

--- a/scripts/single-file-build.js
+++ b/scripts/single-file-build.js
@@ -39,7 +39,8 @@ fs.writeFileSync('.build/mobx.ts', allContents, { encoding: 'utf8', flag: 'a' })
     'tsc -m commonjs -t es5 -d --removeComments --outDir lib .build/mobx.ts',
     'browserify -s mobx -e lib/mobx.js -o lib/mobx.umd.js',
     `uglifyjs -m sort,toplevel -c --screw-ie8 --preamble "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */" --source-map lib/mobx.min.js.map -o lib/mobx.min.js lib/mobx.js`,
-    `uglifyjs -m sort,toplevel -c --screw-ie8 --preamble "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */" --source-map lib/mobx.umd.min.js.map -o lib/mobx.umd.min.js lib/mobx.umd.js`
+    `uglifyjs -m sort,toplevel -c --screw-ie8 --preamble "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */" --source-map lib/mobx.umd.min.js.map -o lib/mobx.umd.min.js lib/mobx.umd.js`,
+    `ncp flow-typed/mobx.js lib/mobx.js.flow`
 ]
     .map(cmd => `${__dirname}/../node_modules/.bin/${cmd}`)
     .map(cmd => exec(cmd))


### PR DESCRIPTION
Also publish the flow typings to npm, so we can use them. 

Where should I add the documentation on how to use this? You should add this to the `[libs]` section of your .flowconfig. 
```
[libs]
node_modules/mobx/lib/mobx.js.flow
```
