### PR TITLE
Fix CHANGELOG.md version history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-# 3.1.2
+# 3.1.3
 
 * Make sure that `ObservableArray.replace` can handle large arrays by not using splats internally. (See e.g. #859)
 * Exposed `ObservableArray.spliceWithArray`, that unlike a normal splice, doesn't use a variadic argument list so that it is possible to splice in new arrays that are larger then allowed by the callstack.
 
-# 3.1.1
+# 3.1.2
 
 * Fixed incompatiblity issue with `mobx-react@4.1.0`
 


### PR DESCRIPTION
Seems like the version history has been off by 1 since `3.1.1` was introduced but left unpublished. Latest version of mobx published to npm is 3.1.3
