### PR TITLE
Improve typings of intercept method of observable array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.17
+
+* Improved typings of `IObservableArray.intercept`: use more restrictive types for `change` parameter of `handler`, by @bvanreeven
+
 # 3.1.16
 
 * Restored `default` export (and added warning), which broke code that was importing mobx like `import mobx from "mobx"`. Use `import * as mobx from "mobx"` or use named importes instead. By @andykog, see #1043, #1050

--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -160,7 +160,8 @@ declare module 'mobx' {
       listener: (changeData: IArrayChange<T> | IArraySplice<T>) => void,
       fireImmediately?: boolean,
     ): Lambda,
-    intercept(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda,
+    intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda,
+    intercept(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda, // TODO: remove in 4.0
     intercept<T>(
       handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>,
     ): Lambda, // TODO: remove in 4.0

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -21,7 +21,8 @@ const safariPrototypeSetterInheritanceBug = (() => {
 export interface IObservableArray<T> extends Array<T> {
 	spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[];
 	observe(listener: (changeData: IArrayChange<T>|IArraySplice<T>) => void, fireImmediately?: boolean): Lambda;
-	intercept(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda;
+	intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda;
+	intercept(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda; // TODO: remove in 4.0
 	intercept<T>(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda; // TODO: remove in 4.0
 	clear(): T[];
 	peek(): T[];
@@ -115,8 +116,8 @@ class ObservableArrayAdministration<T> implements IInterceptable<IArrayWillChang
 		return values;
 	}
 
-	intercept(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda {
-		return registerInterceptor<IArrayChange<T>|IArraySplice<T>>(this, handler);
+	intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda {
+		return registerInterceptor<IArrayWillChange<T>|IArrayWillSplice<T>>(this, handler);
 	}
 
 	observe(listener: (changeData: IArrayChange<T>|IArraySplice<T>) => void, fireImmediately = false): Lambda {
@@ -279,7 +280,7 @@ export class ObservableArray<T> extends StubArray {
 		}
 	}
 
-	intercept(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda {
+	intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda {
 		return this.$mobx.intercept(handler);
 	}
 

--- a/test/typescript/typescript-tests.ts
+++ b/test/typescript/typescript-tests.ts
@@ -1,7 +1,8 @@
 /// <reference path='tape.d.ts' />
 import {
     observe, computed, observable, autorun, autorunAsync, extendObservable, action,
-    IObservableObject, IObservableArray, IArrayChange, IArraySplice, IObservableValue, isObservable, isObservableObject,
+    IObservableObject, IObservableArray, IArrayChange, IArraySplice, IArrayWillChange, IArrayWillSplice,
+    IObservableValue, isObservable, isObservableObject,
     extras, Atom, transaction, IObjectChange, spy, useStrict, isAction
 } from "../../lib/mobx";
 import * as test from 'tape';
@@ -139,11 +140,17 @@ test('scope', function(t) {
 
 test('typing', function(t) {
     var ar:IObservableArray<number> = observable([1,2]);
+    ar.intercept((c:IArrayWillChange<number>|IArrayWillSplice<number>) => {
+        console.log(c.type);
+    });
     ar.observe((d:IArrayChange<number>|IArraySplice<number>) => {
         console.log(d.type);
     });
 
     var ar2:IObservableArray<number> = observable([1,2]);
+    ar2.intercept((c:IArrayWillChange<number>|IArrayWillSplice<number>) => {
+        console.log(c.type);
+    });
     ar2.observe((d:IArrayChange<number>|IArraySplice<number>) => {
         console.log(d.type);
     });


### PR DESCRIPTION
The `intercept` method of `ObservableArray` was using the types
`IArrayChange` and `IArraySplice`, but should have used the types
`IArrayWillChange` and `IArrayWillSplice` instead, as there are less
properties available when intercepting a change than when observing one.