### PR TITLE
Fix missing `this` in code example

### DIFF
--- a/docs/best/react.md
+++ b/docs/best/react.md
@@ -298,7 +298,7 @@ A common mistake is to store local variables that dereference observables, and t
     }
 
     render() {
-        return <div>{author.name}</div>
+        return <div>{this.author.name}</div>
     }
 }
 ```


### PR DESCRIPTION
Fix code example:

 ```javascript
 @observer class MyComponent extends React.component {
     author;
     constructor(props) {
         super(props)
         this.author = props.message.author;
     }
 
     render() {
        return <div>{author.name}</div> // ---->   should be this.author.name
     }
 }
 ```