### PR TITLE
Added missing apostrophe to PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@ PR checklist:
 
 Feel free to ask help with any of these boxes!
 
-The above process doesnt apply to doc updates etc.
+The above process doesn't apply to doc updates etc.


### PR DESCRIPTION
TIL GitHub will still use the old PR template if you send a PR to update the PR template... 😄 

PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [x] Updated docs (either in the description of this PR as markdown, or as seperate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesnt apply to doc updates etc.
