### PR TITLE
single-file-build now can handle spaces in path.

### DIFF
--- a/scripts/single-file-build.js
+++ b/scripts/single-file-build.js
@@ -43,10 +43,11 @@ fs.writeFileSync('.build/mobx.ts', allContents, { encoding: 'utf8', flag: 'a' })
     `uglifyjs -m sort,toplevel -c --screw-ie8 --preamble "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */" --source-map lib/mobx.umd.min.js.map -o lib/mobx.umd.min.js lib/mobx.umd.js`,
     `ncp flow-typed/mobx.js lib/mobx.js.flow`
 ]
-    .map(cmd => `${__dirname}/../node_modules/.bin/${cmd}`)
+    .map(cmd => `${__dirname.replace(/ /g, '\\ ')}/../node_modules/.bin/${cmd}`)
     .map(cmd => {
 		try {
-			exec(cmd);
+      console.log(cmd);
+      exec(cmd);
 		} catch (e) {
 			console.log(e.stdout.toString());
 			console.error(e.stderr.toString());

--- a/scripts/single-file-build.js
+++ b/scripts/single-file-build.js
@@ -46,8 +46,7 @@ fs.writeFileSync('.build/mobx.ts', allContents, { encoding: 'utf8', flag: 'a' })
     .map(cmd => `${__dirname.replace(/ /g, '\\ ')}/../node_modules/.bin/${cmd}`)
     .map(cmd => {
 		try {
-      console.log(cmd);
-      exec(cmd);
+      		exec(cmd);
 		} catch (e) {
 			console.log(e.stdout.toString());
 			console.error(e.stderr.toString());


### PR DESCRIPTION
Spaces in the path led to errors when running `npm run small-build`. 

PR checklist:

* [ ] Added unit tests
* [x] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
