### PR TITLE
Remove types in Javascript code examples

### DIFF
--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -30,8 +30,8 @@ If you have [decorators enabled](../best/decorators.md) you can use the `@comput
 import {observable, computed} from "mobx";
 
 class OrderLine {
-    @observable price:number = 0;
-    @observable amount:number = 1;
+    @observable price = 0;
+    @observable amount = 1;
 
     constructor(price) {
         this.price = price;

--- a/docs/refguide/observable-decorator.md
+++ b/docs/refguide/observable-decorator.md
@@ -8,8 +8,8 @@ This offers fine-grained control on which parts of your object become observable
 import {observable} from "mobx";
 
 class OrderLine {
-    @observable price:number = 0;
-    @observable amount:number = 1;
+    @observable price = 0;
+    @observable amount = 1;
 
     constructor(price) {
         this.price = price;


### PR DESCRIPTION
Some sneaky numbers managed to find their way in from typed land.