### PR TITLE
observe, typescript: index & mapped types

### DIFF
--- a/src/api/observe.ts
+++ b/src/api/observe.ts
@@ -1,6 +1,6 @@
 import {IObservableArray, IArrayChange, IArraySplice} from "../types/observablearray";
 import {ObservableMap, IMapChange} from "../types/observablemap";
-import {IObjectChange} from "../types/observableobject";
+import {IObjectDidChange} from "../types/observableobject";
 import {IComputedValue} from "../core/computedvalue";
 
 import {IObservableValue, IValueDidChange} from "../types/observablevalue";
@@ -11,7 +11,7 @@ export function observe<T>(value: IObservableValue<T> | IComputedValue<T>, liste
 export function observe<T>(observableArray: IObservableArray<T>, listener: (change: IArrayChange<T> | IArraySplice<T>) => void, fireImmediately?: boolean): Lambda;
 export function observe<T>(observableMap: ObservableMap<T>, listener: (change: IMapChange<T>) => void, fireImmediately?: boolean): Lambda;
 export function observe<T>(observableMap: ObservableMap<T>, property: string, listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda;
-export function observe(object: Object, listener: (change: IObjectChange) => void, fireImmediately?: boolean): Lambda;
+export function observe<T>(object: T, listener: (change: IObjectDidChange<T, keyof T>) => void, fireImmediately?: boolean): Lambda;
 export function observe(object: Object, property: string, listener: (change: IValueDidChange<any>) => void, fireImmediately?: boolean): Lambda;
 export function observe(thing, propOrCb?, cbOrFire?, fireImmediately?): Lambda {
 	if (typeof cbOrFire === "function")

--- a/src/types/observableobject.ts
+++ b/src/types/observableobject.ts
@@ -15,7 +15,14 @@ export interface IObservableObject {
 	"observable-object": IObservableObject;
 }
 
-// In 3.0, change to IObjectDidChange
+export interface IObjectDidChange<T, K extends keyof T> {
+	name: K;
+	object: T;
+	type: "update" | "add";
+	oldValue?: T[K];
+	newValue: T[K];
+}
+
 export interface IObjectChange {
 	name: string;
 	object: any;


### PR DESCRIPTION
Enable index types and mapped types on `IObjectdidChange` for better typecheck and inference
