### PR TITLE
Clarify English

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ class Todo {
 ```
 
 Using `observable` is like turning the properties of an object into a spreadsheet cells.
-But unlike spreadsheets, these values cannot just be primitive values, but also references, objects and arrays.
+But unlike spreadsheets, these values can be not only primitive values, but also references, objects and arrays.
 You can even [define your own](http://mobxjs.github.io/mobx/refguide/extending.html) observable data sources.
 
 ### Intermezzo: Using MobX in ES5, ES6 and ES.next environments


### PR DESCRIPTION
Generally, "but also" is preceded by "not only", which makes this sentence clearer (it's a correlative conjunction). The previous text said that the values _can't_ be primitive values, but of course they can. It is that they are not _limited_ to being primitive values.