### PR TITLE
new Map()

### DIFF
--- a/docs/refguide/map.md
+++ b/docs/refguide/map.md
@@ -7,6 +7,8 @@ Observable maps are very useful if you don't want to react just to the change of
 Optionally takes an object, entries array or string keyed [ES6 map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) with initial values.
 Unlike ES6 maps, only strings are accepted as keys.
 
+Using ES6 Map constructor you can initialize observable map using observable(new Map()) or for class properties using the decorator @observable map = new Map().
+
 The following methods are exposed according to the [ES6 Map spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map):
 
 * `has(key)` Returns whether this map has an entry the provided key. Note that the presence of a key is an observable fact in itself.

--- a/docs/refguide/map.md
+++ b/docs/refguide/map.md
@@ -7,7 +7,7 @@ Observable maps are very useful if you don't want to react just to the change of
 Optionally takes an object, entries array or string keyed [ES6 map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) with initial values.
 Unlike ES6 maps, only strings are accepted as keys.
 
-Using ES6 Map constructor you can initialize observable map using observable(new Map()) or for class properties using the decorator @observable map = new Map().
+Using ES6 Map constructor you can initialize observable map using `observable(new Map())` or for class properties using the decorator `@observable map = new Map()`.
 
 The following methods are exposed according to the [ES6 Map spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map):
 


### PR DESCRIPTION
Important since ES5 maps are standard

I used the edit this page, but some reason it adds that last redundant edit there no matter what.