### PR TITLE
Missing es6 map error

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -199,7 +199,7 @@ export function isArrayLike(x: any): boolean {
 }
 
 export function isES6Map(thing): boolean {
-	if (thing instanceof getGlobal().Map)
+	if (getGlobal().Map !== undefined && thing instanceof getGlobal().Map)
 		return true;
 	return false;
 }

--- a/test/observables.js
+++ b/test/observables.js
@@ -1661,3 +1661,20 @@ test('603 - transaction should not kill reactions', t => {
 	t.end()
 
 })
+
+test('observables should not fail when ES6 Map is missing', t => {
+    const globalMapFunction = global.Map;
+    global.Map = undefined;
+    t.equal(global.Map, undefined);
+    try {
+        var a = observable([1,2,3]); //trigger isES6Map in utils
+    }
+    catch (e) {
+        t.fail('Should not fail when Map is missing');
+    }
+
+    t.equal(m.isObservable(a), true);
+
+    global.Map = globalMapFunction;
+    t.end();
+})


### PR DESCRIPTION
In an environment where the ES6 Map is missing, any call to observable() will throw an uncaught error at the `isES6Map` check in `utils/utils.ts` and the observable won't be created. This pull request is a simple fix that makes sure that we don't try to call `type instanceof undefined`.

PR checklist:

* [x] Implementation
* [x] Added tests
* [x] Verified that there is no significant performance drop (`npm run perf`)
* [ ] Updated (either in the description of this PR as markdown, or as seperate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added type annotations (if you are unfamiliar with typescript, untyped, `:any` based PRs are welcome as well
