### PR TITLE
Updated spelling of compuations to computations

### DIFF
--- a/docs/refguide/api.md
+++ b/docs/refguide/api.md
@@ -343,7 +343,7 @@ It is recommended to use `action` instead, which uses `transaction` internally.
 ### `untracked`
 Usage: `untracked(() => { block })`.
 Low-level api that might be useful inside reactions and computations.
-Any observables accessed in the `block` won't cause the reaction / compuations to be recomputed automatically.
+Any observables accessed in the `block` won't cause the reaction / computations to be recomputed automatically.
 However it is recommended to use `action` instead, which uses `untracked` internally.
 [&laquo;details&raquo;](untracked.md)
 


### PR DESCRIPTION
Updated spelling of `compuations` to `computations` in api documentation.

* [x] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated