### PR TITLE
Add flow type of ObservableMap.replace

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -290,6 +290,7 @@ declare module 'mobx' {
     ): void;
     merge(other: ObservableMap<V> | IKeyValueMap<V>): ObservableMap<V>;
     clear(): void;
+    replace(other: ObservableMap<V> | IKeyValueMap<V>): ObservableMap<V>;
     size: number;
     toJS(): IKeyValueMap<V>;
     toJs(): IKeyValueMap<V>;


### PR DESCRIPTION
Flowtype definition was missing only for `observable.map#replace`.