### PR TITLE
feat: added IAction to action function return type

### DIFF
--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -1,27 +1,27 @@
 import {invariant, addHiddenProp} from "../utils/utils";
 import {createClassPropertyDecorator} from "../utils/decorators";
-import {createAction, executeAction} from "../core/action";
+import {createAction, executeAction, IAction} from "../core/action";
 
 export interface IActionFactory {
 	// nameless actions
-	<A1, R, T extends (a1: A1) => R>(fn: T): T;
-	<A1, A2, R, T extends (a1: A1, a2: A2) => R>(fn: T): T;
-	<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(fn: T): T;
-	<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(fn: T): T;
-	<A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(fn: T): T;
-	<A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(fn: T): T;
+	<A1, R, T extends (a1: A1) => R>(fn: T): T & IAction;
+	<A1, A2, R, T extends (a1: A1, a2: A2) => R>(fn: T): T & IAction;
+	<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(fn: T): T & IAction;
+	<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(fn: T): T & IAction;
+	<A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(fn: T): T & IAction;
+	<A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(fn: T): T & IAction;
 
 	// named actions
-	<A1, R, T extends (a1: A1) => R>(name: string, fn: T): T;
-	<A1, A2, R, T extends (a1: A1, a2: A2) => R>(name: string, fn: T): T;
-	<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(name: string, fn: T): T;
-	<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(name: string, fn: T): T;
-	<A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(name: string, fn: T): T;
-	<A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(name: string, fn: T): T;
+	<A1, R, T extends (a1: A1) => R>(name: string, fn: T): T & IAction;
+	<A1, A2, R, T extends (a1: A1, a2: A2) => R>(name: string, fn: T): T & IAction;
+	<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(name: string, fn: T): T & IAction;
+	<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(name: string, fn: T): T & IAction;
+	<A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(name: string, fn: T): T & IAction;
+	<A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(name: string, fn: T): T & IAction;
 
 	// generic forms
-	<T extends Function>(fn: T): T;
-	<T extends Function>(name: string, fn: T): T;
+	<T extends Function>(fn: T): T & IAction;
+	<T extends Function>(name: string, fn: T): T & IAction;
 
 	// named decorator
 	(customName: string): (target: Object, key: string, baseDescriptor?: PropertyDescriptor) => void;
@@ -30,12 +30,12 @@ export interface IActionFactory {
 	(target: Object, propertyKey: string, descriptor?: PropertyDescriptor): void;
 
 	// .bound
-	bound<A1, R, T extends (a1: A1) => R>(fn: T): T;
-	bound<A1, A2, R, T extends (a1: A1, a2: A2) => R>(fn: T): T;
-	bound<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(fn: T): T;
-	bound<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(fn: T): T;
-	bound<A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(fn: T): T;
-	bound<A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(fn: T): T;
+	bound<A1, R, T extends (a1: A1) => R>(fn: T): T & IAction;
+	bound<A1, A2, R, T extends (a1: A1, a2: A2) => R>(fn: T): T & IAction;
+	bound<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(fn: T): T & IAction;
+	bound<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(fn: T): T & IAction;
+	bound<A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(fn: T): T & IAction;
+	bound<A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(fn: T): T & IAction;
 
 	// .bound decorator
 	bound(target: Object, propertyKey: string, descriptor?: PropertyDescriptor): void;

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -6,7 +6,12 @@ import {isSpyEnabled, spyReportStart, spyReportEnd} from "../core/spy";
 import {isComputedValue} from "../core/computedvalue";
 import {globalState} from "../core/globalstate";
 
-export function createAction(actionName: string, fn: Function): Function {
+export interface IAction{
+	originalFn: Function
+	isMobxAction: boolean
+}
+
+export function createAction(actionName: string, fn: Function): Function & IAction {
 	invariant(typeof fn === "function", "`action` can only be invoked on functions");
 	invariant(typeof actionName === "string" && actionName.length > 0, `actions should have valid names, got: '${actionName}'`);
 	const res = function () {
@@ -14,7 +19,7 @@ export function createAction(actionName: string, fn: Function): Function {
 	};
 	(res as any).originalFn = fn;
 	(res as any).isMobxAction = true;
-	return res;
+	return res as any;
 }
 
 export function executeAction(actionName: string, fn: Function, scope?: any, args?: IArguments) {

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -23,7 +23,7 @@ export { IAtom, Atom, BaseAtom                                } from "./core/ato
 export { IObservable, IDepTreeNode                            } from "./core/observable";
 export { Reaction, IReactionPublic, IReactionDisposer         } from "./core/reaction";
 export { IDerivation, untracked, IDerivationState             } from "./core/derivation";
-export { useStrict, isStrictModeEnabled                       } from "./core/action";
+export { useStrict, isStrictModeEnabled, IAction              } from "./core/action";
 export { spy                                                  } from "./core/spy";
 export { IComputedValue                                       } from "./core/computedvalue";
 


### PR DESCRIPTION
As discussed with @mweststrate, added IAction to the return type of an action() call.

PR checklist:

* [X] Implementation
* [X] Added tests
* [X] Verified that there is no significant performance drop (`npm run perf`)
* [X] Updated (either in the description of this PR as markdown, or as seperate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [X] Added type annotations (if you are unfamiliar with typescript, untyped, `:any` based PRs are welcome as well
