### PR TITLE
Improve flow typing for action method

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -301,6 +301,8 @@ declare module 'mobx' {
   declare function extendShallowObservable(target: any): any;
 
   declare function action(targetOrName: any, propertyKeyOrFuc?: any, descriptor?: PropertyDescriptor): any;
+  declare function action<T>(name: string, func: T): T;
+  declare function action<T>(func: T): T;
   declare function runInAction<T>(name: string, block: () => T, scope?: any): T;
   declare function runInAction<T>(block: () => T, scope?: any): T;
   declare function isAction(thing: any): boolean;


### PR DESCRIPTION
This PR adds two new type definitions for the `action()` method:

`action(name: string, func: T): T`
`action(func: T): T`

More specifically, this types the non-decorator implementation of `action()`.

The existing `action()` type definition returns `any`, which causes type information associated with the wrapped function to be lost. At some point, we should probably investigate flow-type support for decorators. I could be mistaken but I think decorators in flow-type either causes warnings or are ignored, so the current definition may not provide the intended value.