### PR TITLE
WIP: Extending createTransformer to allow multiple arbitrary arguments in the transformer

### DIFF
--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -22,7 +22,8 @@ export function createTransformer<F extends (...args: any[]) => R, R>(transforme
 	return (function (...objects: any[]) {
 		// Limit the length to that of the transformer
 		// Without this, use in functions like .map() break because of extra unwanted arguments
-		objects = objects.slice(0, transformer.length);
+		// this is added at the start so that createTransformer can be run on prototypes
+		const memoizeObjects = [this, ...objects.slice(0, transformer.length)];
 
 		if (resetId !== globalState.resetId) {
 			objectCache = {};
@@ -30,7 +31,7 @@ export function createTransformer<F extends (...args: any[]) => R, R>(transforme
 			resetId = globalState.resetId;
 		}
 
-		const identifier = getMemoizationId(symbolCache, objects);
+		const identifier = getMemoizationId(symbolCache, memoizeObjects);
 		let reactiveTransformer = objectCache[identifier];
 		if (reactiveTransformer)
 			return reactiveTransformer.get();

--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -44,7 +44,18 @@ export function createTransformer<A, B>(transformer: ITransformer<A, B>, onClean
 	};
 }
 
-function getMemoizationId(object): string {
+function getMemoizationId(...objects: any[]): string {
+	// Get a key for each arg
+    const keys = objects.map(getObjectMemoizationId);
+
+    // Get the lengths of each key
+    const keyLengths = keys.map(key => key.length);
+
+    // The key lengths are added to the front so that f("a", "b") !== f("ab")
+    return `${keyLengths.join(",")}:${keys.join("")}`;
+}
+
+function getObjectMemoizationId(object): string {
 	switch (typeof object) {
 		case "symbol": throw new Error("Symbols are not supported as createTransformer arguments.");
 		case "undefined": return "undefined";
@@ -60,7 +71,7 @@ function getMemoizationId(object): string {
         default: {
             if (object === null) return "null";
 
-			let tid = object.$transformId;
+			let tid = object.$transformId as number;
 			if (tid === undefined) {
 				tid = getNextId();
 				addHiddenProp(object, "$transformId", tid);

--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -38,7 +38,7 @@ export function createTransformer<F extends (...args: any[]) => R, R>(transforme
 	// This construction is used to avoid leaking refs to the objectCache directly
 	let resetId = globalState.resetId;
 
-	return (function transformedWrapper (...objects: any[]) {
+	function transformedWrapper (...objects: any[]) {
 		// Poor man's new.target check
 		const constructorCall = this instanceof transformedWrapper && !this.$constructed;
 		if (constructorCall) addHiddenProp(this, "$constructed", true);
@@ -78,7 +78,12 @@ export function createTransformer<F extends (...args: any[]) => R, R>(transforme
 		reactiveTransformer = objectCache[identifier];
 
 		return reactiveTransformer.get();
-	}) as F;
+	}
+
+	// Give the returned function the same arity as the input
+	Object.defineProperty(transformedWrapper, "length", {value: transformer.length});
+	
+	return transformedWrapper as F;
 }
 
 // Calls onCleanup from onBecomeUnobserved

--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -4,6 +4,24 @@ import {globalState} from "../core/globalstate";
 
 export type ITransformer<A, B> = (object: A) => B;
 
+// Method decorator
+export function transformer<F extends (...args: any[]) => R, R>(transformer: F): F
+export function transformer<T>(object: T, name: keyof T, descriptor?: PropertyDescriptor): void;
+export function transformer() {
+	switch(arguments.length) {
+		case 1: return createTransformer(arguments[0]);
+		case 3: {
+			const object = arguments[0] as {};
+			const name = arguments[1] as string;
+			const descriptor = arguments[2] as PropertyDescriptor;
+
+			descriptor.value = createTransformer(descriptor.value);
+
+			return descriptor;
+		}
+	}
+}
+
 // Doesn't currently support the onCleanup for multiple arguments because I don't know how to type it
 export function createTransformer<F extends new (...args: any[]) => R, R>(transformer: F): F
 export function createTransformer<F extends (...args: any[]) => R, R>(transformer: F): F

--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -19,7 +19,7 @@ export function createTransformer<F extends (...args: any[]) => R, R>(transforme
 	// This construction is used to avoid leaking refs to the objectCache directly
 	let resetId = globalState.resetId;
 
-	return ((...objects: any[]) => {
+	return (function (...objects: any[]) {
 		// Limit the length to that of the transformer
 		// Without this, use in functions like .map() break because of extra unwanted arguments
 		objects = objects.slice(0, transformer.length);
@@ -36,7 +36,7 @@ export function createTransformer<F extends (...args: any[]) => R, R>(transforme
 			return reactiveTransformer.get();
 
 		// Not in cache; create a reactive view
-		objectCache[identifier] = new cleanupValue(() => transformer(...objects), lastValue => {
+		objectCache[identifier] = new cleanupValue(() => transformer.apply(this, objects), lastValue => {
 			delete objectCache[identifier];
 			if (onCleanup) onCleanup(lastValue, ...objects);
 		});

--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -44,15 +44,29 @@ export function createTransformer<A, B>(transformer: ITransformer<A, B>, onClean
 	};
 }
 
-function getMemoizationId(object) {
-	if(typeof object === 'string' || typeof object === 'number')
-		return object
-	if (object === null  || typeof object !== "object")
-		throw new Error("[mobx] transform expected some kind of object or primitive value, got: " + object);
-	let tid = object.$transformId;
-	if (tid === undefined) {
-		tid = getNextId();
-		addHiddenProp(object, "$transformId", tid);
-	}
-	return tid;
+function getMemoizationId(object): string {
+	switch (typeof object) {
+		case "symbol": throw new Error("Symbols are not supported as createTransformer arguments.");
+		case "undefined": return "undefined";
+
+        case "string":
+        case "number":
+        case "boolean":
+		{
+            // The type is added such that f("1") !== f(1)
+            return `${typeof object}:${object.toString()}`;
+		}
+
+        default: {
+            if (object === null) return "null";
+
+			let tid = object.$transformId;
+			if (tid === undefined) {
+				tid = getNextId();
+				addHiddenProp(object, "$transformId", tid);
+			}
+
+            return tid.toString();
+        }
+    }
 }

--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -30,9 +30,9 @@ export function createTransformer<F extends (...args: any[]) => R, R>(transforme
 	invariant(typeof transformer === "function", "createTransformer expects a function");
 
 	// Memoizes: object id -> reactive view that applies transformer to the object
-	let objectCache: {[key: string]: ComputedValue<R>} = {};
+	let objectCache: {[key: string]: ComputedValue<R>} = Object.create(null);
 	// Caches symbol -> string key
-	let symbolCache: {} = {};
+	let symbolCache: {} = Object.create(null);
 
 	// If the resetId changes, we will clear the object cache, see #163
 	// This construction is used to avoid leaking refs to the objectCache directly

--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -81,6 +81,8 @@ function getObjectMemoizationId(symbolCache: {}, object): string {
 
 			let tid = object.$transformId as number;
 			if (tid === undefined) {
+				if (!Object.isExtensible(object)) throw new Error("Transformed objects must be extensible.");
+
 				tid = getNextId();
 				addHiddenProp(object, "$transformId", tid);
 			}

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -55,7 +55,7 @@ export { action, isAction, runInAction, IActionFactory        } from "./api/acti
 
 export { expr                                                 } from "./api/expr";
 export { toJS                                                 } from "./api/tojs";
-export { ITransformer, createTransformer                      } from "./api/createtransformer";
+export { ITransformer, createTransformer, transformer         } from "./api/createtransformer";
 export { whyRun                                               } from "./api/whyrun";
 
 export { Lambda, isArrayLike                                  } from "./utils/utils";

--- a/test/api.js
+++ b/test/api.js
@@ -42,6 +42,7 @@ test('correct api should be exposed', function(t) {
 		'spy',
 		'toJS',
 		'transaction',
+		'transformer',
 		'untracked',
 		'useStrict',
 		'when',

--- a/test/transform.js
+++ b/test/transform.js
@@ -1376,3 +1376,41 @@ test('transform base class method and work with different this values', function
 
 	t.end();
 });
+
+test('transform class constructor', function(t) {
+	m.extras.resetGlobalState();
+
+	var observableObjs = m.observable.shallowArray();
+	var objs = [];
+
+	class Person {
+		constructor(name) {
+			this.name = name;
+		}
+	}
+
+	const transformedPersonConstructor = m.createTransformer(Person);
+
+	m.autorun(function() {
+		objs = observableObjs.map(function(name) {
+			return new transformedPersonConstructor(name);
+		});
+	});
+
+	observableObjs.push("Jeremy");
+	observableObjs.push("Jeremy");
+	t.equal(objs[0], objs[1]);
+	t.equal(objs[0].name, "Jeremy");
+	t.equal(objs[0] instanceof Person, true);
+
+	observableObjs.clear();
+	observableObjs.push("Jeremy");
+	observableObjs.push("Theresa");
+	t.notEqual(objs[0], objs[1]);
+	t.equal(objs[0].name, "Jeremy");
+	t.equal(objs[1].name, "Theresa");
+	t.equal(objs[0] instanceof Person, true);
+	t.equal(objs[1] instanceof Person, true);
+
+	t.end();
+});

--- a/test/transform.js
+++ b/test/transform.js
@@ -1334,6 +1334,40 @@ test('transform class method and maintain this value', function(t) {
 	t.end();
 });
 
+test('transform static class method', function(t) {
+	m.extras.resetGlobalState();
+
+	var observableObjs = m.observable.shallowArray();
+	var objs = [];
+
+	class Doubler {
+		static double(n) {
+			return [n * 2];
+		}
+	}
+	Doubler.double = m.createTransformer(Doubler.double);
+
+	m.autorun(function() {
+		objs = observableObjs.map(function(n) {
+			return Doubler.double(n);
+		});
+	});
+
+	observableObjs.push(10);
+	observableObjs.push(10);
+	t.equal(objs[0][0], 20);
+	t.equal(objs[0], objs[1]);
+
+	observableObjs.clear();
+	observableObjs.push(5);
+	observableObjs.push(10);
+	t.equal(objs[0][0], 10);
+	t.equal(objs[1][0], 20);
+	t.notEqual(objs[0], objs[1]);
+
+	t.end();
+});
+
 test('transform base class method and work with different this values', function(t) {
 	m.extras.resetGlobalState();
 

--- a/test/transform.js
+++ b/test/transform.js
@@ -1053,3 +1053,184 @@ test('transform with primitive key', function(t) {
 	t.end();
 });
 
+test('transform with object key as reference', function(t) {
+	m.extras.resetGlobalState();
+
+	var observableObjs = m.observable.shallowArray();
+	var objs = [];
+
+	var factory = m.createTransformer(function(key) {
+		return {};
+	});
+
+	m.autorun(function() {
+		objs = observableObjs.map(function(obj) {
+			return factory(obj);
+		});
+	});
+
+	const obj1 = {};
+	const obj2 = {};
+
+	observableObjs.push(obj1);
+	observableObjs.push(obj1);
+	t.equal(objs[0], objs[1]);
+	
+	observableObjs.clear();
+	observableObjs.push(obj1);
+	observableObjs.push(obj2);
+	t.notEqual(objs[0], objs[1]);
+
+	t.end();
+});
+
+test('transform with array key as reference', function(t) {
+	m.extras.resetGlobalState();
+
+	var observableObjs = m.observable.shallowArray();
+	var objs = [];
+
+	var factory = m.createTransformer(function(key) {
+		return {};
+	});
+
+	m.autorun(function() {
+		objs = observableObjs.map(function(obj) {
+			return factory(obj);
+		});
+	});
+
+	const obj1 = [];
+	const obj2 = [];
+
+	observableObjs.push(obj1);
+	observableObjs.push(obj1);
+	t.equal(objs[0], objs[1]);
+	
+	observableObjs.clear();
+	observableObjs.push(obj1);
+	observableObjs.push(obj2);
+	t.notEqual(objs[0], objs[1]);
+
+	t.end();
+});
+
+test('transform with null key', function(t) {
+	m.extras.resetGlobalState();
+
+	var observableObjs = m.observable.shallowArray();
+	var objs = [];
+
+	var factory = m.createTransformer(function(key) {
+		return {};
+	});
+
+	m.autorun(function() {
+		objs = observableObjs.map(function(obj) {
+			return factory(obj);
+		});
+	});
+
+	observableObjs.push(null);
+	observableObjs.push(null);
+	t.equal(objs[0], objs[1]);
+
+	observableObjs.clear();
+	observableObjs.push(null);
+	observableObjs.push("null");
+	t.notEqual(objs[0], objs[1]);
+
+	t.end();
+});
+
+test('transform with undefined key', function(t) {
+	m.extras.resetGlobalState();
+
+	var observableObjs = m.observable.shallowArray();
+	var objs = [];
+
+	var factory = m.createTransformer(function(key) {
+		return {};
+	});
+
+	m.autorun(function() {
+		objs = observableObjs.map(function(obj) {
+			return factory(obj);
+		});
+	});
+
+	observableObjs.push(undefined);
+	observableObjs.push(undefined);
+	t.equal(objs[0], objs[1]);
+
+	observableObjs.clear();
+	observableObjs.push(undefined);
+	observableObjs.push("undefined");
+	t.notEqual(objs[0], objs[1]);
+
+	t.end();
+});
+
+test('transform with boolean key', function(t) {
+	m.extras.resetGlobalState();
+
+	var observableObjs = m.observable.shallowArray();
+	var objs = [];
+
+	var factory = m.createTransformer(function(key) {
+		return {};
+	});
+
+	m.autorun(function() {
+		objs = observableObjs.map(function(obj) {
+			return factory(obj);
+		});
+	});
+
+	observableObjs.push(true);
+	observableObjs.push(true);
+	t.equal(objs[0], objs[1]);
+	
+	observableObjs.clear();
+	observableObjs.push(true);
+	observableObjs.push(false);
+	t.notEqual(objs[0], objs[1]);
+
+	observableObjs.clear();
+	observableObjs.push(true);
+	observableObjs.push("true");
+	t.notEqual(objs[0], objs[1]);
+
+	t.end();
+});
+
+test('transform with Symbol key', function(t) {
+	m.extras.resetGlobalState();
+
+	var observableObjs = m.observable.shallowArray();
+	var objs = [];
+
+	var factory = m.createTransformer(function(key) {
+		return {};
+	});
+
+	m.autorun(function() {
+		objs = observableObjs.map(function(obj) {
+			return factory(obj);
+		});
+	});
+
+	const symbol1 = Symbol();
+	const symbol2 = Symbol();
+
+	observableObjs.push(symbol1);
+	observableObjs.push(symbol1);
+	t.equal(objs[0], objs[1]);
+	
+	observableObjs.clear();
+	observableObjs.push(symbol1);
+	observableObjs.push(symbol2);
+	t.notEqual(objs[0], objs[1]);
+
+	t.end();
+});

--- a/test/transform.js
+++ b/test/transform.js
@@ -1448,3 +1448,13 @@ test('transform class constructor', function(t) {
 
 	t.end();
 });
+
+test('maintain function arity', function(t) {
+	m.extras.resetGlobalState();
+
+	t.equal(m.createTransformer(() => {}).length, 0);
+	t.equal(m.createTransformer((a) => {}).length, 1);
+	t.equal(m.createTransformer((a, b) => {}).length, 2);
+
+	t.end();
+});

--- a/test/transform.js
+++ b/test/transform.js
@@ -1234,3 +1234,69 @@ test('transform with Symbol key', function(t) {
 
 	t.end();
 });
+
+test('transform with zero keys', function(t) {
+	m.extras.resetGlobalState();
+
+	var observableObjs = m.observable.shallowArray();
+	var objs = [];
+
+	var factory = m.createTransformer(function() {
+		return {};
+	});
+
+	m.autorun(function() {
+		objs = observableObjs.map(function(obj) {
+			return factory();
+		});
+	});
+
+	observableObjs.push(undefined);
+	observableObjs.push(undefined);
+	t.equal(objs[0], objs[1]);
+
+	t.end();
+});
+
+test('transform with two keys', function(t) {
+	m.extras.resetGlobalState();
+
+	var observableObjs = m.observable.shallowArray();
+	var objs = [];
+
+	var factory = m.createTransformer(function(a, b) {
+		return `${a}, ${b}`;
+	});
+
+	m.autorun(function() {
+		objs = observableObjs.map(function(pair) {
+			return factory(pair[0], pair[1]);
+		});
+	});
+
+	observableObjs.push([1, 1]);
+	observableObjs.push([1, 1]);
+	t.equal(objs[0], objs[1]);
+
+	observableObjs.clear();
+	observableObjs.push([1, 1]);
+	observableObjs.push([0, 0]);
+	t.notEqual(objs[0], objs[1]);
+
+	observableObjs.clear();
+	observableObjs.push([1, 1]);
+	observableObjs.push([1, 0]);
+	t.notEqual(objs[0], objs[1]);
+
+	observableObjs.clear();
+	observableObjs.push([1, 1]);
+	observableObjs.push([0, 1]);
+	t.notEqual(objs[0], objs[1]);
+
+	observableObjs.clear();
+	observableObjs.push([1]);
+	observableObjs.push([1, 1]);
+	t.notEqual(objs[0], objs[1]);
+
+	t.end();
+});


### PR DESCRIPTION
I made an issue for this at #1087. That hasn't gotten any response yet and I know this may not be accepted, but I wanted to have a play with it to help familiarise myself with mobx anyway.

## Stuff to do
- [x] Allow any arbitrary type to be used as arguments in the transformer
- [x] Allow any number (zero or more) arguments to be used in the transformer
- [x] Allow the value of `this` to pass through, such that a method can be a transformer and still have access to its class members
- [x] Allow constructors to become transformers, such that using `new` respects memoization
- [x] Provide a `@transformer` decorator for methods
- [ ] Provide `transformer.global` function (needs a better name) to use a default global cache, calling `transformer.global(f)` multiple times with the same `f` should share a cache, see below
- [ ] Maybe allow `@transformer` to be applied directly to classes
- [ ] Maybe merge `@transformer` functionality into `@computed`
- [ ] Maybe rename the transformer concept to better reflect the generalised concept
- [ ] Document changes
- [ ] Work out if there are more places tests need to be added - maybe Babel? Performance?

**Bug of note**: Currently it throws an error if one of the arguments to the transformer is not extensible. To the best of my knowledge, this is not fixable without ES6 features, specifically Map. An argument could be made for this not throwing, and just silently not memoizing instead.

### `transformer.global`
Probably implemented as some version of:
```TS
transformer.global = createTransformer(createTransformer).bind(transformer);
```
Calling `createTransformer` directly creates a unique local cache, calling `createTransformer.global` shares a cache among all global calls. This is useful when interfacing with third-party libraries that don't expose their functions as transformers. `createTranformer` works transparently with constructors, so this also provides a way to memoize constructor calls without creating an explicit boilerplate factory.

## PR to do
* [x] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [x] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

I'm not a particularly experienced javascript/TS developer, so I'm uncomfortable making hard claims about this working with any arbitrary object and not breaking backwards compatibility. To the best of my knowledge it does both of those things, but it could use some more stressful unit tests from someone who might know some weird edge cases. 