### PR TITLE
Support primitives as memoization key for `createTransformer`

### DIFF
--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -45,6 +45,8 @@ export function createTransformer<A, B>(transformer: ITransformer<A, B>, onClean
 }
 
 function getMemoizationId(object) {
+	if(typeof object === 'string' || typeof object === 'number')
+		return object
 	if (object === null  || typeof object !== "object")
 		throw new Error("[mobx] transform expected some kind of object, got: " + object);
 	let tid = object.$transformId;

--- a/test/transform.js
+++ b/test/transform.js
@@ -1004,3 +1004,47 @@ test('transform tree (dynamic tags - peek / rebuild)', function(t) {
 
 	t.end();
 });
+
+// https://github.com/mobxjs/mobx/issues/886
+test('transform with primitive key', function(t) {
+	m.extras.resetGlobalState();
+
+	function Bob() {
+		this.num = Math.floor(Math.random() * 1000);
+		m.extendObservable(this, {
+			get name() {
+				return 'Bob' + this.num;
+			}
+		});
+	}
+
+	var _state = m.createTransformer( function(key) {
+		return m.observable([]);
+	});
+
+	var observableBobs = m.observable([]);
+	var bobs = [];
+
+	var bobFactory = m.createTransformer(function(key) {
+		return new Bob();
+	});
+
+	m.autorun(function() {
+		bobs = observableBobs.map(function(bob) {
+			return bobFactory(bob);
+		});
+	});
+
+	var b = m.observable({name: 'Bob1'});
+	observableBobs.push('Bob1');
+	observableBobs.push('Bob1');
+	t.equal(bobs[0].name, bobs[1].name);
+
+	observableBobs.clear();
+	observableBobs.push('Bob1');
+	observableBobs.push('Bob2');
+	t.notEqual(bobs[0].name, bobs[1].name);
+
+	t.end();
+});
+

--- a/test/transform.js
+++ b/test/transform.js
@@ -1018,10 +1018,6 @@ test('transform with primitive key', function(t) {
 		});
 	}
 
-	var _state = m.createTransformer( function(key) {
-		return m.observable([]);
-	});
-
 	var observableBobs = m.observable([]);
 	var bobs = [];
 
@@ -1035,7 +1031,6 @@ test('transform with primitive key', function(t) {
 		});
 	});
 
-	var b = m.observable({name: 'Bob1'});
 	observableBobs.push('Bob1');
 	observableBobs.push('Bob1');
 	t.equal(bobs[0].name, bobs[1].name);
@@ -1043,6 +1038,16 @@ test('transform with primitive key', function(t) {
 	observableBobs.clear();
 	observableBobs.push('Bob1');
 	observableBobs.push('Bob2');
+	t.notEqual(bobs[0].name, bobs[1].name);
+
+	observableBobs.clear();
+	observableBobs.push(1);
+	observableBobs.push(1);
+	t.equal(bobs[0].name, bobs[1].name);
+
+	observableBobs.clear();
+	observableBobs.push(1);
+	observableBobs.push(2);
 	t.notEqual(bobs[0].name, bobs[1].name);
 
 	t.end();


### PR DESCRIPTION
Fixes #886 