### PR TITLE
Removed unnecessary apostrophe from pitfalls.md

### DIFF
--- a/docs/best/pitfalls.md
+++ b/docs/best/pitfalls.md
@@ -23,7 +23,7 @@ However object iterators like `for .. in` or `Object.keys()` won't react to this
 If you need a dynamically keyed object, for example to store users by id, create observable _map_s using [`observable.map`](../refguide/map.md).
 For more info see [what will MobX react to?](react.md).
 
-### Use `@observer` on all components that render `@observable`'s.
+### Use `@observer` on all components that render `@observable`s.
 
 `@observer` only enhances the component you are decorating, not the components used inside it.
 So usually all your components should be decorated. Don't worry, this is not inefficient, in contrast, more `observer` components make rendering more efficient.


### PR DESCRIPTION
`@observable` <strong>'</strong>s is possessive. We want the plural, `@observable`s.

PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [x] Updated docs (either in the description of this PR as markdown, or as seperate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)
