### PR TITLE
ObservableArray#findIndex

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -150,6 +150,9 @@ declare module 'mobx' {
     find(
       predicate: (item: T, index: number, array: Array<T>) => boolean, thisArg?: any, fromIndex?: number
     ): T | any;
+    findIndex(
+      predicate: (item: T, index: number, array: Array<T>) => boolean, thisArg?: any, fromIndex?: number
+    ): number;
     remove(value: T): boolean;
   }
 

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -27,6 +27,7 @@ export interface IObservableArray<T> extends Array<T> {
 	peek(): T[];
 	replace(newItems: T[]): T[];
 	find(predicate: (item: T, index: number, array: IObservableArray<T>) => boolean, thisArg?: any, fromIndex?: number): T;
+	findIndex(predicate: (item: T, index: number, array: IObservableArray<T>) => boolean, thisArg?: any, fromIndex?: number): number;
 	remove(value: T): boolean;
 	move(fromIndex: number, toIndex: number): void;
 }
@@ -299,12 +300,18 @@ export class ObservableArray<T> extends StubArray {
 
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
 	find(predicate: (item: T, index: number, array: ObservableArray<T>) => boolean, thisArg?, fromIndex = 0): T | undefined {
+		const idx = this.findIndex.apply(this, arguments);
+		return idx === -1 ? undefined : this.$mobx.values[idx];
+	}
+
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
+	findIndex(predicate: (item: T, index: number, array: ObservableArray<T>) => boolean, thisArg?, fromIndex = 0): number {
 		this.$mobx.atom.reportObserved();
 		const items = this.$mobx.values, l = items.length;
 		for (let i = fromIndex; i < l; i++)
 			if (predicate.call(thisArg, items[i], i, this))
-				return items[i];
-		return undefined;
+				return i;
+		return -1;
 	}
 
 	/*
@@ -478,6 +485,7 @@ makeNonEnumerable(ObservableArray.prototype, [
 	"toJSON",
 	"peek",
 	"find",
+	"findIndex",
 	"splice",
 	"spliceWithArray",
 	"push",

--- a/test/array.js
+++ b/test/array.js
@@ -121,7 +121,7 @@ test('array should support iterall / iterable ', t => {
 	t.end()
 })
 
-test('find and remove', function(t) {
+test('find(findIndex) and remove', function(t) {
     var a = mobx.observable([10,20,20]);
     var idx = -1;
     function predicate(item, index) {
@@ -134,21 +134,27 @@ test('find and remove', function(t) {
 
     t.equal(a.find(predicate), 20);
     t.equal(idx, 1);
+    t.equal(a.findIndex(predicate), 1);
     t.equal(a.find(predicate, null, 1), 20);
     t.equal(idx, 1);
+    t.equal(a.findIndex(predicate, null, 1), 1);
     t.equal(a.find(predicate, null, 2), 20);
     t.equal(idx, 2);
+    t.equal(a.findIndex(predicate, null, 2), 2);
     idx = -1;
     t.equal(a.find(predicate, null, 3), undefined);
     t.equal(idx, -1);
+    t.equal(a.findIndex(predicate, null, 3), -1);
 
     t.equal(a.remove(20), true);
     t.equal(a.find(predicate), 20);
     t.equal(idx, 1);
+    t.equal(a.findIndex(predicate), 1);
     idx = -1;
     t.equal(a.remove(20), true);
     t.equal(a.find(predicate), undefined);
     t.equal(idx, -1);
+    t.equal(a.findIndex(predicate), -1);
 
     t.equal(a.remove(20), false);
 


### PR DESCRIPTION
refs #934 

Implement `ObservableArray#findIndex` to accepts 3rd arguments like `ObservableArray#find`.

* [x] Added unit tests
* [x] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)

I'll send another PR for updating docs later. -> #938 