### PR TITLE
workaround for webpack build not finding `exports`

### DIFF
--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -108,9 +108,17 @@ declare var __MOBX_DEVTOOLS_GLOBAL_HOOK__: { injectMobx: ((any) => void)};
 declare var module: { exports: any };
 declare var exports: any;
 
+const _exports = (
+	typeof exports !== 'undefined'
+		? exports
+		: typeof module !== 'undefined' && typeof module.exports !== 'undefined'
+			? module.exports
+			: {} /* what to do here, throw? */
+);
+
 if (typeof __MOBX_DEVTOOLS_GLOBAL_HOOK__ === "object") {
-	__MOBX_DEVTOOLS_GLOBAL_HOOK__.injectMobx(exports)
+	__MOBX_DEVTOOLS_GLOBAL_HOOK__.injectMobx(_exports)
 }
 
 // TODO: remove in 4.0, temporarily incompatibility fix for mobx-react@4.1.0 which accidentally uses default exports
-export default exports;
+_exports['default'] = _exports;


### PR DESCRIPTION
In Webpack 2, `exports` isn't passed in to the module's function scope, rather `module` is. I've modified the code here to be a bit more forgiving depending on the environment that the module is included in, but not sure what to do when neither `module` _or_ `exports` is available.

My first instinct in that scenario would be to just essentially no-op, as the rest of the module's exports are still intact (and this is essentially a hack anyways)

Fixes #1039