### PR TITLE
change the return type of a function parameter of autorun/autorunAsync to any

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -307,9 +307,9 @@ declare module 'mobx' {
   declare function runInAction<T>(name: string, block: () => T, scope?: any): T;
   declare function runInAction<T>(block: () => T, scope?: any): T;
   declare function isAction(thing: any): boolean;
-  declare function autorun(nameOrFunction: string | (r: IReactionPublic) => void, viewOrScope?: any, scope?: any): any;
+  declare function autorun(nameOrFunction: string | (r: IReactionPublic) => any, viewOrScope?: any, scope?: any): any;
   declare function when(predicate: () => boolean, effect: Lambda, scope?: any): any
-  declare function autorunAsync(func: (r: IReactionPublic) => void, delay?: number, scope?: any): any
+  declare function autorunAsync(func: (r: IReactionPublic) => any, delay?: number, scope?: any): any
   declare function reaction<T>(
     expression: (r: IReactionPublic) => T, effect: (arg: T, r: IReactionPublic) => void, fireImmediately?: boolean, delay?: number, scope?: any
   ): any

--- a/src/api/autorun.ts
+++ b/src/api/autorun.ts
@@ -12,7 +12,7 @@ import {getMessage} from "../utils/messages";
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(view: (r: IReactionPublic) => void, scope?: any): IReactionDisposer;
+export function autorun(view: (r: IReactionPublic) => any, scope?: any): IReactionDisposer;
 
 /**
  * Creates a named reactive view and keeps it alive, so that the view is always
@@ -22,10 +22,10 @@ export function autorun(view: (r: IReactionPublic) => void, scope?: any): IReact
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(name: string, view: (r: IReactionPublic) => void, scope?: any): IReactionDisposer;
+export function autorun(name: string, view: (r: IReactionPublic) => any, scope?: any): IReactionDisposer;
 export function autorun(arg1: any, arg2: any, arg3?: any) {
 	let name: string,
-		view: (r: IReactionPublic) => void,
+		view: (r: IReactionPublic) => any,
 		scope: any;
 
 	if (typeof arg1 === "string") {
@@ -105,10 +105,10 @@ export function when(arg1: any, arg2: any, arg3?: any, arg4?: any) {
 	return disposer;
 }
 
-export function autorunAsync(name: string, func: (r: IReactionPublic) => void, delay?: number, scope?: any): IReactionDisposer;
-export function autorunAsync(func: (r: IReactionPublic) => void, delay?: number, scope?: any): IReactionDisposer;
+export function autorunAsync(name: string, func: (r: IReactionPublic) => any, delay?: number, scope?: any): IReactionDisposer;
+export function autorunAsync(func: (r: IReactionPublic) => any, delay?: number, scope?: any): IReactionDisposer;
 export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
-	let name: string, func: (r: IReactionPublic) => void, delay: number, scope: any;
+	let name: string, func: (r: IReactionPublic) => any, delay: number, scope: any;
 	if (typeof arg1 === "string") {
 		name = arg1;
 		func = arg2;


### PR DESCRIPTION
I stumbled on this:

```javascript
autorunAsync(async () => {}, 500)
```
being labeled as wrong by flow, because async function always returns a promise.

```
src/routes/areas-to-follow.js:23
 23:     this.disposer = autorunAsync(async () => {
                                                 ^ Promise. This type is incompatible with the expected param type of
312:   declare function autorunAsync(func: (r: IReactionPublic) => void, delay?: number, scope?: any): any
                                                                   ^^^^ undefined. See lib: node_modules/mobx/lib/mobx.js.flow:312
```