### PR TITLE
Add support for Symbol.toPrimitive() and valueOf() on observables #GoodnessSquad

### DIFF
--- a/src/types/observablevalue.ts
+++ b/src/types/observablevalue.ts
@@ -27,6 +27,8 @@ export interface IObservableValue<T> {
 	observe(listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda;
 }
 
+declare var Symbol;
+
 export class ObservableValue<T> extends BaseAtom implements IObservableValue<T>, IInterceptable<IValueWillChange<T>>, IListenable {
 	hasUnreportedChange = false;
 	interceptors;
@@ -40,6 +42,14 @@ export class ObservableValue<T> extends BaseAtom implements IObservableValue<T>,
 			// only notify spy if this is a stand-alone observable
 			spyReport({ type: "create", object: this, newValue: this.value });
 		}
+
+		if (typeof Symbol !== undefined) {
+			this[Symbol.toPrimitive] = this.valueOf;
+		}
+	}
+
+	public valueOf(): T {
+    	return this.get()
 	}
 
 	public set(newValue: T) {

--- a/test/observables.js
+++ b/test/observables.js
@@ -1661,3 +1661,18 @@ test('603 - transaction should not kill reactions', t => {
 	t.end()
 
 })
+
+test('#561 test toPrimitive() of observable objects', function(t) {
+    var x = observable(3);
+
+    t.equal(x.valueOf(), 3);
+    t.equal(x[Symbol.toPrimitive](), 3);
+    
+    t.equal(+x, 3);
+    t.equal(++x, 4);
+
+    var y = observable(3);
+
+    t.equal(y + 7, 10);
+    t.end()
+})


### PR DESCRIPTION
As per #561.
Big thanks to @wildeyes for helping me!

Note: `console.log(mobx.observable(3))` returns `ObservableValue` and not `3`. Is this okay?

#GoodnessSquad