### PR TITLE
Fix typo, clarify comparison

### DIFF
--- a/docs/refguide/untracked.md
+++ b/docs/refguide/untracked.md
@@ -1,7 +1,7 @@
 # Untracked
 
 Untracked allows you to run a piece of code without establishing observers.
-Like `transaction`, `untracked` is automatically applied by `(@)action`, so usually it makes more sense to use actions then `untracked` directly.
+Like `transaction`, `untracked` is automatically applied by `(@)action`, so usually it makes more sense to use actions than to use `untracked` directly.
 Example:
 
 ```javascript


### PR DESCRIPTION
The original typo made it seem like the two approaches can happen sequentially when, after re-reading, it seems like the intent is to convey that `untracked` is a lower-level operation than `(@)action`, and that if you're using `(@)action`, then `untracked` isn't necessary.