### PR TITLE
add an es-modules build (referenced with pkg.module)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ test/typescript/typescript-tests.js
 test/perf/perf.txt
 .vscode
 dist/
-.build/
+.build*/
 yarn.lock
 .idea
-.rpt2_cache

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Simple, scalable state management.",
   "main": "lib/mobx.js",
   "umd:main": "lib/mobx.umd.js",
+  "module": "lib/mobx.module.js",
   "typings": "lib/mobx.d.ts",
   "scripts": {
     "test": "npm run quick-build && npm run tape",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,71 +1,86 @@
-const rollup = require('rollup');
-const fs = require('fs-extra');
-const path = require('path');
-const ts = require('typescript');
-const exec = require('child_process').execSync;
+const rollup = require("rollup");
+const fs = require("fs-extra");
+const path = require("path");
+const ts = require("typescript");
+const exec = require("child_process").execSync;
 
 // make sure we're in the right folder
-process.chdir(path.resolve(__dirname, '..'));
+process.chdir(path.resolve(__dirname, ".."));
 
-const binFolder = path.resolve('node_modules/.bin/');
+const binFolder = path.resolve("node_modules/.bin/");
 
-fs.removeSync('lib');
-fs.removeSync('.build');
+fs.removeSync("lib");
+fs.removeSync(".build.cjs");
+fs.removeSync(".build.es");
 
-function runTypeScriptBuild() {
-	console.log('Running typescript build.');
-	const tsConfig = path.resolve('tsconfig.json');
+function runTypeScriptBuild(outDir, target, declarations) {
+	console.log(`Running typescript build (target: ${ts.ScriptTarget[target]}) in ${outDir}/`);
+
+	const tsConfig = path.resolve("tsconfig.json");
 	const json = ts.parseConfigFileTextToJson(
 		tsConfig,
 		ts.sys.readFile(tsConfig),
 		true
 	);
 
-	const { options } = ts.parseJsonConfigFileContent(json.config, ts.sys, path.dirname(tsConfig));
+	const { options } = ts.parseJsonConfigFileContent(
+		json.config,
+		ts.sys,
+		path.dirname(tsConfig)
+	);
+
+	options.target = target;
+	options.outDir = outDir;
+	options.declaration = declarations;
 
 	options.module = ts.ModuleKind.ES2015;
-	options.outDir = path.resolve('.', '.build');
-	options.declarationDir = path.resolve('.', 'lib');
 	options.importHelpers = true;
 	options.noEmitHelpers = true;
+	if (declarations)
+		options.declarationDir = path.resolve(".", "lib");
 
-	const rootFile = path.resolve('src', 'mobx.ts');
+	const rootFile = path.resolve("src", "mobx.ts");
 	const host = ts.createCompilerHost(options, true);
 	const prog = ts.createProgram([rootFile], options, host);
 	const result = prog.emit();
 	if (result.emitSkipped) {
 		const message = result.diagnostics.map(d =>
 			`${ts.DiagnosticCategory[d.category]} ${d.code} (${d.file}:${d.start}): ${d.messageText}`
-		).join('\n');
+		).join("\n");
 
 		throw new Error(`Failed to compile typescript:\n\n${message}`);
 	}
 }
 
-function generateBundledModule() {
-	console.log('Generating lib/mobx.js bundle.');
+
+const rollupPlugins = [
+	require("rollup-plugin-node-resolve")(),
+	require("rollup-plugin-progress")(),
+	require("rollup-plugin-filesize")()
+];
+
+function generateBundledModule(inputFile, outputFile, format) {
+
+	console.log(`Generating ${outputFile} bundle.`);
+
 	return rollup.rollup({
-		entry: '.build/mobx.js',
-		plugins: [
-			require('rollup-plugin-node-resolve')(),
-			require('rollup-plugin-progress')(),
-			require('rollup-plugin-filesize')()
-		]
+		entry: inputFile,
+		plugins: rollupPlugins
 	}).then(bundle => bundle.write({
-		dest: 'lib/mobx.js',
-		format: 'cjs',
-		banner: '/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */',
-		exports: 'named',
+		dest: outputFile,
+		format,
+		banner: "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */",
+		exports: "named"
 	}));
 }
 
 function generateUmd() {
-	console.log('Generating mobx.umd.js');
-	exec('browserify -s mobx -e lib/mobx.js -o lib/mobx.umd.js');
+	console.log("Generating mobx.umd.js");
+	exec("browserify -s mobx -e lib/mobx.js -o lib/mobx.umd.js");
 }
 
 function generateMinified() {
-	console.log('Generating mobx.min.js and mobx.umd.min.js');
+	console.log("Generating mobx.min.js and mobx.umd.min.js");
 	exec(
 		`${binFolder}/uglifyjs -m sort,toplevel -c warnings=false --screw-ie8 --preamble "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */" --source-map lib/mobx.min.js.map -o lib/mobx.min.js lib/mobx.js`
 	);
@@ -75,13 +90,28 @@ function generateMinified() {
 }
 
 function copyFlowDefinitions() {
-	console.log('Copying flowtype definitions');
+	console.log("Copying flowtype definitions");
 	exec(`${binFolder}/ncp flow-typed/mobx.js lib/mobx.js.flow`);
 }
 
 function build() {
-	runTypeScriptBuild();
-	return generateBundledModule().then(() => {
+	runTypeScriptBuild(".build.cjs", ts.ScriptTarget.ES5, true);
+	runTypeScriptBuild(".build.es", ts.ScriptTarget.ES2015, false);
+	return Promise.all([
+
+		generateBundledModule(
+			path.resolve(".build.cjs", "mobx.js"),
+			path.resolve("lib", "mobx.js"),
+			"cjs"
+		),
+
+		generateBundledModule(
+			path.resolve(".build.es", "mobx.js"),
+			path.resolve("lib", "mobx.module.js"),
+			"es"
+		)
+
+	]).then(() => {
 		generateUmd();
 		generateMinified();
 		copyFlowDefinitions();

--- a/src/api/observable.ts
+++ b/src/api/observable.ts
@@ -193,7 +193,10 @@ export const observable: IObservableFactory & IObservableFactories & {
 } = createObservable as any;
 
 // weird trick to keep our typings nicely with our funcs, and still extend the observable function
-Object.keys(IObservableFactories.prototype).forEach(key => observable[key] = IObservableFactories.prototype[key]);
+// ES6 class methods aren't enumerable, can't use Object.keys
+Object.getOwnPropertyNames(IObservableFactories.prototype)
+	.filter(name => name !== "constructor")
+	.forEach(name => observable[name] = IObservableFactories.prototype[name]);
 
 observable.deep.struct = observable.struct;
 observable.ref.struct = function() {

--- a/src/api/observable.ts
+++ b/src/api/observable.ts
@@ -183,7 +183,7 @@ export class IObservableFactories {
 	}
 }
 
-export var observable: IObservableFactory & IObservableFactories & {
+export const observable: IObservableFactory & IObservableFactories & {
 	deep: {
 		struct<T>(initialValue?: T): T
 	},

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -74,10 +74,7 @@ export interface IArrayWillSplice<T> {
  */
 let OBSERVABLE_ARRAY_BUFFER_SIZE = 0;
 
-// Typescript workaround to make sure ObservableArray extends Array
-export class StubArray {
-}
-StubArray.prototype = [];
+export class StubArray extends Array { }
 
 class ObservableArrayAdministration<T> implements IInterceptable<IArrayWillChange<T> | IArrayWillSplice<T>>, IListenable {
 	atom: BaseAtom;

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -77,7 +77,11 @@ let OBSERVABLE_ARRAY_BUFFER_SIZE = 0;
 // Typescript workaround to make sure ObservableArray extends Array
 export class StubArray {
 }
-StubArray.prototype = [];
+const setProto: (o, p) => void = typeof Object["setPrototypeOf"] !== "undefined"
+	? Object["setPrototypeOf"]
+	: (obj, proto) => obj.__proto__ = proto
+	;
+setProto(StubArray.prototype, Array.prototype);
 
 class ObservableArrayAdministration<T> implements IInterceptable<IArrayWillChange<T> | IArrayWillSplice<T>>, IListenable {
 	atom: BaseAtom;

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -75,13 +75,19 @@ export interface IArrayWillSplice<T> {
 let OBSERVABLE_ARRAY_BUFFER_SIZE = 0;
 
 // Typescript workaround to make sure ObservableArray extends Array
-export class StubArray {
+export class StubArray { }
+function inherit(ctor, proto) {
+	if (typeof Object["setPrototypeOf"] !== "undefined") {
+		Object["setPrototypeOf"](ctor.prototype, proto);
+	} else if (typeof ctor.prototype.__proto__ !== "undefined") {
+		ctor.prototype.__proto__ = proto;
+	} else {
+		ctor["prototype"] = proto;
+	}
 }
-const setProto: (o, p) => void = typeof Object["setPrototypeOf"] !== "undefined"
-	? Object["setPrototypeOf"]
-	: (obj, proto) => obj.__proto__ = proto
-	;
-setProto(StubArray.prototype, Array.prototype);
+inherit(StubArray, Array.prototype);
+
+
 
 class ObservableArrayAdministration<T> implements IInterceptable<IArrayWillChange<T> | IArrayWillSplice<T>>, IListenable {
 	atom: BaseAtom;

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -74,7 +74,10 @@ export interface IArrayWillSplice<T> {
  */
 let OBSERVABLE_ARRAY_BUFFER_SIZE = 0;
 
-export class StubArray extends Array { }
+// Typescript workaround to make sure ObservableArray extends Array
+export class StubArray {
+}
+StubArray.prototype = [];
 
 class ObservableArrayAdministration<T> implements IInterceptable<IArrayWillChange<T> | IArrayWillSplice<T>>, IListenable {
 	atom: BaseAtom;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,7 @@
         "moduleResolution": "node",
         "lib": [
             "es5",
-            "dom",
-            "es2015.promise"
+            "dom"
         ]
     },
     "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
         "moduleResolution": "node",
         "lib": [
             "es5",
-            "dom"
+            "dom",
+            "es2015.promise"
         ]
     },
     "exclude": [


### PR DESCRIPTION
This output file (mobx.module.js) is built with the ES2015 typescript target, so no ES2015 features get transpiled, and es module exports are preserved. This allows consumers of mobx to take advantage of
tree-shaking bundlers such as rollupjs and webpack 2.

I was considering using the `.mjs` extension, as that looks like it will be the most likely extension for es modules, but as it's not supported in node at all at the moment, I decided against it. 

## Point of discussion: 

Should es2015+ features still be transpiled?

I'm not sure what the standard practice here is. Webpack usage typically avoids processing code from `node_modules`, so a consumer trying to include the `mobx` module version would have to be made aware that they need to include mobx in their transpilation process if they're targeting ES5. However, from what I've seen rollup configs usually include the `node-resolve` plugin _before_ things like babel / typescript, so the module code would generally be included in that transpilation process as well.