### PR TITLE
Improve class action autonaming

### DIFF
--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -81,7 +81,9 @@ export var action: IActionFactory = function action(arg1, arg2?, arg3?, arg4?): 
 	if (arguments.length === 1 && typeof arg1 === "string")
 		return namedActionDecorator(arg1);
 
-	return namedActionDecorator(arg2).apply(null, arguments);
+    const targetName = arg1.constructor.name;
+    name = targetName ? targetName + '.' + arg2 : arg2;
+    return namedActionDecorator(name).apply(null, arguments);
 } as any;
 
 action.bound = function boundAction(arg1, arg2?, arg3?) {

--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -83,7 +83,7 @@ export var action: IActionFactory = function action(arg1, arg2?, arg3?, arg4?): 
 
     const targetName = arg1.constructor.name;
     arg2 = targetName ? targetName + '.' + arg2 : arg2;
-    return namedActionDecorator(name).apply(null, arguments);
+    return namedActionDecorator(arg2).apply(null, arguments);
 } as any;
 
 action.bound = function boundAction(arg1, arg2?, arg3?) {

--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -82,7 +82,7 @@ export var action: IActionFactory = function action(arg1, arg2?, arg3?, arg4?): 
 		return namedActionDecorator(arg1);
 
     const targetName = arg1.constructor.name;
-    name = targetName ? targetName + '.' + arg2 : arg2;
+    arg2 = targetName ? targetName + '.' + arg2 : arg2;
     return namedActionDecorator(name).apply(null, arguments);
 } as any;
 


### PR DESCRIPTION
I'm not sure this is the right place, but AFAIK it is the only way for now to include class name with action name without changing the ObservableValue API. I think this change is too minor to follow the checklist.

* [ ] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)
