### PR TITLE
[docs] lately → late

### DIFF
--- a/best/pitfalls.html
+++ b/best/pitfalls.html
@@ -902,7 +902,7 @@ For more info see <a href="react.html">what will MobX react to?</a>.</p>
 <h3 id="use-observer-on-all-components-that-render-observable-s">Use <code>@observer</code> on all components that render <code>@observable</code>&apos;s.</h3>
 <p><code>@observer</code> only enhances the component you are decorating, not the components used inside it.
 So usually all your components should be decorated. Don&apos;t worry, this is not inefficient, in contrast, more <code>observer</code> components make rendering more efficient.</p>
-<h3 id="dereference-values-as-lately-as-possible">Dereference values as lately as possible</h3>
+<h3 id="dereference-values-as-late-as-possible">Dereference values as late as possible</h3>
 <p>MobX can do a lot, but it cannot make primitive values observable (although it can wrap them in an object see <a href="../refguide/boxed.html">boxed observables</a>).
 So it is not the <em>values</em> that are observable, but the <em>properties</em> of an object. This means that <code>@observer</code> actually reacts to the fact that you dereference a value.
 So in our above example, the <code>Timer</code> component would <strong>not</strong> react if it was initialized as follows:</p>

--- a/best/pitfalls.md
+++ b/best/pitfalls.md
@@ -23,7 +23,7 @@ If you need a dynamically keyed object, for example to store users by id, create
 `@observer` only enhances the component you are decorating, not the components used inside it.
 So usually all your components should be decorated. Don't worry, this is not inefficient, in contrast, more `observer` components make rendering more efficient.
 
-### Dereference values as lately as possible
+### Dereference values as late as possible
 
 MobX can do a lot, but it cannot make primitive values observable (although it can wrap them in an object see [boxed observables](boxed.md)).
 So it are not the _values_ that are observable, but the _properties_ of an object. This means that `@observer` actually reacts to the fact that you dereference a value.

--- a/best/react-performance.html
+++ b/best/react-performance.html
@@ -928,7 +928,7 @@ It is therefore recommended to have components that just map over a collection a
 <h2 id="don-t-use-array-indexes-as-keys">Don&apos;t use array indexes as keys</h2>
 <p>Don&apos;t use array indexes or any value that might change in the future as key. Generate id&apos;s for your objects if needed.
 See also this <a href="https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318" target="_blank">blog</a>.</p>
-<h2 id="dereference-values-lately">Dereference values lately</h2>
+<h2 id="dereference-values-late">Dereference values late</h2>
 <p>When using <code>mobx-react</code> it is recommended to dereference values as late as possible.
 This is because MobX will re-render components that dereference observable values automatically.
 If this happens deeper in your component tree, less components have to re-render.</p>

--- a/docs/best/pitfalls.md
+++ b/docs/best/pitfalls.md
@@ -28,7 +28,7 @@ For more info see [what will MobX react to?](react.md).
 `@observer` only enhances the component you are decorating, not the components used inside it.
 So usually all your components should be decorated. Don't worry, this is not inefficient, in contrast, more `observer` components make rendering more efficient.
 
-### Dereference values as lately as possible
+### Dereference values as late as possible
 
 MobX can do a lot, but it cannot make primitive values observable (although it can wrap them in an object see [boxed observables](../refguide/boxed.md)).
 So it is not the _values_ that are observable, but the _properties_ of an object. This means that `@observer` actually reacts to the fact that you dereference a value.

--- a/docs/best/react-performance.md
+++ b/docs/best/react-performance.md
@@ -59,7 +59,7 @@ Good:
 Don't use array indexes or any value that might change in the future as key. Generate id's for your objects if needed.
 See also this [blog](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318).
 
-## Dereference values lately
+## Dereference values late
 
 When using `mobx-react` it is recommended to dereference values as late as possible.
 This is because MobX will re-render components that dereference observable values automatically.


### PR DESCRIPTION
The use of `lately` is confusing (and I think, incorrect) in this context. "lately" means "recently" -- "not long ago". What the docs mean is to dereference _late_ in the process.