### PR TITLE
Add size-limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-browser-chrome": "npm run small-build && ( browserify test/*.js | tape-run --browser chrome | faucet )",
     "test-browser-safari": "npm run small-build && ( browserify test/*.js -t [ babelify --presets [ es2015 ] ] | tape-run --browser safari | faucet )",
     "test-browser-firefox": "npm run small-build && ( browserify test/*.js  | tape-run --browser firefox | faucet )",
-    "test-travis": "npm run full-test && npm run quick-build && istanbul cover tape test/*.js test/typescript/typescript-tests.js",
+    "test-travis": "npm run full-test && npm run quick-build && istanbul cover tape test/*.js test/typescript/typescript-tests.js && npm run size",
     "test-flow": "node_modules/.bin/flow check",
     "test-webpack": "node scripts/webpack-regression-tests.js",
     "coverage": "npm run quick-build && npm run build-tests && istanbul cover tape test/*.js test/typescript/typescript-tests.js",
@@ -26,7 +26,8 @@
     "build-typescript-tests": "tsc -p test/typescript",
     "build-babel-tests": "babel test/babel/babel-tests.js -o test/babel-tests.js",
     "use-minified": "cp lib/mobx.min.js lib/mobx.js",
-    "lint": "tslint -c tslint.json src/*.ts src/types/*.ts src/api/*.ts src/core/*.ts src/utils/*.ts"
+    "lint": "tslint -c tslint.json src/*.ts src/types/*.ts src/api/*.ts src/core/*.ts src/utils/*.ts",
+    "size": "size-limit 19KB lib/mobx.js"
   },
   "repository": {
     "type": "git",
@@ -67,6 +68,7 @@
     "rollup-plugin-filesize": "^1.3.2",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-progress": "^0.4.0",
+    "size-limit": "^0.2.0",
     "tape": "^4.2.2",
     "tape-run": "^2.1.0",
     "tslib": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build-babel-tests": "babel test/babel/babel-tests.js -o test/babel-tests.js",
     "use-minified": "cp lib/mobx.min.js lib/mobx.js",
     "lint": "tslint -c tslint.json src/*.ts src/types/*.ts src/api/*.ts src/core/*.ts src/utils/*.ts",
-    "size": "size-limit 19KB lib/mobx.js"
+    "size": "size-limit 20KB lib/mobx.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[size-limit](https://github.com/ai/size-limit) is a tool to show how many kilobytes your JS library increases the user bundle. You can set size budget and size-limit will prevent JavaScript libraries bloat on Travis CI.

It already used in Autoprefixer, PostCSS and JSS. For instance, I reduce Logux Client size 2x because I found some unexpected huge dependencies.

@mweststrate what do you think about this tool?