### PR TITLE
Introduce prettier to keep the format of the codebase consistent

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -1,550 +1,488 @@
-declare module 'mobx' {
-  declare type Extras = {
-    allowStateChanges: <T>(allowStateChanges: boolean, func: () => T) => T,
-    getAtom: (thing: any, property?: string) => IDepTreeNode,
-    getDebugName: (thing: any, property?: string) => string,
-    getDependencyTree: (thing: any, property?: string) => IDependencyTree,
-    getGlobalState: () => any,
-    getObserverTree: (thing: any, property?: string) => IObserverTree,
-    isComputingDerivation: () => boolean,
-    isSpyEnabled: () => boolean,
-    resetGlobalState: () => void,
-    shareGlobalState: () => void,
-    spyReport: (event: any) => boolean,
-    spyReportEnd: (change?: any) => void,
-    spyReportStart: (event: any) => void,
-    setReactionScheduler: (fn: (f: () => void) => void) => void,
-	onReactionError: (error: Error) => void,
-  };
-	
-  declare var extras: Extras;
+declare module "mobx" {
+    declare type Extras = {
+        allowStateChanges: <T>(allowStateChanges: boolean, func: () => T) => T,
+        getAtom: (thing: any, property?: string) => IDepTreeNode,
+        getDebugName: (thing: any, property?: string) => string,
+        getDependencyTree: (thing: any, property?: string) => IDependencyTree,
+        getGlobalState: () => any,
+        getObserverTree: (thing: any, property?: string) => IObserverTree,
+        isComputingDerivation: () => boolean,
+        isSpyEnabled: () => boolean,
+        resetGlobalState: () => void,
+        shareGlobalState: () => void,
+        spyReport: (event: any) => boolean,
+        spyReportEnd: (change?: any) => void,
+        spyReportStart: (event: any) => void,
+        setReactionScheduler: (fn: (f: () => void) => void) => void,
+        onReactionError: (error: Error) => void
+    }
 
-  declare type IObservableMapInitialValues<V> =
-    | IMapEntries<V>
-    | IKeyValueMap<V>
-    | IMap<string, V>;
+    declare var extras: Extras
 
-  declare interface IReactionOptions {
-    context?: any,
-    fireImmediately?: boolean,
-    delay?: number,
-    compareStructural?: boolean,
-    name?: string,
-  }
+    declare type IObservableMapInitialValues<V> = IMapEntries<V> | IKeyValueMap<V> | IMap<string, V>
 
-  declare interface IInterceptable<T> {
-    interceptors: IInterceptor<T>[] | any,
-    intercept(handler: IInterceptor<T>): Lambda,
-  }
+    declare interface IReactionOptions {
+        context?: any,
+        fireImmediately?: boolean,
+        delay?: number,
+        compareStructural?: boolean,
+        name?: string
+    }
 
-  declare type _ = {
-    getAdministration: (thing: any, property?: string) => any,
-    resetGlobalState: () => void,
-  };
+    declare interface IInterceptable<T> {
+        interceptors: IInterceptor<T>[] | any,
+        intercept(handler: IInterceptor<T>): Lambda
+    }
 
-  declare type ITransformer<A, B> = (object: A) => B;
+    declare type _ = {
+        getAdministration: (thing: any, property?: string) => any,
+        resetGlobalState: () => void
+    }
 
-  declare type IInterceptor<T> = (change: T) => T;
+    declare type ITransformer<A, B> = (object: A) => B
 
-  declare type IMapEntry<V> = [string, V];
+    declare type IInterceptor<T> = (change: T) => T
 
-  declare type IMapEntries<V> = IMapEntry<V>[];
+    declare type IMapEntry<V> = [string, V]
 
-  declare interface IMap<K, V> {
-    clear(): void,
-    delete(key: K): boolean,
-    forEach(
-      callbackfn: (value: V, index: K, map: IMap<K, V>) => void,
-      thisArg?: any,
-    ): void,
-    get(key: K): V | any,
-    has(key: K): boolean,
-    set(key: K, value?: V): any,
-    size: number,
-  }
+    declare type IMapEntries<V> = IMapEntry<V>[]
 
-  declare type isObservableMap = (x: any) => boolean;
+    declare interface IMap<K, V> {
+        clear(): void,
+        delete(key: K): boolean,
+        forEach(callbackfn: (value: V, index: K, map: IMap<K, V>) => void, thisArg?: any): void,
+        get(key: K): V | any,
+        has(key: K): boolean,
+        set(key: K, value?: V): any,
+        size: number
+    }
 
-  declare type ISimpleEventListener = {
-    (): void,
-  };
+    declare type isObservableMap = (x: any) => boolean
 
-  declare interface IComputedValueOptions<T> {
-    compareStructural?: boolean,
-    name?: string,
-    setter?: (value: T) => void,
-    context?: any,
-  }
+    declare type ISimpleEventListener = {
+        (): void
+    }
 
-  declare type IDerivationState =
-    | 'NOT_TRACKING'
-    | 'UP_TO_DATE'
-    | 'POSSIBLY_STALE'
-    | 'STALE';
-  declare type PropertyDescriptor = any;
+    declare interface IComputedValueOptions<T> {
+        compareStructural?: boolean,
+        name?: string,
+        setter?: (value: T) => void,
+        context?: any
+    }
 
-  declare interface IComputed {
-    <T>(func: () => T, setter?: (value: T) => void): IComputedValue<T>,
-    <T>(func: () => T, options: IComputedValueOptions<T>): IComputedValue<T>,
-    (target: Object, key: string, baseDescriptor?: PropertyDescriptor): void,
-    struct(
-      target: Object,
-      key: string,
-      baseDescriptor?: PropertyDescriptor,
-    ): void,
-  }
+    declare type IDerivationState = "NOT_TRACKING" | "UP_TO_DATE" | "POSSIBLY_STALE" | "STALE"
+    declare type PropertyDescriptor = any
 
-  declare interface IDependencyTree {
-    name: string,
-    dependencies?: IDependencyTree[],
-  }
+    declare interface IComputed {
+        <T>(func: () => T, setter?: (value: T) => void): IComputedValue<T>,
+        <T>(func: () => T, options: IComputedValueOptions<T>): IComputedValue<T>,
+        (target: Object, key: string, baseDescriptor?: PropertyDescriptor): void,
+        struct(target: Object, key: string, baseDescriptor?: PropertyDescriptor): void
+    }
 
-  declare interface IObserverTree {
-    name: string,
-    observers?: IObserverTree[],
-  }
+    declare interface IDependencyTree {
+        name: string,
+        dependencies?: IDependencyTree[]
+    }
 
-  declare interface IAtom {}
+    declare interface IObserverTree {
+        name: string,
+        observers?: IObserverTree[]
+    }
 
-  declare interface IComputedValue<T> {
-    get(): T,
-    set(value: T): void,
-    observe(
-      listener: (newValue: T, oldValue: T) => void,
-      fireImmediately?: boolean,
-    ): Lambda,
-  }
+    declare interface IAtom {}
 
-  declare interface IObservable {
-    diffValue: number,
-    lastAccessedBy: number,
-    lowestObserverState: IDerivationState,
-    isPendingUnobservation: boolean,
-    observers: IDerivation[],
-    observersIndexes: {},
-    onBecomeUnobserved(): any,
-  }
+    declare interface IComputedValue<T> {
+        get(): T,
+        set(value: T): void,
+        observe(listener: (newValue: T, oldValue: T) => void, fireImmediately?: boolean): Lambda
+    }
 
-  declare interface IDepTreeNode {
-    name: string,
-    observing?: IObservable[],
-  }
+    declare interface IObservable {
+        diffValue: number,
+        lastAccessedBy: number,
+        lowestObserverState: IDerivationState,
+        isPendingUnobservation: boolean,
+        observers: IDerivation[],
+        observersIndexes: {},
+        onBecomeUnobserved(): any
+    }
 
-  declare interface IDerivation {
-    name: string,
-    observing: IObservable[],
-    newObserving: ?(IObservable[]),
-    dependenciesState: IDerivationState,
-    runId: number,
-    unboundDepsCount: number,
-    ___mapid: string,
-    onBecomeStale(): any,
-    recoverFromError(): any,
-  }
+    declare interface IDepTreeNode {
+        name: string,
+        observing?: IObservable[]
+    }
 
-  declare interface IReactionPublic {
-    dispose: () => void,
-  }
+    declare interface IDerivation {
+        name: string,
+        observing: IObservable[],
+        newObserving: ?(IObservable[]),
+        dependenciesState: IDerivationState,
+        runId: number,
+        unboundDepsCount: number,
+        ___mapid: string,
+        onBecomeStale(): any,
+        recoverFromError(): any
+    }
 
-  declare interface IListenable {
-    changeListeners: any,
-    observe(
-      handler: (change: any, oldValue?: any) => void,
-      fireImmediately?: boolean,
-    ): Lambda,
-  }
+    declare interface IReactionPublic {
+        dispose: () => void
+    }
 
-  declare interface IObservableArray<T> extends Array<T> {
-    spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[],
-    observe(
-      listener: (changeData: IArrayChange<T> | IArraySplice<T>) => void,
-      fireImmediately?: boolean,
-    ): Lambda,
-    intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda,
-    intercept(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda, // TODO: remove in 4.0
-    intercept<T>(
-      handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>,
-    ): Lambda, // TODO: remove in 4.0
-    clear(): T[],
-    peek(): T[],
-    replace(newItems: T[]): T[],
-    find(
-      predicate: (item: T, index: number, array: Array<T>) => boolean,
-      thisArg?: any,
-      fromIndex?: number,
-    ): T | any,
-    findIndex(
-      predicate: (item: T, index: number, array: Array<T>) => boolean,
-      thisArg?: any,
-      fromIndex?: number,
-    ): number,
-    remove(value: T): boolean,
-  }
+    declare interface IListenable {
+        changeListeners: any,
+        observe(handler: (change: any, oldValue?: any) => void, fireImmediately?: boolean): Lambda
+    }
 
-  declare interface IArrayChange<T> {
-    type: 'update',
-    object: IObservableArray<T>,
-    index: number,
-    newValue: T,
-    oldValue: T,
-  }
+    declare interface IObservableArray<T> extends Array<T> {
+        spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[],
+        observe(
+            listener: (changeData: IArrayChange<T> | IArraySplice<T>) => void,
+            fireImmediately?: boolean
+        ): Lambda,
+        intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda,
+        intercept(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda, // TODO: remove in 4.0
+        intercept<T>(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda, // TODO: remove in 4.0
+        clear(): T[],
+        peek(): T[],
+        replace(newItems: T[]): T[],
+        find(
+            predicate: (item: T, index: number, array: Array<T>) => boolean,
+            thisArg?: any,
+            fromIndex?: number
+        ): T | any,
+        findIndex(
+            predicate: (item: T, index: number, array: Array<T>) => boolean,
+            thisArg?: any,
+            fromIndex?: number
+        ): number,
+        remove(value: T): boolean
+    }
 
-  declare interface IArraySplice<T> {
-    type: 'splice',
-    object: IObservableArray<T>,
-    index: number,
-    added: T[],
-    addedCount: number,
-    removed: T[],
-    removedCount: number,
-  }
+    declare interface IArrayChange<T> {
+        type: "update",
+        object: IObservableArray<T>,
+        index: number,
+        newValue: T,
+        oldValue: T
+    }
 
-  declare interface IArrayWillChange<T> {
-    type: 'update',
-    object: IObservableArray<T>,
-    index: number,
-    newValue: T,
-  }
+    declare interface IArraySplice<T> {
+        type: "splice",
+        object: IObservableArray<T>,
+        index: number,
+        added: T[],
+        addedCount: number,
+        removed: T[],
+        removedCount: number
+    }
 
-  declare interface IArrayWillSplice<T> {
-    type: 'splice',
-    object: IObservableArray<T>,
-    index: number,
-    added: T[],
-    removedCount: number,
-  }
+    declare interface IArrayWillChange<T> {
+        type: "update",
+        object: IObservableArray<T>,
+        index: number,
+        newValue: T
+    }
 
-  declare interface IKeyValueMap<V> {
-    [key: string]: V,
-  }
+    declare interface IArrayWillSplice<T> {
+        type: "splice",
+        object: IObservableArray<T>,
+        index: number,
+        added: T[],
+        removedCount: number
+    }
 
-  declare interface IMapChange<T> {
-    object: ObservableMap<T>,
-    type: 'update' | 'add' | 'delete',
-    name: string,
-    newValue?: any,
-    oldValue?: any,
-  }
+    declare interface IKeyValueMap<V> {
+        [key: string]: V
+    }
 
-  declare interface IMapWillChange<T> {
-    object: ObservableMap<T>,
-    type: 'update' | 'add' | 'delete',
-    name: string,
-    newValue?: any,
-  }
+    declare interface IMapChange<T> {
+        object: ObservableMap<T>,
+        type: "update" | "add" | "delete",
+        name: string,
+        newValue?: any,
+        oldValue?: any
+    }
 
-  declare interface IObservableObject {}
+    declare interface IMapWillChange<T> {
+        object: ObservableMap<T>,
+        type: "update" | "add" | "delete",
+        name: string,
+        newValue?: any
+    }
 
-  declare interface IObjectChange {
-    name: string,
-    object: any,
-    type: 'update' | 'add',
-    oldValue?: any,
-    newValue: any,
-  }
+    declare interface IObservableObject {}
 
-  declare interface IObjectWillChange {
-    object: any,
-    type: 'update' | 'add',
-    name: string,
-    newValue: any,
-  }
+    declare interface IObjectChange {
+        name: string,
+        object: any,
+        type: "update" | "add",
+        oldValue?: any,
+        newValue: any
+    }
 
-  declare interface IValueWillChange<T> {
-    object: any,
-    type: 'update',
-    newValue: T,
-  }
+    declare interface IObjectWillChange {
+        object: any,
+        type: "update" | "add",
+        name: string,
+        newValue: any
+    }
 
-  declare interface IValueDidChange<T> extends IValueWillChange<T> {
-    oldValue: T | typeof undefined,
-  }
+    declare interface IValueWillChange<T> {
+        object: any,
+        type: "update",
+        newValue: T
+    }
 
-  declare interface IObservableValue<T> {
-    get(): T,
-    set(value: T): void,
-    intercept(handler: IInterceptor<IValueWillChange<T>>): Lambda,
-    observe(
-      listener: (change: IValueDidChange<T>) => void,
-      fireImmediately?: boolean,
-    ): Lambda,
-  }
+    declare interface IValueDidChange<T> extends IValueWillChange<T> {
+        oldValue: T | typeof undefined
+    }
 
-  declare interface IObservableFactory {
-    (value: any, key?: string, baseDescriptor?: PropertyDescriptor): any,
-  }
+    declare interface IObservableValue<T> {
+        get(): T,
+        set(value: T): void,
+        intercept(handler: IInterceptor<IValueWillChange<T>>): Lambda,
+        observe(listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda
+    }
 
-  declare class IObservableFactories {
-    box<T>(value?: T, name?: string): IObservableValue<T>,
-    shallowBox<T>(value?: T, name?: string): IObservableValue<T>,
-    array<T>(initialValues?: T[], name?: string): IObservableArray<T>,
-    shallowArray<T>(initialValues?: T[], name?: string): IObservableArray<T>,
-    map<T>(
-      initialValues?: IObservableMapInitialValues<T>,
-      name?: string,
-    ): ObservableMap<T>,
-    shallowMap<T>(
-      initialValues?: IObservableMapInitialValues<T>,
-      name?: string,
-    ): ObservableMap<T>,
-    object<T>(props: T, name?: string): T & IObservableObject,
-    shallowObject<T>(props: T, name?: string): T & IObservableObject,
-    ref(target: Object, property?: string, descriptor?: PropertyDescriptor): any,
-    shallow(
-      target: Object,
-      property?: string,
-      descriptor?: PropertyDescriptor,
-    ): any,
-    deep(target: Object, property?: string, descriptor?: PropertyDescriptor): any,
-  }
+    declare interface IObservableFactory {
+        (value: any, key?: string, baseDescriptor?: PropertyDescriptor): any
+    }
 
-  declare interface Iterator<T> {
-    next(): {
-      done: boolean,
-      value?: T,
-    },
-  }
+    declare class IObservableFactories {
+        box<T>(value?: T, name?: string): IObservableValue<T>,
+        shallowBox<T>(value?: T, name?: string): IObservableValue<T>,
+        array<T>(initialValues?: T[], name?: string): IObservableArray<T>,
+        shallowArray<T>(initialValues?: T[], name?: string): IObservableArray<T>,
+        map<T>(initialValues?: IObservableMapInitialValues<T>, name?: string): ObservableMap<T>,
+        shallowMap<T>(
+            initialValues?: IObservableMapInitialValues<T>,
+            name?: string
+        ): ObservableMap<T>,
+        object<T>(props: T, name?: string): T & IObservableObject,
+        shallowObject<T>(props: T, name?: string): T & IObservableObject,
+        ref(target: Object, property?: string, descriptor?: PropertyDescriptor): any,
+        shallow(target: Object, property?: string, descriptor?: PropertyDescriptor): any,
+        deep(target: Object, property?: string, descriptor?: PropertyDescriptor): any
+    }
 
-  declare interface Lambda {
-    (): void,
-    name?: string,
-  }
+    declare interface Iterator<T> {
+        next(): {
+            done: boolean,
+            value?: T
+        }
+    }
 
-  declare interface IActionFactory {
-    (a1: any, a2?: any, a3?: any, a4?: any, a6?: any): any,
-    bound(
-      target: Object,
-      propertyKey: string,
-      descriptor?: PropertyDescriptor,
-    ): void,
-  }
+    declare interface Lambda {
+        (): void,
+        name?: string
+    }
 
-  declare class ObservableMap<V> {
-    $mobx: {},
-    name: string,
-    interceptors: any,
-    changeListeners: any,
-    constructor(
-      initialData?: IMapEntries<V> | IKeyValueMap<V>,
-      valueModeFunc?: Function,
-    ): this,
-    has(key: string): boolean,
-    set(key: string, value: V): void,
-    delete(key: string): boolean,
-    get(key: string): V,
-    keys(): string[] & Iterator<string>,
-    values(): V[] & Iterator<V>,
-    entries(): IMapEntries<V> & Iterator<IMapEntry<V>>,
-    forEach(
-      callback: (value: V, key: string, object: IKeyValueMap<V>) => void,
-      thisArg?: any,
-    ): void,
-    merge(other: ObservableMap<V> | IKeyValueMap<V>): ObservableMap<V>,
-    clear(): void,
-    replace(other: ObservableMap<V> | IKeyValueMap<V>): ObservableMap<V>,
-    size: number,
-    toJS(): IKeyValueMap<V>,
-    toJs(): IKeyValueMap<V>,
-    toJSON(): IKeyValueMap<V>,
-    toString(): string,
-    observe(
-      listener: (changes: IMapChange<V>) => void,
-      fireImmediately?: boolean,
-    ): Lambda,
-    intercept(handler: IInterceptor<IMapWillChange<V>>): Lambda,
-  }
+    declare interface IActionFactory {
+        (a1: any, a2?: any, a3?: any, a4?: any, a6?: any): any,
+        bound(target: Object, propertyKey: string, descriptor?: PropertyDescriptor): void
+    }
 
-  declare function extendShallowObservable(target: any): any;
+    declare class ObservableMap<V> {
+        $mobx: {},
+        name: string,
+        interceptors: any,
+        changeListeners: any,
+        constructor(initialData?: IMapEntries<V> | IKeyValueMap<V>, valueModeFunc?: Function): this,
+        has(key: string): boolean,
+        set(key: string, value: V): void,
+        delete(key: string): boolean,
+        get(key: string): V,
+        keys(): string[] & Iterator<string>,
+        values(): V[] & Iterator<V>,
+        entries(): IMapEntries<V> & Iterator<IMapEntry<V>>,
+        forEach(
+            callback: (value: V, key: string, object: IKeyValueMap<V>) => void,
+            thisArg?: any
+        ): void,
+        merge(other: ObservableMap<V> | IKeyValueMap<V>): ObservableMap<V>,
+        clear(): void,
+        replace(other: ObservableMap<V> | IKeyValueMap<V>): ObservableMap<V>,
+        size: number,
+        toJS(): IKeyValueMap<V>,
+        toJs(): IKeyValueMap<V>,
+        toJSON(): IKeyValueMap<V>,
+        toString(): string,
+        observe(listener: (changes: IMapChange<V>) => void, fireImmediately?: boolean): Lambda,
+        intercept(handler: IInterceptor<IMapWillChange<V>>): Lambda
+    }
 
-  declare function action(
-    targetOrName: any,
-    propertyKeyOrFuc?: any,
-    descriptor?: PropertyDescriptor,
-  ): any;
-  declare function action<T>(name: string, func: T): T;
-  declare function action<T>(func: T): T;
-  declare function runInAction<T>(name: string, block: () => T, scope?: any): T;
-  declare function runInAction<T>(block: () => T, scope?: any): T;
-  declare function isAction(thing: any): boolean;
-  declare function autorun(
-    nameOrFunction: string | ((r: IReactionPublic) => any),
-    viewOrScope?: any,
-    scope?: any,
-  ): any;
-  declare function when(
-    name: string,
-    cond: () => boolean,
-    effect: Lambda,
-    scope?: any,
-  ): any;
-  declare function when(cond: () => boolean, effect: Lambda, scope?: any): any;
-  declare function autorunAsync(
-    func: (r: IReactionPublic) => any,
-    delay?: number,
-    scope?: any,
-  ): any;
-  declare function reaction<T>(
-    expression: (r: IReactionPublic) => T,
-    effect: (arg: T, r: IReactionPublic) => void,
-    fireImmediately?: boolean,
-    delay?: number,
-    scope?: any,
-  ): any;
+    declare function extendShallowObservable(target: any): any
 
-  declare function computed<T>(
-    target: any,
-    key?: string,
-    baseDescriptor?: PropertyDescriptor,
-  ): any;
-  declare function createTransformer<A, B>(
-    transformer: ITransformer<A, B>,
-    onCleanup?: (resultObject: ?B | any, sourceObject?: A) => void,
-  ): ITransformer<A, B>;
-  declare function expr<T>(expr: () => T, scope?: any): T;
-  declare function extendObservable<A, B>(target: A, ...properties: B[]): A & B;
+    declare function action(
+        targetOrName: any,
+        propertyKeyOrFuc?: any,
+        descriptor?: PropertyDescriptor
+    ): any
+    declare function action<T>(name: string, func: T): T
+    declare function action<T>(func: T): T
+    declare function runInAction<T>(name: string, block: () => T, scope?: any): T
+    declare function runInAction<T>(block: () => T, scope?: any): T
+    declare function isAction(thing: any): boolean
+    declare function autorun(
+        nameOrFunction: string | ((r: IReactionPublic) => any),
+        viewOrScope?: any,
+        scope?: any
+    ): any
+    declare function when(name: string, cond: () => boolean, effect: Lambda, scope?: any): any
+    declare function when(cond: () => boolean, effect: Lambda, scope?: any): any
+    declare function autorunAsync(
+        func: (r: IReactionPublic) => any,
+        delay?: number,
+        scope?: any
+    ): any
+    declare function reaction<T>(
+        expression: (r: IReactionPublic) => T,
+        effect: (arg: T, r: IReactionPublic) => void,
+        fireImmediately?: boolean,
+        delay?: number,
+        scope?: any
+    ): any
 
-  declare function intercept(
-    object: Object,
-    property: string,
-    handler: IInterceptor<any>,
-  ): Lambda;
+    declare function computed<T>(
+        target: any,
+        key?: string,
+        baseDescriptor?: PropertyDescriptor
+    ): any
+    declare function createTransformer<A, B>(
+        transformer: ITransformer<A, B>,
+        onCleanup?: (resultObject: ?B | any, sourceObject?: A) => void
+    ): ITransformer<A, B>
+    declare function expr<T>(expr: () => T, scope?: any): T
+    declare function extendObservable<A, B>(target: A, ...properties: B[]): A & B
 
-  declare function isComputed(value: any, property?: string): boolean;
+    declare function intercept(object: Object, property: string, handler: IInterceptor<any>): Lambda
 
-  declare function isObservable(value: any, property?: string): boolean;
+    declare function isComputed(value: any, property?: string): boolean
 
-  declare function observable<T>(value: T): any;
+    declare function isObservable(value: any, property?: string): boolean
 
-  declare function observe<T>(
-    value: IObservableValue<T> | IComputedValue<T>,
-    listener: (change: IValueDidChange<T>) => void,
-    fireImmediately?: boolean,
-  ): Lambda;
-  declare function observe<T>(
-    observableArray: IObservableArray<T>,
-    listener: (change: IArrayChange<T> | IArraySplice<T>) => void,
-    fireImmediately?: boolean,
-  ): Lambda;
-  declare function observe<T>(
-    observableMap: ObservableMap<T>,
-    listener: (change: IMapChange<T>) => void,
-    fireImmediately?: boolean,
-  ): Lambda;
-  declare function observe<T>(
-    observableMap: ObservableMap<T>,
-    property: string,
-    listener: (change: IValueDidChange<T>) => void,
-    fireImmediately?: boolean,
-  ): Lambda;
-  declare function observe(
-    object: any,
-    listener: (change: IObjectChange) => void,
-    fireImmediately?: boolean,
-  ): Lambda;
-  declare function observe(
-    object: any,
-    property: string,
-    listener: (change: IValueDidChange<any>) => void,
-    fireImmediately?: boolean,
-  ): Lambda;
+    declare function observable<T>(value: T): any
 
-  declare function toJS(
-    source: any,
-    detectCycles?: boolean,
-    ___alreadySeen?: [any, any][],
-  ): any;
-  declare function toJSlegacy(
-    source: any,
-    detectCycles?: boolean,
-    ___alreadySeen?: [any, any][],
-  ): any;
-  declare function whyRun(thing?: any, prop?: string): string;
-  declare function useStrict(strict: boolean): void;
+    declare function observe<T>(
+        value: IObservableValue<T> | IComputedValue<T>,
+        listener: (change: IValueDidChange<T>) => void,
+        fireImmediately?: boolean
+    ): Lambda
+    declare function observe<T>(
+        observableArray: IObservableArray<T>,
+        listener: (change: IArrayChange<T> | IArraySplice<T>) => void,
+        fireImmediately?: boolean
+    ): Lambda
+    declare function observe<T>(
+        observableMap: ObservableMap<T>,
+        listener: (change: IMapChange<T>) => void,
+        fireImmediately?: boolean
+    ): Lambda
+    declare function observe<T>(
+        observableMap: ObservableMap<T>,
+        property: string,
+        listener: (change: IValueDidChange<T>) => void,
+        fireImmediately?: boolean
+    ): Lambda
+    declare function observe(
+        object: any,
+        listener: (change: IObjectChange) => void,
+        fireImmediately?: boolean
+    ): Lambda
+    declare function observe(
+        object: any,
+        property: string,
+        listener: (change: IValueDidChange<any>) => void,
+        fireImmediately?: boolean
+    ): Lambda
 
-  declare function isStrictModeEnabled(): boolean;
-  declare function untracked<T>(action: () => T): T;
+    declare function toJS(source: any, detectCycles?: boolean, ___alreadySeen?: [any, any][]): any
+    declare function toJSlegacy(
+        source: any,
+        detectCycles?: boolean,
+        ___alreadySeen?: [any, any][]
+    ): any
+    declare function whyRun(thing?: any, prop?: string): string
+    declare function useStrict(strict: boolean): void
 
-  declare function spy(listener: (change: any) => void): Lambda;
+    declare function isStrictModeEnabled(): boolean
+    declare function untracked<T>(action: () => T): T
 
-  declare function transaction<T>(
-    action: () => T,
-    thisArg?: any,
-    report?: boolean,
-  ): T;
+    declare function spy(listener: (change: any) => void): Lambda
 
-  declare function asReference<T>(value: T): T;
-  declare function asStructure<T>(value: T): T;
-  declare function asFlat<T>(value: T): T;
-  declare function asMap<T>(
-    data: IKeyValueMap<T>,
-    modifierFunc?: Function,
-  ): ObservableMap<T>;
-  declare function isObservableArray(thing: any): boolean;
+    declare function transaction<T>(action: () => T, thisArg?: any, report?: boolean): T
 
-  declare function map<V>(
-    initialValues?: IMapEntries<V> | IKeyValueMap<V>,
-    valueModifier?: Function,
-  ): ObservableMap<V>;
+    declare function asReference<T>(value: T): T
+    declare function asStructure<T>(value: T): T
+    declare function asFlat<T>(value: T): T
+    declare function asMap<T>(data: IKeyValueMap<T>, modifierFunc?: Function): ObservableMap<T>
+    declare function isObservableArray(thing: any): boolean
 
-  declare function isObservableObject<T>(thing: T): boolean;
+    declare function map<V>(
+        initialValues?: IMapEntries<V> | IKeyValueMap<V>,
+        valueModifier?: Function
+    ): ObservableMap<V>
 
-  declare function isArrayLike(x: any): boolean;
+    declare function isObservableObject<T>(thing: T): boolean
 
-  declare class BaseAtom {
-    name: string,
-    isPendingUnobservation: boolean,
-    observers: any[],
-    observersIndexes: {},
-    diffValue: number,
-    lastAccessedBy: number,
-    lowestObserverState: IDerivationState,
-    constructor(name?: string): this,
-    onBecomeUnobserved(): void,
-    reportObserved(): void,
-    reportChanged(): void,
-    toString(): string,
-  }
+    declare function isArrayLike(x: any): boolean
 
-  declare class Atom {
-    name: string,
-    onBecomeObservedHandler: () => void,
-    onBecomeUnobservedHandler: () => void,
-    isPendingUnobservation: boolean,
-    isBeingTracked: boolean,
-    constructor(
-      name?: string,
-      onBecomeObservedHandler?: () => void,
-      onBecomeUnobservedHandler?: () => void,
-    ): this,
-    reportObserved(): boolean,
-    onBecomeUnobserved(): void,
-  }
+    declare class BaseAtom {
+        name: string,
+        isPendingUnobservation: boolean,
+        observers: any[],
+        observersIndexes: {},
+        diffValue: number,
+        lastAccessedBy: number,
+        lowestObserverState: IDerivationState,
+        constructor(name?: string): this,
+        onBecomeUnobserved(): void,
+        reportObserved(): void,
+        reportChanged(): void,
+        toString(): string
+    }
 
-  declare class Reaction {
-    name: string,
-    observing: any[],
-    newObserving: any[],
-    dependenciesState: IDerivationState,
-    diffValue: number,
-    runId: number,
-    unboundDepsCount: number,
-    ___mapid: string,
-    isDisposed: boolean,
-    _isScheduled: boolean,
-    _isTrackPending: boolean,
-    _isRunning: boolean,
-    constructor(name: string, onInvalidate: () => void): this,
-    onBecomeStale(): void,
-    schedule(): void,
-    isScheduled(): boolean,
-    runReaction(): void,
-    track(fn: () => void): void,
-    recoverFromError(): void,
-    dispose(): void,
-    getDisposer(): Lambda & {
-      $mosbservable: Reaction,
-    },
-    toString(): string,
-    whyRun(): string,
-  }
+    declare class Atom {
+        name: string,
+        onBecomeObservedHandler: () => void,
+        onBecomeUnobservedHandler: () => void,
+        isPendingUnobservation: boolean,
+        isBeingTracked: boolean,
+        constructor(
+            name?: string,
+            onBecomeObservedHandler?: () => void,
+            onBecomeUnobservedHandler?: () => void
+        ): this,
+        reportObserved(): boolean,
+        onBecomeUnobserved(): void
+    }
+
+    declare class Reaction {
+        name: string,
+        observing: any[],
+        newObserving: any[],
+        dependenciesState: IDerivationState,
+        diffValue: number,
+        runId: number,
+        unboundDepsCount: number,
+        ___mapid: string,
+        isDisposed: boolean,
+        _isScheduled: boolean,
+        _isTrackPending: boolean,
+        _isRunning: boolean,
+        constructor(name: string, onInvalidate: () => void): this,
+        onBecomeStale(): void,
+        schedule(): void,
+        isScheduled(): boolean,
+        runReaction(): void,
+        track(fn: () => void): void,
+        recoverFromError(): void,
+        dispose(): void,
+        getDisposer(): Lambda & {
+            $mosbservable: Reaction
+        },
+        toString(): string,
+        whyRun(): string
+    }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "lib/mobx.module.js",
   "typings": "lib/mobx.d.ts",
   "scripts": {
+    "prettier": "prettier --write --print-width 100 --tab-width 4 --no-semi \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.ts\"",
     "test": "npm run quick-build && npm run tape",
     "full-test": "npm run small-build && npm run build-tests && npm run use-minified && npm run tape && node --expose-gc test/perf/index.js && npm run test-flow && node test/mixed-versions/mixed-versions.js && npm run test-webpack",
     "tape": "tape test/*.js test/typescript/typescript-tests.js | faucet",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "build-babel-tests": "babel test/babel/babel-tests.js -o test/babel-tests.js",
     "use-minified": "cp lib/mobx.min.js lib/mobx.js",
     "lint": "tslint -c tslint.json src/*.ts src/types/*.ts src/api/*.ts src/core/*.ts src/utils/*.ts",
-    "size": "size-limit 20KB lib/mobx.js"
+    "size": "size-limit 20KB lib/mobx.js",
+    "precommit": "lint-staged"
   },
   "repository": {
     "type": "git",
@@ -61,9 +62,11 @@
     "fs-extra": "^3.0.1",
     "istanbul": "^0.3.21",
     "iterall": "^1.0.2",
+    "lint-staged": "^3.6.1",
     "lodash.intersection": "^3.2.0",
     "ncp": "^2.0.0",
     "nscript": "^0.1.10",
+    "prettier": "^1.4.4",
     "rollup": "^0.41.6",
     "rollup-plugin-filesize": "^1.3.2",
     "rollup-plugin-node-resolve": "^3.0.0",
@@ -88,5 +91,11 @@
     "functional-reactive-programming",
     "state management",
     "data flow"
-  ]
+  ],
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": [
+      "prettier --write --print-width 100 --tab-width 4 --no-semi",
+      "git add"
+    ]
+  }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,126 +1,119 @@
-const rollup = require("rollup");
-const fs = require("fs-extra");
-const path = require("path");
-const ts = require("typescript");
-const exec = require("child_process").execSync;
+const rollup = require("rollup")
+const fs = require("fs-extra")
+const path = require("path")
+const ts = require("typescript")
+const exec = require("child_process").execSync
 
 // make sure we're in the right folder
-process.chdir(path.resolve(__dirname, ".."));
+process.chdir(path.resolve(__dirname, ".."))
 
-const binFolder = path.resolve("node_modules/.bin/");
+const binFolder = path.resolve("node_modules/.bin/")
 
-fs.removeSync("lib");
-fs.removeSync(".build.cjs");
-fs.removeSync(".build.es");
+fs.removeSync("lib")
+fs.removeSync(".build.cjs")
+fs.removeSync(".build.es")
 
 function runTypeScriptBuild(outDir, target, declarations) {
-	console.log(`Running typescript build (target: ${ts.ScriptTarget[target]}) in ${outDir}/`);
+    console.log(`Running typescript build (target: ${ts.ScriptTarget[target]}) in ${outDir}/`)
 
-	const tsConfig = path.resolve("tsconfig.json");
-	const json = ts.parseConfigFileTextToJson(
-		tsConfig,
-		ts.sys.readFile(tsConfig),
-		true
-	);
+    const tsConfig = path.resolve("tsconfig.json")
+    const json = ts.parseConfigFileTextToJson(tsConfig, ts.sys.readFile(tsConfig), true)
 
-	const { options } = ts.parseJsonConfigFileContent(
-		json.config,
-		ts.sys,
-		path.dirname(tsConfig)
-	);
+    const { options } = ts.parseJsonConfigFileContent(json.config, ts.sys, path.dirname(tsConfig))
 
-	options.target = target;
-	options.outDir = outDir;
-	options.declaration = declarations;
+    options.target = target
+    options.outDir = outDir
+    options.declaration = declarations
 
-	options.module = ts.ModuleKind.ES2015;
-	options.importHelpers = true;
-	options.noEmitHelpers = true;
-	if (declarations)
-		options.declarationDir = path.resolve(".", "lib");
+    options.module = ts.ModuleKind.ES2015
+    options.importHelpers = true
+    options.noEmitHelpers = true
+    if (declarations) options.declarationDir = path.resolve(".", "lib")
 
-	const rootFile = path.resolve("src", "mobx.ts");
-	const host = ts.createCompilerHost(options, true);
-	const prog = ts.createProgram([rootFile], options, host);
-	const result = prog.emit();
-	if (result.emitSkipped) {
-		const message = result.diagnostics.map(d =>
-			`${ts.DiagnosticCategory[d.category]} ${d.code} (${d.file}:${d.start}): ${d.messageText}`
-		).join("\n");
+    const rootFile = path.resolve("src", "mobx.ts")
+    const host = ts.createCompilerHost(options, true)
+    const prog = ts.createProgram([rootFile], options, host)
+    const result = prog.emit()
+    if (result.emitSkipped) {
+        const message = result.diagnostics
+            .map(
+                d =>
+                    `${ts.DiagnosticCategory[
+                        d.category
+                    ]} ${d.code} (${d.file}:${d.start}): ${d.messageText}`
+            )
+            .join("\n")
 
-		throw new Error(`Failed to compile typescript:\n\n${message}`);
-	}
+        throw new Error(`Failed to compile typescript:\n\n${message}`)
+    }
 }
 
-
-const rollupPlugins = [
-	require("rollup-plugin-node-resolve")(),
-	require("rollup-plugin-filesize")()
-];
+const rollupPlugins = [require("rollup-plugin-node-resolve")(), require("rollup-plugin-filesize")()]
 
 function generateBundledModule(inputFile, outputFile, format) {
+    console.log(`Generating ${outputFile} bundle.`)
 
-	console.log(`Generating ${outputFile} bundle.`);
-
-	return rollup.rollup({
-		entry: inputFile,
-		plugins: rollupPlugins
-	}).then(bundle => bundle.write({
-		dest: outputFile,
-		format,
-		banner: "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */",
-		exports: "named"
-	}));
+    return rollup
+        .rollup({
+            entry: inputFile,
+            plugins: rollupPlugins
+        })
+        .then(bundle =>
+            bundle.write({
+                dest: outputFile,
+                format,
+                banner: "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */",
+                exports: "named"
+            })
+        )
 }
 
 function generateUmd() {
-	console.log("Generating mobx.umd.js");
-	exec("browserify -s mobx -e lib/mobx.js -o lib/mobx.umd.js");
+    console.log("Generating mobx.umd.js")
+    exec("browserify -s mobx -e lib/mobx.js -o lib/mobx.umd.js")
 }
 
 function generateMinified() {
-	console.log("Generating mobx.min.js and mobx.umd.min.js");
-	exec(
-		`${binFolder}/uglifyjs -m sort,toplevel -c warnings=false --screw-ie8 --preamble "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */" --source-map lib/mobx.min.js.map -o lib/mobx.min.js lib/mobx.js`
-	);
-	exec(
-		`${binFolder}/uglifyjs -m sort,toplevel -c warnings=false --screw-ie8 --preamble "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */" --source-map lib/mobx.umd.min.js.map -o lib/mobx.umd.min.js lib/mobx.umd.js`
-	);
+    console.log("Generating mobx.min.js and mobx.umd.min.js")
+    exec(
+        `${binFolder}/uglifyjs -m sort,toplevel -c warnings=false --screw-ie8 --preamble "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */" --source-map lib/mobx.min.js.map -o lib/mobx.min.js lib/mobx.js`
+    )
+    exec(
+        `${binFolder}/uglifyjs -m sort,toplevel -c warnings=false --screw-ie8 --preamble "/** MobX - (c) Michel Weststrate 2015, 2016 - MIT Licensed */" --source-map lib/mobx.umd.min.js.map -o lib/mobx.umd.min.js lib/mobx.umd.js`
+    )
 }
 
 function copyFlowDefinitions() {
-	console.log("Copying flowtype definitions");
-	exec(`${binFolder}/ncp flow-typed/mobx.js lib/mobx.js.flow`);
+    console.log("Copying flowtype definitions")
+    exec(`${binFolder}/ncp flow-typed/mobx.js lib/mobx.js.flow`)
 }
 
 function build() {
-	runTypeScriptBuild(".build.cjs", ts.ScriptTarget.ES5, true);
-	runTypeScriptBuild(".build.es", ts.ScriptTarget.ES5, false);
-	return Promise.all([
+    runTypeScriptBuild(".build.cjs", ts.ScriptTarget.ES5, true)
+    runTypeScriptBuild(".build.es", ts.ScriptTarget.ES5, false)
+    return Promise.all([
+        generateBundledModule(
+            path.resolve(".build.cjs", "mobx.js"),
+            path.resolve("lib", "mobx.js"),
+            "cjs"
+        ),
 
-		generateBundledModule(
-			path.resolve(".build.cjs", "mobx.js"),
-			path.resolve("lib", "mobx.js"),
-			"cjs"
-		),
-
-		generateBundledModule(
-			path.resolve(".build.es", "mobx.js"),
-			path.resolve("lib", "mobx.module.js"),
-			"es"
-		)
-
-	]).then(() => {
-		generateUmd();
-		generateMinified();
-		copyFlowDefinitions();
-	});
+        generateBundledModule(
+            path.resolve(".build.es", "mobx.js"),
+            path.resolve("lib", "mobx.module.js"),
+            "es"
+        )
+    ]).then(() => {
+        generateUmd()
+        generateMinified()
+        copyFlowDefinitions()
+    })
 }
 
 build().catch(e => {
-	console.error(e);
-	if (e.frame) {
-		console.error(e.frame);
-	}
-	process.exit(1);
-});
+    console.error(e)
+    if (e.frame) {
+        console.error(e.frame)
+    }
+    process.exit(1)
+})

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,36 +3,39 @@
 /* Publish.js, publish a new version of the npm package as found in the current directory */
 /* Run this file from the root of the repository */
 module.exports = function(shell, npm, git) {
-	// build
-	npm("run", "small-build")
+    // build
+    npm("run", "small-build")
 
-    var pkg = JSON.parse(shell.read('package.json'));
+    var pkg = JSON.parse(shell.read("package.json"))
 
     // Bump version number
-    var nrs = pkg.version.split(".");
-    nrs[2] = 1 + parseInt(nrs[2], 10);
-    var version = pkg.version = shell.prompt("Please specify the new package version of '" + pkg.name + "' (Ctrl^C to abort)", nrs.join("."));
-    if (!version.match(/^\d+\.\d+\.\d+$/))
-        shell.exit(1, "Invalid semantic version: " + version);
+    var nrs = pkg.version.split(".")
+    nrs[2] = 1 + parseInt(nrs[2], 10)
+    var version = (pkg.version = shell.prompt(
+        "Please specify the new package version of '" + pkg.name + "' (Ctrl^C to abort)",
+        nrs.join(".")
+    ))
+    if (!version.match(/^\d+\.\d+\.\d+$/)) shell.exit(1, "Invalid semantic version: " + version)
 
     // Check registery data
     if (npm.silent().test("info", pkg.name)) {
         //package is registered in npm?
-        var publishedPackageInfo = JSON.parse(npm.get("info", pkg.name, "--json"));
-        if (publishedPackageInfo.versions == version || publishedPackageInfo.versions.indexOf(version) != -1)
-            shell.exit(2, "Version " + pkg.version + " is already published to npm");
+        var publishedPackageInfo = JSON.parse(npm.get("info", pkg.name, "--json"))
+        if (
+            publishedPackageInfo.versions == version ||
+            publishedPackageInfo.versions.indexOf(version) != -1
+        )
+            shell.exit(2, "Version " + pkg.version + " is already published to npm")
 
-        shell.write('package.json', JSON.stringify(pkg, null, 2));
+        shell.write("package.json", JSON.stringify(pkg, null, 2))
 
         // Finally, commit and publish!
-        npm("publish");
-        git("commit","-am","Published version " + version);
-        git("tag", version);
+        npm("publish")
+        git("commit", "-am", "Published version " + version)
+        git("tag", version)
 
-        git("push");
-        git("push","--tags");
-        console.log("Published!");
-    }
-    else
-        shell.exit(1, pkg.name + " is not an existing npm package");
-};
+        git("push")
+        git("push", "--tags")
+        console.log("Published!")
+    } else shell.exit(1, pkg.name + " is not an existing npm package")
+}

--- a/scripts/webpack-regression-tests.js
+++ b/scripts/webpack-regression-tests.js
@@ -1,7 +1,7 @@
-const path = require('path');
-const fs = require('fs-extra');
-const chalk = require('chalk');
-const cp = require('child_process');
+const path = require("path")
+const fs = require("fs-extra")
+const chalk = require("chalk")
+const cp = require("child_process")
 
 const mainScript = `
 const store = observable.object({ count: 0 });
@@ -12,10 +12,10 @@ autorun(function () {
 
 store.count++;
 store.count--;
-`;
+`
 
 const files = {
-	'package.json': `
+    "package.json": `
 {
 	"name": "mobx-webpack-build",
 	"version": "0.0.1",
@@ -23,7 +23,7 @@ const files = {
 }
 	`,
 
-	'webpack.config.js': `
+    "webpack.config.js": `
 module.exports = {
 	entry: './index.js',
 	output: {
@@ -32,7 +32,7 @@ module.exports = {
 	}
 };`,
 
-	'index.cjs.js': `
+    "index.cjs.js": `
 const mobx = require('../');
 const observable = mobx.observable;
 const autorun = mobx.autorun;
@@ -40,7 +40,7 @@ const autorun = mobx.autorun;
 ${mainScript}
 `,
 
-	'index.es.js': `
+    "index.es.js": `
 import { observable, autorun } from '../';
 
 ${mainScript}
@@ -48,81 +48,81 @@ ${mainScript}
 }
 
 function exec(cmd) {
-	return new Promise((resolve, reject) => {
-		cp.exec(cmd, (err, stdout, stderr) => {
-			if (err) return reject(err);
-			return resolve({ stdout, stderr });
-		});
-	});
+    return new Promise((resolve, reject) => {
+        cp.exec(cmd, (err, stdout, stderr) => {
+            if (err) return reject(err)
+            return resolve({ stdout, stderr })
+        })
+    })
 }
 
 function writeFile(key, name = key) {
-	return new Promise((resolve, reject) => {
-		fs.writeFile(name, files[key], 'utf8', (err) => {
-			if (err) reject(err);
-			else resolve();
-		});
-	});
+    return new Promise((resolve, reject) => {
+        fs.writeFile(name, files[key], "utf8", err => {
+            if (err) reject(err)
+            else resolve()
+        })
+    })
 }
-
 
 function runWebpackBuild({ webpackVersion, moduleFormat }) {
-	const buildDir = path.resolve(
-		__dirname,
-		'..',
-		`.wp-build.${webpackVersion}.${moduleFormat}`
-	);
+    const buildDir = path.resolve(__dirname, "..", `.wp-build.${webpackVersion}.${moduleFormat}`)
 
-	const immediate = () => new Promise(r => setImmediate(r));
+    const immediate = () => new Promise(r => setImmediate(r))
 
-	function initBuildFolder() {
-		fs.mkdirSync(buildDir);
-		process.chdir(buildDir);
-		return Promise.all([
-			writeFile('package.json'),
-			writeFile('webpack.config.js'),
-			writeFile(`index.${moduleFormat}.js`, 'index.js'),
-		]);
-	}
+    function initBuildFolder() {
+        fs.mkdirSync(buildDir)
+        process.chdir(buildDir)
+        return Promise.all([
+            writeFile("package.json"),
+            writeFile("webpack.config.js"),
+            writeFile(`index.${moduleFormat}.js`, "index.js")
+        ])
+    }
 
-	function installWebpack() {
-		console.log(chalk.yellow(`Installing webpack@${webpackVersion}, using ${moduleFormat} modules`));
-		// TODO: npm? v5 was giving me issues
-		return exec(`yarn add --dev webpack@${webpackVersion}`);
-	}
+    function installWebpack() {
+        console.log(
+            chalk.yellow(`Installing webpack@${webpackVersion}, using ${moduleFormat} modules`)
+        )
+        // TODO: npm? v5 was giving me issues
+        return exec(`yarn add --dev webpack@${webpackVersion}`)
+    }
 
-	function execWebpack() {
-		return exec(path.resolve('node_modules', '.bin', 'webpack'));
-	}
+    function execWebpack() {
+        return exec(path.resolve("node_modules", ".bin", "webpack"))
+    }
 
-	const execBundle = () => {
-		console.log(chalk.yellow(`Excuting bundle.js with ${process.execPath}`));
-		return exec(`"${process.execPath}" bundle.js`);
-	};
+    const execBundle = () => {
+        console.log(chalk.yellow(`Excuting bundle.js with ${process.execPath}`))
+        return exec(`"${process.execPath}" bundle.js`)
+    }
 
-	function reportStatus({ stdout, stderr }) {
-		console.log(chalk.red.bold('Output:'));
-		console.log(stdout);
-		if (stdout !== 'store.count: 0\nstore.count: 1\nstore.count: 0\n') {
-			return Promise.reject('Stdout from test program was not as expected:\n\n' + stdout);
-		}
-		console.log(chalk.green('Success'))
-		return Promise.resolve();
-	}
+    function reportStatus({ stdout, stderr }) {
+        console.log(chalk.red.bold("Output:"))
+        console.log(stdout)
+        if (stdout !== "store.count: 0\nstore.count: 1\nstore.count: 0\n") {
+            return Promise.reject("Stdout from test program was not as expected:\n\n" + stdout)
+        }
+        console.log(chalk.green("Success"))
+        return Promise.resolve()
+    }
 
-	console.log(chalk.cyan(`Running webpack build in ${buildDir}`));
-	return fs.remove(buildDir)
-		// Need to wait until after I/O stuff completes or there's intermittent
-		// access-denied exceptions
-		.then(immediate)
-		.then(initBuildFolder)
-		.then(installWebpack)
-		.then(execWebpack)
-		.then(execBundle)
-		.then(reportStatus);
+    console.log(chalk.cyan(`Running webpack build in ${buildDir}`))
+    return (
+        fs
+            .remove(buildDir)
+            // Need to wait until after I/O stuff completes or there's intermittent
+            // access-denied exceptions
+            .then(immediate)
+            .then(initBuildFolder)
+            .then(installWebpack)
+            .then(execWebpack)
+            .then(execBundle)
+            .then(reportStatus)
+    )
 }
 
-runWebpackBuild({ webpackVersion: '2', moduleFormat: 'es' })
-	.then(() => runWebpackBuild({ webpackVersion: '2', moduleFormat: 'cjs' }))
-	.then(() => runWebpackBuild({ webpackVersion: '1', moduleFormat: 'cjs' }))
-	.catch(e => console.error(e));
+runWebpackBuild({ webpackVersion: "2", moduleFormat: "es" })
+    .then(() => runWebpackBuild({ webpackVersion: "2", moduleFormat: "cjs" }))
+    .then(() => runWebpackBuild({ webpackVersion: "1", moduleFormat: "cjs" }))
+    .catch(e => console.error(e))

--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -1,140 +1,155 @@
-import {invariant, addHiddenProp} from "../utils/utils";
-import {createClassPropertyDecorator} from "../utils/decorators";
-import {createAction, executeAction, IAction} from "../core/action";
-import {getMessage} from "../utils/messages";
+import { invariant, addHiddenProp } from "../utils/utils"
+import { createClassPropertyDecorator } from "../utils/decorators"
+import { createAction, executeAction, IAction } from "../core/action"
+import { getMessage } from "../utils/messages"
 
 export interface IActionFactory {
-	// nameless actions
-	<A1, R, T extends (a1: A1) => R>(fn: T): T & IAction;
-	<A1, A2, R, T extends (a1: A1, a2: A2) => R>(fn: T): T & IAction;
-	<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(fn: T): T & IAction;
-	<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(fn: T): T & IAction;
-	<A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(fn: T): T & IAction;
-	<A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(fn: T): T & IAction;
+    // nameless actions
+    <A1, R, T extends (a1: A1) => R>(fn: T): T & IAction
+    <A1, A2, R, T extends (a1: A1, a2: A2) => R>(fn: T): T & IAction
+    <A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(fn: T): T & IAction
+    <A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(fn: T): T & IAction
+    <A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(fn: T): T &
+        IAction
+    <A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(fn: T): T &
+        IAction
 
-	// named actions
-	<A1, R, T extends (a1: A1) => R>(name: string, fn: T): T & IAction;
-	<A1, A2, R, T extends (a1: A1, a2: A2) => R>(name: string, fn: T): T & IAction;
-	<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(name: string, fn: T): T & IAction;
-	<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(name: string, fn: T): T & IAction;
-	<A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(name: string, fn: T): T & IAction;
-	<A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(name: string, fn: T): T & IAction;
+    // named actions
+    <A1, R, T extends (a1: A1) => R>(name: string, fn: T): T & IAction
+    <A1, A2, R, T extends (a1: A1, a2: A2) => R>(name: string, fn: T): T & IAction
+    <A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(name: string, fn: T): T & IAction
+    <A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(name: string, fn: T): T &
+        IAction
+    <A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(
+        name: string,
+        fn: T
+    ): T & IAction
+    <A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(
+        name: string,
+        fn: T
+    ): T & IAction
 
-	// generic forms
-	<T extends Function>(fn: T): T & IAction;
-	<T extends Function>(name: string, fn: T): T & IAction;
+    // generic forms
+    <T extends Function>(fn: T): T & IAction
+    <T extends Function>(name: string, fn: T): T & IAction
 
-	// named decorator
-	(customName: string): (target: Object, key: string, baseDescriptor?: PropertyDescriptor) => void;
+    // named decorator
+    (customName: string): (target: Object, key: string, baseDescriptor?: PropertyDescriptor) => void
 
-	// unnamed decorator
-	(target: Object, propertyKey: string, descriptor?: PropertyDescriptor): void;
+    // unnamed decorator
+    (target: Object, propertyKey: string, descriptor?: PropertyDescriptor): void
 
-	// .bound
-	bound<A1, R, T extends (a1: A1) => R>(fn: T): T & IAction;
-	bound<A1, A2, R, T extends (a1: A1, a2: A2) => R>(fn: T): T & IAction;
-	bound<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(fn: T): T & IAction;
-	bound<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(fn: T): T & IAction;
-	bound<A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(fn: T): T & IAction;
-	bound<A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(fn: T): T & IAction;
+    // .bound
+    bound<A1, R, T extends (a1: A1) => R>(fn: T): T & IAction
+    bound<A1, A2, R, T extends (a1: A1, a2: A2) => R>(fn: T): T & IAction
+    bound<A1, A2, A3, R, T extends (a1: A1, a2: A2, a3: A3) => R>(fn: T): T & IAction
+    bound<A1, A2, A3, A4, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4) => R>(fn: T): T & IAction
+    bound<A1, A2, A3, A4, A5, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R>(
+        fn: T
+    ): T & IAction
+    bound<A1, A2, A3, A4, A5, A6, R, T extends (a1: A1, a2: A2, a3: A3, a4: A4, a6: A6) => R>(
+        fn: T
+    ): T & IAction
 
-	// generic forms
-	bound<T extends Function>(fn: T): T & IAction;
-	bound<T extends Function>(name: string, fn: T): T & IAction;
+    // generic forms
+    bound<T extends Function>(fn: T): T & IAction
+    bound<T extends Function>(name: string, fn: T): T & IAction
 
-	// .bound decorator
-	bound(target: Object, propertyKey: string, descriptor?: PropertyDescriptor): void;
+    // .bound decorator
+    bound(target: Object, propertyKey: string, descriptor?: PropertyDescriptor): void
 }
 
 const actionFieldDecorator = createClassPropertyDecorator(
-	function (target, key, value, args, originalDescriptor) {
-		const actionName = (args && args.length === 1) ? args[0] : (value.name || key || "<unnamed action>");
-		const wrappedAction = action(actionName, value);
-		addHiddenProp(target, key, wrappedAction);
-	},
-	function (key) {
-		return this[key];
-	},
-	function () {
-		invariant(false, getMessage("m001"));
-	},
-	false,
-	true
-);
+    function(target, key, value, args, originalDescriptor) {
+        const actionName =
+            args && args.length === 1 ? args[0] : value.name || key || "<unnamed action>"
+        const wrappedAction = action(actionName, value)
+        addHiddenProp(target, key, wrappedAction)
+    },
+    function(key) {
+        return this[key]
+    },
+    function() {
+        invariant(false, getMessage("m001"))
+    },
+    false,
+    true
+)
 
 const boundActionDecorator = createClassPropertyDecorator(
-	function (target, key, value) {
-		defineBoundAction(target, key, value);
-	},
-	function (key) {
-		return this[key];
-	},
-	function () {
-		invariant(false, getMessage("m001"));
-	},
-	false,
-	false
-);
+    function(target, key, value) {
+        defineBoundAction(target, key, value)
+    },
+    function(key) {
+        return this[key]
+    },
+    function() {
+        invariant(false, getMessage("m001"))
+    },
+    false,
+    false
+)
 
 export var action: IActionFactory = function action(arg1, arg2?, arg3?, arg4?): any {
-	if (arguments.length === 1 && typeof arg1 === "function")
-		return createAction(arg1.name || "<unnamed action>", arg1);
-	if (arguments.length === 2  && typeof arg2 === "function")
-		return createAction(arg1, arg2);
+    if (arguments.length === 1 && typeof arg1 === "function")
+        return createAction(arg1.name || "<unnamed action>", arg1)
+    if (arguments.length === 2 && typeof arg2 === "function") return createAction(arg1, arg2)
 
-	if (arguments.length === 1 && typeof arg1 === "string")
-		return namedActionDecorator(arg1);
+    if (arguments.length === 1 && typeof arg1 === "string") return namedActionDecorator(arg1)
 
-	return namedActionDecorator(arg2).apply(null, arguments);
-} as any;
+    return namedActionDecorator(arg2).apply(null, arguments)
+} as any
 
 action.bound = function boundAction(arg1, arg2?, arg3?) {
-	if (typeof arg1 === "function") {
-		const action = createAction("<not yet bound action>", arg1);
-		(action as any).autoBind = true;
-		return action;
-	}
+    if (typeof arg1 === "function") {
+        const action = createAction("<not yet bound action>", arg1)
+        ;(action as any).autoBind = true
+        return action
+    }
 
-	return boundActionDecorator.apply(null, arguments);
-};
-
-function namedActionDecorator(name: string) {
-	return function (target, prop, descriptor) {
-		if (descriptor && typeof descriptor.value === "function") {
-			// TypeScript @action method() { }. Defined on proto before being decorated
-			// Don't use the field decorator if we are just decorating a method
-			descriptor.value = createAction(name, descriptor.value);
-			descriptor.enumerable = false;
-			descriptor.configurable = true;
-			return descriptor;
-		}
-		// bound instance methods
-		return actionFieldDecorator(name).apply(this, arguments);
-	};
+    return boundActionDecorator.apply(null, arguments)
 }
 
-export function runInAction<T>(block: () => T, scope?: any): T;
-export function runInAction<T>(name: string, block: () => T, scope?: any): T;
+function namedActionDecorator(name: string) {
+    return function(target, prop, descriptor) {
+        if (descriptor && typeof descriptor.value === "function") {
+            // TypeScript @action method() { }. Defined on proto before being decorated
+            // Don't use the field decorator if we are just decorating a method
+            descriptor.value = createAction(name, descriptor.value)
+            descriptor.enumerable = false
+            descriptor.configurable = true
+            return descriptor
+        }
+        // bound instance methods
+        return actionFieldDecorator(name).apply(this, arguments)
+    }
+}
+
+export function runInAction<T>(block: () => T, scope?: any): T
+export function runInAction<T>(name: string, block: () => T, scope?: any): T
 export function runInAction<T>(arg1, arg2?, arg3?) {
-	const actionName = typeof arg1 === "string" ? arg1 : arg1.name || "<unnamed action>";
-	const fn = typeof arg1 === "function" ? arg1 : arg2;
-	const scope = typeof arg1 === "function" ? arg2 : arg3;
+    const actionName = typeof arg1 === "string" ? arg1 : arg1.name || "<unnamed action>"
+    const fn = typeof arg1 === "function" ? arg1 : arg2
+    const scope = typeof arg1 === "function" ? arg2 : arg3
 
-	invariant(typeof fn === "function", getMessage("m002"));
-	invariant(fn.length === 0, getMessage("m003"));
-	invariant(typeof actionName === "string" && actionName.length > 0, `actions should have valid names, got: '${actionName}'`);
+    invariant(typeof fn === "function", getMessage("m002"))
+    invariant(fn.length === 0, getMessage("m003"))
+    invariant(
+        typeof actionName === "string" && actionName.length > 0,
+        `actions should have valid names, got: '${actionName}'`
+    )
 
-	return executeAction(actionName, fn, scope, undefined);
+    return executeAction(actionName, fn, scope, undefined)
 }
 
 export function isAction(thing: any) {
-	return typeof thing === "function" && thing.isMobxAction === true;
+    return typeof thing === "function" && thing.isMobxAction === true
 }
 
 export function defineBoundAction(target: any, propertyName: string, fn: Function) {
-	const res = function () {
-		return executeAction(propertyName, fn, target, arguments);
-	};
-	(res as any).isMobxAction = true;
-	addHiddenProp(target, propertyName, res);
+    const res = function() {
+        return executeAction(propertyName, fn, target, arguments)
+    }
+    ;(res as any).isMobxAction = true
+    addHiddenProp(target, propertyName, res)
 }

--- a/src/api/autorun.ts
+++ b/src/api/autorun.ts
@@ -1,10 +1,10 @@
-import {Lambda, getNextId, invariant, fail} from "../utils/utils";
-import {isModifierDescriptor} from "../types/modifiers";
-import {Reaction, IReactionPublic, IReactionDisposer} from "../core/reaction";
-import {untrackedStart, untrackedEnd} from "../core/derivation";
-import {action, isAction, runInAction} from "./action";
-import {IEqualsComparer, comparer} from "../types/comparer";
-import {getMessage} from "../utils/messages";
+import { Lambda, getNextId, invariant, fail } from "../utils/utils"
+import { isModifierDescriptor } from "../types/modifiers"
+import { Reaction, IReactionPublic, IReactionDisposer } from "../core/reaction"
+import { untrackedStart, untrackedEnd } from "../core/derivation"
+import { action, isAction, runInAction } from "./action"
+import { IEqualsComparer, comparer } from "../types/comparer"
+import { getMessage } from "../utils/messages"
 
 /**
  * Creates a reactive view and keeps it alive, so that the view is always
@@ -13,7 +13,7 @@ import {getMessage} from "../utils/messages";
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(view: (r: IReactionPublic) => any, scope?: any): IReactionDisposer;
+export function autorun(view: (r: IReactionPublic) => any, scope?: any): IReactionDisposer
 
 /**
  * Creates a named reactive view and keeps it alive, so that the view is always
@@ -23,41 +23,39 @@ export function autorun(view: (r: IReactionPublic) => any, scope?: any): IReacti
  * @param scope (optional)
  * @returns disposer function, which can be used to stop the view from being updated in the future.
  */
-export function autorun(name: string, view: (r: IReactionPublic) => any, scope?: any): IReactionDisposer;
+export function autorun(
+    name: string,
+    view: (r: IReactionPublic) => any,
+    scope?: any
+): IReactionDisposer
 export function autorun(arg1: any, arg2: any, arg3?: any) {
-	let name: string,
-		view: (r: IReactionPublic) => any,
-		scope: any;
+    let name: string, view: (r: IReactionPublic) => any, scope: any
 
-	if (typeof arg1 === "string") {
-		name = arg1;
-		view = arg2;
-		scope = arg3;
-	} else {
-		name = arg1.name || ("Autorun@" + getNextId());
-		view = arg1;
-		scope = arg2;
-	}
+    if (typeof arg1 === "string") {
+        name = arg1
+        view = arg2
+        scope = arg3
+    } else {
+        name = arg1.name || "Autorun@" + getNextId()
+        view = arg1
+        scope = arg2
+    }
 
-	invariant(typeof view === "function", getMessage("m004"));
-	invariant(
-		isAction(view) === false,
-		getMessage("m005")
-	);
-	if (scope)
-		view = view.bind(scope);
+    invariant(typeof view === "function", getMessage("m004"))
+    invariant(isAction(view) === false, getMessage("m005"))
+    if (scope) view = view.bind(scope)
 
-	const reaction = new Reaction(name, function () {
-		this.track(reactionRunner);
-	});
+    const reaction = new Reaction(name, function() {
+        this.track(reactionRunner)
+    })
 
-	function reactionRunner() {
-		view(reaction);
-	}
+    function reactionRunner() {
+        view(reaction)
+    }
 
-	reaction.schedule();
+    reaction.schedule()
 
-	return reaction.getDisposer();
+    return reaction.getDisposer()
 }
 
 /**
@@ -69,7 +67,12 @@ export function autorun(arg1: any, arg2: any, arg3?: any) {
  * @param scope (optional)
  * @returns disposer function to prematurely end the observer.
  */
-export function when(name: string, predicate: () => boolean, effect: Lambda, scope?: any): IReactionDisposer;
+export function when(
+    name: string,
+    predicate: () => boolean,
+    effect: Lambda,
+    scope?: any
+): IReactionDisposer
 
 /**
  * Similar to 'observer', observes the given predicate until it returns true.
@@ -79,88 +82,92 @@ export function when(name: string, predicate: () => boolean, effect: Lambda, sco
  * @param scope (optional)
  * @returns disposer function to prematurely end the observer.
  */
-export function when(predicate: () => boolean, effect: Lambda, scope?: any): Lambda;
+export function when(predicate: () => boolean, effect: Lambda, scope?: any): Lambda
 
 export function when(arg1: any, arg2: any, arg3?: any, arg4?: any) {
-	let name: string, predicate: () => boolean, effect: Lambda, scope: any;
-	if (typeof arg1 === "string") {
-		name = arg1;
-		predicate = arg2;
-		effect = arg3;
-		scope = arg4;
-	} else {
-		name = ("When@" + getNextId());
-		predicate = arg1;
-		effect = arg2;
-		scope = arg3;
-	}
+    let name: string, predicate: () => boolean, effect: Lambda, scope: any
+    if (typeof arg1 === "string") {
+        name = arg1
+        predicate = arg2
+        effect = arg3
+        scope = arg4
+    } else {
+        name = "When@" + getNextId()
+        predicate = arg1
+        effect = arg2
+        scope = arg3
+    }
 
-	const disposer = autorun(name, r => {
-		if (predicate.call(scope)) {
-			r.dispose();
-			const prevUntracked = untrackedStart();
-			(effect as any).call(scope);
-			untrackedEnd(prevUntracked);
-		}
-	});
-	return disposer;
+    const disposer = autorun(name, r => {
+        if (predicate.call(scope)) {
+            r.dispose()
+            const prevUntracked = untrackedStart()
+            ;(effect as any).call(scope)
+            untrackedEnd(prevUntracked)
+        }
+    })
+    return disposer
 }
 
-export function autorunAsync(name: string, func: (r: IReactionPublic) => any, delay?: number, scope?: any): IReactionDisposer;
-export function autorunAsync(func: (r: IReactionPublic) => any, delay?: number, scope?: any): IReactionDisposer;
+export function autorunAsync(
+    name: string,
+    func: (r: IReactionPublic) => any,
+    delay?: number,
+    scope?: any
+): IReactionDisposer
+export function autorunAsync(
+    func: (r: IReactionPublic) => any,
+    delay?: number,
+    scope?: any
+): IReactionDisposer
 export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
-	let name: string, func: (r: IReactionPublic) => any, delay: number, scope: any;
-	if (typeof arg1 === "string") {
-		name = arg1;
-		func = arg2;
-		delay = arg3;
-		scope = arg4;
-	} else {
-		name = arg1.name || ("AutorunAsync@" + getNextId());
-		func = arg1;
-		delay = arg2;
-		scope = arg3;
-	}
-	invariant(
-		isAction(func) === false,
-		getMessage("m006")
-	);
-	if (delay === void 0)
-		delay = 1;
+    let name: string, func: (r: IReactionPublic) => any, delay: number, scope: any
+    if (typeof arg1 === "string") {
+        name = arg1
+        func = arg2
+        delay = arg3
+        scope = arg4
+    } else {
+        name = arg1.name || "AutorunAsync@" + getNextId()
+        func = arg1
+        delay = arg2
+        scope = arg3
+    }
+    invariant(isAction(func) === false, getMessage("m006"))
+    if (delay === void 0) delay = 1
 
-	if (scope)
-		func = func.bind(scope);
+    if (scope) func = func.bind(scope)
 
-	let isScheduled = false;
+    let isScheduled = false
 
-	const r = new Reaction(name, () => {
-		if (!isScheduled) {
-			isScheduled = true;
-			setTimeout(() => {
-				isScheduled = false;
-				if (!r.isDisposed)
-					r.track(reactionRunner);
-			}, delay);
-		}
-	});
+    const r = new Reaction(name, () => {
+        if (!isScheduled) {
+            isScheduled = true
+            setTimeout(() => {
+                isScheduled = false
+                if (!r.isDisposed) r.track(reactionRunner)
+            }, delay)
+        }
+    })
 
-	function reactionRunner() { func(r); }
+    function reactionRunner() {
+        func(r)
+    }
 
-	r.schedule();
-	return r.getDisposer();
+    r.schedule()
+    return r.getDisposer()
 }
 
 export interface IReactionOptions {
-	context?: any;
-	fireImmediately?: boolean;
-	delay?: number;
-	compareStructural?: boolean; // TODO: remove in 4.0 in favor of equals
-	/** alias for compareStructural */
-	struct?: boolean; // TODO: remove in 4.0 in favor of equals
-	equals?: IEqualsComparer<any>;
-	name?: string;
+    context?: any
+    fireImmediately?: boolean
+    delay?: number
+    compareStructural?: boolean // TODO: remove in 4.0 in favor of equals
+    /** alias for compareStructural */
+    struct?: boolean // TODO: remove in 4.0 in favor of equals
+    equals?: IEqualsComparer<any>
+    name?: string
 }
-
 
 /**
  *
@@ -168,72 +175,79 @@ export interface IReactionOptions {
  * or
  * autorun(() => action(effect)(expr));
  */
-export function reaction<T>(expression: (r: IReactionPublic) => T, effect: (arg: T, r: IReactionPublic) => void, opts?: IReactionOptions): IReactionDisposer;
-export function reaction<T>(expression: (r: IReactionPublic) => T, effect: (arg: T, r: IReactionPublic) => void, fireImmediately?: boolean): IReactionDisposer;
-export function reaction<T>(expression: (r: IReactionPublic) => T, effect: (arg: T, r: IReactionPublic) => void, arg3: any) {
-	if (arguments.length > 3) {
-		fail(getMessage("m007"));
-	}
-	if (isModifierDescriptor(expression)) {
-		fail(getMessage("m008"));
-	}
+export function reaction<T>(
+    expression: (r: IReactionPublic) => T,
+    effect: (arg: T, r: IReactionPublic) => void,
+    opts?: IReactionOptions
+): IReactionDisposer
+export function reaction<T>(
+    expression: (r: IReactionPublic) => T,
+    effect: (arg: T, r: IReactionPublic) => void,
+    fireImmediately?: boolean
+): IReactionDisposer
+export function reaction<T>(
+    expression: (r: IReactionPublic) => T,
+    effect: (arg: T, r: IReactionPublic) => void,
+    arg3: any
+) {
+    if (arguments.length > 3) {
+        fail(getMessage("m007"))
+    }
+    if (isModifierDescriptor(expression)) {
+        fail(getMessage("m008"))
+    }
 
-	let opts: IReactionOptions;
-	if (typeof arg3 === "object") {
-		opts = arg3;
-	} else {
-		opts = {};
-	}
+    let opts: IReactionOptions
+    if (typeof arg3 === "object") {
+        opts = arg3
+    } else {
+        opts = {}
+    }
 
-	opts.name = opts.name || (expression as any).name || (effect as any).name || ("Reaction@" + getNextId());
-	opts.fireImmediately = arg3 === true || opts.fireImmediately === true;
-	opts.delay = opts.delay || 0;
-	opts.compareStructural = opts.compareStructural || opts.struct || false;
-	// TODO: creates ugly spy events, use `effect = (r) => runInAction(opts.name, () => effect(r))` instead
-	effect = action(opts.name!, opts.context ? effect.bind(opts.context) : effect);
-	if (opts.context) {
-		expression = expression.bind(opts.context);
-	}
+    opts.name =
+        opts.name || (expression as any).name || (effect as any).name || "Reaction@" + getNextId()
+    opts.fireImmediately = arg3 === true || opts.fireImmediately === true
+    opts.delay = opts.delay || 0
+    opts.compareStructural = opts.compareStructural || opts.struct || false
+    // TODO: creates ugly spy events, use `effect = (r) => runInAction(opts.name, () => effect(r))` instead
+    effect = action(opts.name!, opts.context ? effect.bind(opts.context) : effect)
+    if (opts.context) {
+        expression = expression.bind(opts.context)
+    }
 
-	let firstTime = true;
-	let isScheduled = false;
-	let value: T;
+    let firstTime = true
+    let isScheduled = false
+    let value: T
 
-	const equals = opts.equals
-		? opts.equals
-		: (opts.compareStructural || opts.struct)
-			? comparer.structural
-			: comparer.default;
+    const equals = opts.equals
+        ? opts.equals
+        : opts.compareStructural || opts.struct ? comparer.structural : comparer.default
 
-	const r = new Reaction(opts.name, () => {
-		if (firstTime || (opts.delay as any) < 1) {
-			reactionRunner();
-		} else if (!isScheduled) {
-			isScheduled = true;
-			setTimeout(() => {
-				isScheduled = false;
-				reactionRunner();
-			}, opts.delay);
-		}
-	});
+    const r = new Reaction(opts.name, () => {
+        if (firstTime || (opts.delay as any) < 1) {
+            reactionRunner()
+        } else if (!isScheduled) {
+            isScheduled = true
+            setTimeout(() => {
+                isScheduled = false
+                reactionRunner()
+            }, opts.delay)
+        }
+    })
 
-	function reactionRunner () {
-		if (r.isDisposed)
-			return;
-		let changed = false;
-		r.track(() => {
-			const nextValue = expression(r);
-			changed = firstTime || !equals(value, nextValue);
-			value = nextValue;
-		});
-		if (firstTime && opts.fireImmediately!)
-			effect(value, r);
-		if (!firstTime && (changed as boolean) === true)
-			effect(value, r);
-		if (firstTime)
-			firstTime = false;
-	}
+    function reactionRunner() {
+        if (r.isDisposed) return
+        let changed = false
+        r.track(() => {
+            const nextValue = expression(r)
+            changed = firstTime || !equals(value, nextValue)
+            value = nextValue
+        })
+        if (firstTime && opts.fireImmediately!) effect(value, r)
+        if (!firstTime && (changed as boolean) === true) effect(value, r)
+        if (firstTime) firstTime = false
+    }
 
-	r.schedule();
-	return r.getDisposer();
+    r.schedule()
+    return r.getDisposer()
 }

--- a/src/api/computed.ts
+++ b/src/api/computed.ts
@@ -1,76 +1,81 @@
-import {IEqualsComparer, comparer} from "../types/comparer";
-import {asObservableObject, defineComputedProperty} from "../types/observableobject";
-import {invariant} from "../utils/utils";
-import {createClassPropertyDecorator} from "../utils/decorators";
-import {ComputedValue, IComputedValue} from "../core/computedvalue";
-import {getMessage} from "../utils/messages";
+import { IEqualsComparer, comparer } from "../types/comparer"
+import { asObservableObject, defineComputedProperty } from "../types/observableobject"
+import { invariant } from "../utils/utils"
+import { createClassPropertyDecorator } from "../utils/decorators"
+import { ComputedValue, IComputedValue } from "../core/computedvalue"
+import { getMessage } from "../utils/messages"
 
 export interface IComputedValueOptions<T> {
-	compareStructural?: boolean; // TODO: remove in 4.0 in favor of equals
-	struct?: boolean; // TODO: remove in 4.0 in favor of equals
-	equals?: IEqualsComparer<T>;
-	name?: string;
-	setter?: (value: T) => void;
-	context?: any;
+    compareStructural?: boolean // TODO: remove in 4.0 in favor of equals
+    struct?: boolean // TODO: remove in 4.0 in favor of equals
+    equals?: IEqualsComparer<T>
+    name?: string
+    setter?: (value: T) => void
+    context?: any
 }
 
 export interface IComputed {
-	<T>(func: () => T, setter?: (value: T) => void): IComputedValue<T>;
-	<T>(func: () => T, options: IComputedValueOptions<T>): IComputedValue<T>;
-	(target: Object, key: string | symbol, baseDescriptor?: PropertyDescriptor): void;
-	struct(target: Object, key: string | symbol, baseDescriptor?: PropertyDescriptor): void;
-	equals(equals: IEqualsComparer<any>): PropertyDecorator;
+    <T>(func: () => T, setter?: (value: T) => void): IComputedValue<T>
+    <T>(func: () => T, options: IComputedValueOptions<T>): IComputedValue<T>
+    (target: Object, key: string | symbol, baseDescriptor?: PropertyDescriptor): void
+    struct(target: Object, key: string | symbol, baseDescriptor?: PropertyDescriptor): void
+    equals(equals: IEqualsComparer<any>): PropertyDecorator
 }
 
 function createComputedDecorator(equals: IEqualsComparer<any>) {
-	return createClassPropertyDecorator(
-		(target, name, _, __, originalDescriptor) => {
-			invariant(typeof originalDescriptor !== "undefined", getMessage("m009"));
-			invariant(typeof originalDescriptor.get === "function", getMessage("m010"));
+    return createClassPropertyDecorator(
+        (target, name, _, __, originalDescriptor) => {
+            invariant(typeof originalDescriptor !== "undefined", getMessage("m009"))
+            invariant(typeof originalDescriptor.get === "function", getMessage("m010"))
 
-			const adm = asObservableObject(target, "");
-			defineComputedProperty(adm, name, originalDescriptor.get, originalDescriptor.set, equals, false);
-		},
-		function (name) {
-			const observable = this.$mobx.values[name];
-			if (observable === undefined) // See #505
-				return undefined;
-			return observable.get();
-		},
-		function (name, value) {
-			this.$mobx.values[name].set(value);
-		},
-		false,
-		false
-	);
+            const adm = asObservableObject(target, "")
+            defineComputedProperty(
+                adm,
+                name,
+                originalDescriptor.get,
+                originalDescriptor.set,
+                equals,
+                false
+            )
+        },
+        function(name) {
+            const observable = this.$mobx.values[name]
+            if (
+                observable === undefined // See #505
+            )
+                return undefined
+            return observable.get()
+        },
+        function(name, value) {
+            this.$mobx.values[name].set(value)
+        },
+        false,
+        false
+    )
 }
 
-const computedDecorator = createComputedDecorator(comparer.default);
-const computedStructDecorator = createComputedDecorator(comparer.structural);
+const computedDecorator = createComputedDecorator(comparer.default)
+const computedStructDecorator = createComputedDecorator(comparer.structural)
 
 /**
  * Decorator for class properties: @computed get value() { return expr; }.
  * For legacy purposes also invokable as ES5 observable created: `computed(() => expr)`;
  */
-export var computed: IComputed = (
-	function computed(arg1, arg2, arg3) {
-		if (typeof arg2 === "string") {
-			return computedDecorator.apply(null, arguments);
-		}
-		invariant(typeof arg1 === "function", getMessage("m011"));
-		invariant(arguments.length < 3, getMessage("m012"));
-		const opts: IComputedValueOptions<any> = typeof arg2 === "object" ? arg2 : {};
-		opts.setter = typeof arg2 === "function" ? arg2 : opts.setter;
+export var computed: IComputed = function computed(arg1, arg2, arg3) {
+    if (typeof arg2 === "string") {
+        return computedDecorator.apply(null, arguments)
+    }
+    invariant(typeof arg1 === "function", getMessage("m011"))
+    invariant(arguments.length < 3, getMessage("m012"))
+    const opts: IComputedValueOptions<any> = typeof arg2 === "object" ? arg2 : {}
+    opts.setter = typeof arg2 === "function" ? arg2 : opts.setter
 
-		const equals = opts.equals
-			? opts.equals
-			: (opts.compareStructural || opts.struct)
-				? comparer.structural
-				: comparer.default;
+    const equals = opts.equals
+        ? opts.equals
+        : opts.compareStructural || opts.struct ? comparer.structural : comparer.default
 
-		return new ComputedValue(arg1, opts.context, equals, opts.name || arg1.name || "", opts.setter);
-	}
-) as any;
+    return new ComputedValue(arg1, opts.context, equals, opts.name || arg1.name || "", opts.setter)
+} as any
 
-computed.struct = computedStructDecorator;
-computed.equals = createComputedDecorator;
+computed.struct = computedStructDecorator
+computed.equals = createComputedDecorator

--- a/src/api/createtransformer.ts
+++ b/src/api/createtransformer.ts
@@ -1,59 +1,70 @@
-import {ComputedValue} from "../core/computedvalue";
-import {globalState} from "../core/globalstate";
-import {comparer} from "../types/comparer";
-import {invariant, getNextId, addHiddenProp} from "../utils/utils";
+import { ComputedValue } from "../core/computedvalue"
+import { globalState } from "../core/globalstate"
+import { comparer } from "../types/comparer"
+import { invariant, getNextId, addHiddenProp } from "../utils/utils"
 
-export type ITransformer<A, B> = (object: A) => B;
+export type ITransformer<A, B> = (object: A) => B
 
-export function createTransformer<A, B>(transformer: ITransformer<A, B>, onCleanup?: (resultObject: B | undefined, sourceObject?: A) => void): ITransformer<A, B> {
-	invariant(typeof transformer === "function" && transformer.length < 2, "createTransformer expects a function that accepts one argument");
+export function createTransformer<A, B>(
+    transformer: ITransformer<A, B>,
+    onCleanup?: (resultObject: B | undefined, sourceObject?: A) => void
+): ITransformer<A, B> {
+    invariant(
+        typeof transformer === "function" && transformer.length < 2,
+        "createTransformer expects a function that accepts one argument"
+    )
 
-	// Memoizes: object id -> reactive view that applies transformer to the object
-	let objectCache: {[id: number]: ComputedValue<B>} = {};
+    // Memoizes: object id -> reactive view that applies transformer to the object
+    let objectCache: { [id: number]: ComputedValue<B> } = {}
 
-	// If the resetId changes, we will clear the object cache, see #163
-	// This construction is used to avoid leaking refs to the objectCache directly
-	let resetId = globalState.resetId;
+    // If the resetId changes, we will clear the object cache, see #163
+    // This construction is used to avoid leaking refs to the objectCache directly
+    let resetId = globalState.resetId
 
-	// Local transformer class specifically for this transformer
-	class Transformer extends ComputedValue<B> {
-		constructor(private sourceIdentifier: string, private sourceObject: A) {
-			super(() => transformer(sourceObject), undefined, comparer.default, `Transformer-${(<any>transformer).name}-${sourceIdentifier}`, undefined);
-		}
-		onBecomeUnobserved() {
-			const lastValue = this.value;
-			super.onBecomeUnobserved();
-			delete objectCache[this.sourceIdentifier];
-			if (onCleanup)
-				onCleanup(lastValue as any, this.sourceObject);
-		}
-	}
+    // Local transformer class specifically for this transformer
+    class Transformer extends ComputedValue<B> {
+        constructor(private sourceIdentifier: string, private sourceObject: A) {
+            super(
+                () => transformer(sourceObject),
+                undefined,
+                comparer.default,
+                `Transformer-${(<any>transformer).name}-${sourceIdentifier}`,
+                undefined
+            )
+        }
+        onBecomeUnobserved() {
+            const lastValue = this.value
+            super.onBecomeUnobserved()
+            delete objectCache[this.sourceIdentifier]
+            if (onCleanup) onCleanup(lastValue as any, this.sourceObject)
+        }
+    }
 
-	return (object: A) => {
-		if (resetId !== globalState.resetId) {
-			objectCache = {};
-			resetId = globalState.resetId;
-		}
+    return (object: A) => {
+        if (resetId !== globalState.resetId) {
+            objectCache = {}
+            resetId = globalState.resetId
+        }
 
-		const identifier = getMemoizationId(object);
-		let reactiveTransformer = objectCache[identifier];
-		if (reactiveTransformer)
-			return reactiveTransformer.get();
-		// Not in cache; create a reactive view
-		reactiveTransformer = objectCache[identifier] = new Transformer(identifier, object);
-		return reactiveTransformer.get();
-	};
+        const identifier = getMemoizationId(object)
+        let reactiveTransformer = objectCache[identifier]
+        if (reactiveTransformer) return reactiveTransformer.get()
+        // Not in cache; create a reactive view
+        reactiveTransformer = objectCache[identifier] = new Transformer(identifier, object)
+        return reactiveTransformer.get()
+    }
 }
 
 function getMemoizationId(object) {
-	if(typeof object === 'string' || typeof object === 'number')
-		return object
-	if (object === null  || typeof object !== "object")
-		throw new Error("[mobx] transform expected some kind of object or primitive value, got: " + object);
-	let tid = object.$transformId;
-	if (tid === undefined) {
-		tid = getNextId();
-		addHiddenProp(object, "$transformId", tid);
-	}
-	return tid;
+    if (typeof object === "string" || typeof object === "number") return object
+    if (object === null || typeof object !== "object")
+        throw new Error(
+            "[mobx] transform expected some kind of object or primitive value, got: " + object
+        )
+    let tid = object.$transformId
+    if (tid === undefined) {
+        tid = getNextId()
+        addHiddenProp(object, "$transformId", tid)
+    }
+    return tid
 }

--- a/src/api/expr.ts
+++ b/src/api/expr.ts
@@ -1,6 +1,6 @@
-import {computed} from "./computed";
-import {isComputingDerivation} from "../core/derivation";
-import {getMessage} from "../utils/messages";
+import { computed } from "./computed"
+import { isComputingDerivation } from "../core/derivation"
+import { getMessage } from "../utils/messages"
 
 /**
 	* expr can be used to create temporarily views inside views.
@@ -17,8 +17,7 @@ import {getMessage} from "../utils/messages";
 	*
 	*/
 export function expr<T>(expr: () => T, scope?): T {
-	if (!isComputingDerivation())
-		console.warn(getMessage("m013"));
-	// optimization: would be more efficient if the expr itself wouldn't be evaluated first on the next change, but just a 'changed' signal would be fired
-	return computed(expr, { context: scope }).get();
+    if (!isComputingDerivation()) console.warn(getMessage("m013"))
+    // optimization: would be more efficient if the expr itself wouldn't be evaluated first on the next change, but just a 'changed' signal would be fired
+    return computed(expr, { context: scope }).get()
 }

--- a/src/api/extendobservable.ts
+++ b/src/api/extendobservable.ts
@@ -1,41 +1,53 @@
-import {isObservableMap} from "../types/observablemap";
-import {asObservableObject, defineObservablePropertyFromDescriptor} from "../types/observableobject";
-import {isObservable} from "./isobservable";
-import {invariant, isPropertyConfigurable, hasOwnProperty} from "../utils/utils";
-import {deepEnhancer, referenceEnhancer, IEnhancer} from "../types/modifiers";
-import {getMessage} from "../utils/messages";
+import { isObservableMap } from "../types/observablemap"
+import {
+    asObservableObject,
+    defineObservablePropertyFromDescriptor
+} from "../types/observableobject"
+import { isObservable } from "./isobservable"
+import { invariant, isPropertyConfigurable, hasOwnProperty } from "../utils/utils"
+import { deepEnhancer, referenceEnhancer, IEnhancer } from "../types/modifiers"
+import { getMessage } from "../utils/messages"
 
-
-export function extendObservable<A extends Object, B extends Object>(target: A, ...properties: B[]): A & B {
-	return extendObservableHelper(target, deepEnhancer, properties) as any;
+export function extendObservable<A extends Object, B extends Object>(
+    target: A,
+    ...properties: B[]
+): A & B {
+    return extendObservableHelper(target, deepEnhancer, properties) as any
 }
 
-export function extendShallowObservable<A extends Object, B extends Object>(target: A, ...properties: B[]): A & B {
-	return extendObservableHelper(target, referenceEnhancer, properties) as any;
+export function extendShallowObservable<A extends Object, B extends Object>(
+    target: A,
+    ...properties: B[]
+): A & B {
+    return extendObservableHelper(target, referenceEnhancer, properties) as any
 }
 
-export function extendObservableHelper(target: Object, defaultEnhancer: IEnhancer<any>, properties: Object[]): Object {
-	invariant(arguments.length >= 2, getMessage("m014"));
-	invariant(typeof target === "object", getMessage("m015"));
-	invariant(!(isObservableMap(target)), getMessage("m016"));
+export function extendObservableHelper(
+    target: Object,
+    defaultEnhancer: IEnhancer<any>,
+    properties: Object[]
+): Object {
+    invariant(arguments.length >= 2, getMessage("m014"))
+    invariant(typeof target === "object", getMessage("m015"))
+    invariant(!isObservableMap(target), getMessage("m016"))
 
-	properties.forEach(propSet => {
-		invariant(typeof propSet === "object", getMessage("m017"));
-		invariant(!isObservable(propSet), getMessage("m018"));
-	});
+    properties.forEach(propSet => {
+        invariant(typeof propSet === "object", getMessage("m017"))
+        invariant(!isObservable(propSet), getMessage("m018"))
+    })
 
-	const adm = asObservableObject(target);
-	const definedProps = {};
-	// Note could be optimised if properties.length === 1
-	for (let i = properties.length - 1; i >= 0; i--) {
-		const propSet = properties[i];
-		for (let key in propSet) if (definedProps[key] !== true && hasOwnProperty(propSet, key)) {
-			definedProps[key] = true;
-			if (target as any === propSet && !isPropertyConfigurable(target, key))
-				continue; // see #111, skip non-configurable or non-writable props for `observable(object)`.
-			const descriptor = Object.getOwnPropertyDescriptor(propSet, key);
-			defineObservablePropertyFromDescriptor(adm, key, descriptor, defaultEnhancer);
-		}
-	}
-	return target;
+    const adm = asObservableObject(target)
+    const definedProps = {}
+    // Note could be optimised if properties.length === 1
+    for (let i = properties.length - 1; i >= 0; i--) {
+        const propSet = properties[i]
+        for (let key in propSet)
+            if (definedProps[key] !== true && hasOwnProperty(propSet, key)) {
+                definedProps[key] = true
+                if ((target as any) === propSet && !isPropertyConfigurable(target, key)) continue // see #111, skip non-configurable or non-writable props for `observable(object)`.
+                const descriptor = Object.getOwnPropertyDescriptor(propSet, key)
+                defineObservablePropertyFromDescriptor(adm, key, descriptor, defaultEnhancer)
+            }
+    }
+    return target
 }

--- a/src/api/extras.ts
+++ b/src/api/extras.ts
@@ -1,39 +1,39 @@
-import {IDepTreeNode, getObservers, hasObservers} from "../core/observable";
-import {unique} from "../utils/utils";
-import {getAtom} from "../types/type-utils";
+import { IDepTreeNode, getObservers, hasObservers } from "../core/observable"
+import { unique } from "../utils/utils"
+import { getAtom } from "../types/type-utils"
 
 export interface IDependencyTree {
-	name: string;
-	dependencies?: IDependencyTree[];
+    name: string
+    dependencies?: IDependencyTree[]
 }
 
 export interface IObserverTree {
-	name: string;
-	observers?: IObserverTree[];
+    name: string
+    observers?: IObserverTree[]
 }
 
 export function getDependencyTree(thing: any, property?: string): IDependencyTree {
-	return nodeToDependencyTree(getAtom(thing, property));
+    return nodeToDependencyTree(getAtom(thing, property))
 }
 
 function nodeToDependencyTree(node: IDepTreeNode): IDependencyTree {
-	const result: IDependencyTree = {
-		name: node.name
-	};
-	if (node.observing && node.observing.length > 0)
-		result.dependencies = unique(node.observing).map(nodeToDependencyTree);
-	return result;
+    const result: IDependencyTree = {
+        name: node.name
+    }
+    if (node.observing && node.observing.length > 0)
+        result.dependencies = unique(node.observing).map(nodeToDependencyTree)
+    return result
 }
 
 export function getObserverTree(thing: any, property?: string): IObserverTree {
-	return nodeToObserverTree(getAtom(thing, property));
+    return nodeToObserverTree(getAtom(thing, property))
 }
 
 function nodeToObserverTree(node: IDepTreeNode): IObserverTree {
-	const result: IObserverTree = {
-		name: node.name
-	};
-	if (hasObservers(node as any))
-		result.observers = <any>getObservers(node as any).map(<any>nodeToObserverTree);
-	return result;
+    const result: IObserverTree = {
+        name: node.name
+    }
+    if (hasObservers(node as any))
+        result.observers = <any>getObservers(node as any).map(<any>nodeToObserverTree)
+    return result
 }

--- a/src/api/intercept-read.ts
+++ b/src/api/intercept-read.ts
@@ -1,32 +1,43 @@
-import { fail, Lambda } from '../utils/utils';
-import { IObservableArray, isObservableArray } from '../types/observablearray';
-import { isObservableMap, ObservableMap } from '../types/observablemap';
-import { isObservableObject } from '../types/observableobject';
-import { IObservableValue, isObservableValue } from '../types/observablevalue';
-import { getAdministration } from "../types/type-utils";
+import { fail, Lambda } from "../utils/utils"
+import { IObservableArray, isObservableArray } from "../types/observablearray"
+import { isObservableMap, ObservableMap } from "../types/observablemap"
+import { isObservableObject } from "../types/observableobject"
+import { IObservableValue, isObservableValue } from "../types/observablevalue"
+import { getAdministration } from "../types/type-utils"
 
 export type ReadInterceptor<T> = (value: any) => T
 
 /** Experimental feature right now, tested indirectly via Mobx-State-Tree */
-export function interceptReads<T>(value: IObservableValue<T>, handler: ReadInterceptor<T>): Lambda;
-export function interceptReads<T>(observableArray: IObservableArray<T>, handler: ReadInterceptor<T>): Lambda;
-export function interceptReads<T>(observableMap: ObservableMap<T>, handler: ReadInterceptor<T>): Lambda;
-export function interceptReads(object: Object, property: string, handler: ReadInterceptor<any>): Lambda;
+export function interceptReads<T>(value: IObservableValue<T>, handler: ReadInterceptor<T>): Lambda
+export function interceptReads<T>(
+    observableArray: IObservableArray<T>,
+    handler: ReadInterceptor<T>
+): Lambda
+export function interceptReads<T>(
+    observableMap: ObservableMap<T>,
+    handler: ReadInterceptor<T>
+): Lambda
+export function interceptReads(
+    object: Object,
+    property: string,
+    handler: ReadInterceptor<any>
+): Lambda
 export function interceptReads(thing, propOrHandler?, handler?): Lambda {
-	let target
-	if (isObservableMap(thing) || isObservableArray(thing) || isObservableValue(thing)) {
-		target = getAdministration(thing);
-	} else if (isObservableObject(thing)) {
-		if (typeof propOrHandler !== "string")
-			return fail(`InterceptReads can only be used with a specific property, not with an object in general`)
-		target = getAdministration(thing, propOrHandler);
-	} else {
-		return fail(`Expected observable map, object or array as first array`)
-	}
-	if (target.dehancer !== undefined)
-		return fail(`An intercept reader was already established`)
-	target.dehancer = typeof propOrHandler === "function" ? propOrHandler : handler
-	return () => {
-		target.dehancer = undefined
-	}
+    let target
+    if (isObservableMap(thing) || isObservableArray(thing) || isObservableValue(thing)) {
+        target = getAdministration(thing)
+    } else if (isObservableObject(thing)) {
+        if (typeof propOrHandler !== "string")
+            return fail(
+                `InterceptReads can only be used with a specific property, not with an object in general`
+            )
+        target = getAdministration(thing, propOrHandler)
+    } else {
+        return fail(`Expected observable map, object or array as first array`)
+    }
+    if (target.dehancer !== undefined) return fail(`An intercept reader was already established`)
+    target.dehancer = typeof propOrHandler === "function" ? propOrHandler : handler
+    return () => {
+        target.dehancer = undefined
+    }
 }

--- a/src/api/intercept.ts
+++ b/src/api/intercept.ts
@@ -1,28 +1,43 @@
-import {IInterceptor} from "../types/intercept-utils";
-import {IObservableArray, IArrayWillChange, IArrayWillSplice} from "../types/observablearray";
-import {ObservableMap, IMapWillChange} from "../types/observablemap";
-import {IObjectWillChange} from "../types/observableobject";
-import {IValueWillChange, IObservableValue} from "../types/observablevalue";
-import {Lambda} from "../utils/utils";
-import {getAdministration} from "../types/type-utils";
+import { IInterceptor } from "../types/intercept-utils"
+import { IObservableArray, IArrayWillChange, IArrayWillSplice } from "../types/observablearray"
+import { ObservableMap, IMapWillChange } from "../types/observablemap"
+import { IObjectWillChange } from "../types/observableobject"
+import { IValueWillChange, IObservableValue } from "../types/observablevalue"
+import { Lambda } from "../utils/utils"
+import { getAdministration } from "../types/type-utils"
 
-export function intercept<T>(value: IObservableValue<T>, handler: IInterceptor<IValueWillChange<T>>): Lambda;
-export function intercept<T>(observableArray: IObservableArray<T>, handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda;
-export function intercept<T>(observableMap: ObservableMap<T>, handler: IInterceptor<IMapWillChange<T>>): Lambda;
-export function intercept<T>(observableMap: ObservableMap<T>, property: string, handler: IInterceptor<IValueWillChange<T>>): Lambda;
-export function intercept(object: Object, handler: IInterceptor<IObjectWillChange>): Lambda;
-export function intercept(object: Object, property: string, handler: IInterceptor<IValueWillChange<any>>): Lambda;
+export function intercept<T>(
+    value: IObservableValue<T>,
+    handler: IInterceptor<IValueWillChange<T>>
+): Lambda
+export function intercept<T>(
+    observableArray: IObservableArray<T>,
+    handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>
+): Lambda
+export function intercept<T>(
+    observableMap: ObservableMap<T>,
+    handler: IInterceptor<IMapWillChange<T>>
+): Lambda
+export function intercept<T>(
+    observableMap: ObservableMap<T>,
+    property: string,
+    handler: IInterceptor<IValueWillChange<T>>
+): Lambda
+export function intercept(object: Object, handler: IInterceptor<IObjectWillChange>): Lambda
+export function intercept(
+    object: Object,
+    property: string,
+    handler: IInterceptor<IValueWillChange<any>>
+): Lambda
 export function intercept(thing, propOrHandler?, handler?): Lambda {
-	if (typeof handler === "function")
-		return interceptProperty(thing, propOrHandler, handler);
-	else
-		return interceptInterceptable(thing, propOrHandler);
+    if (typeof handler === "function") return interceptProperty(thing, propOrHandler, handler)
+    else return interceptInterceptable(thing, propOrHandler)
 }
 
 function interceptInterceptable(thing, handler) {
-	return getAdministration(thing).intercept(handler);
+    return getAdministration(thing).intercept(handler)
 }
 
 function interceptProperty(thing, property, handler) {
-	return getAdministration(thing, property).intercept(handler);
+    return getAdministration(thing, property).intercept(handler)
 }

--- a/src/api/iscomputed.ts
+++ b/src/api/iscomputed.ts
@@ -1,15 +1,13 @@
-import {isObservableObject} from "../types/observableobject";
-import {getAtom} from "../types/type-utils";
-import {isComputedValue} from "../core/computedvalue";
+import { isObservableObject } from "../types/observableobject"
+import { getAtom } from "../types/type-utils"
+import { isComputedValue } from "../core/computedvalue"
 
 export function isComputed(value, property?: string): boolean {
-	if (value === null || value === undefined)
-		return false;
-	if (property !== undefined) {
-		if (isObservableObject(value) === false)
-			return false;
-		const atom = getAtom(value, property);
-		return isComputedValue(atom)
-	}
-	return isComputedValue(value);
+    if (value === null || value === undefined) return false
+    if (property !== undefined) {
+        if (isObservableObject(value) === false) return false
+        const atom = getAtom(value, property)
+        return isComputedValue(atom)
+    }
+    return isComputedValue(value)
 }

--- a/src/api/isobservable.ts
+++ b/src/api/isobservable.ts
@@ -1,10 +1,10 @@
-import {isObservableArray} from "../types/observablearray";
-import {isObservableMap} from "../types/observablemap";
-import {isObservableObject, ObservableObjectAdministration} from "../types/observableobject";
-import {isAtom} from "../core/atom";
-import {isComputedValue} from "../core/computedvalue";
-import {isReaction} from "../core/reaction";
-import {getMessage} from "../utils/messages";
+import { isObservableArray } from "../types/observablearray"
+import { isObservableMap } from "../types/observablemap"
+import { isObservableObject, ObservableObjectAdministration } from "../types/observableobject"
+import { isAtom } from "../core/atom"
+import { isComputedValue } from "../core/computedvalue"
+import { isReaction } from "../core/reaction"
+import { getMessage } from "../utils/messages"
 
 /**
 	* Returns true if the provided value is reactive.
@@ -12,17 +12,21 @@ import {getMessage} from "../utils/messages";
 	* @param property if property is specified, checks whether value.property is reactive.
 	*/
 export function isObservable(value, property?: string): boolean {
-	if (value === null || value === undefined)
-		return false;
-	if (property !== undefined) {
-		if (isObservableArray(value) || isObservableMap(value))
-			throw new Error(getMessage("m019"));
-		else if (isObservableObject(value)) {
-			const o = <ObservableObjectAdministration> (value as any).$mobx;
-			return o.values && !!o.values[property];
-		}
-		return false;
-	}
-	// For first check, see #701
-	return isObservableObject(value) || !!value.$mobx || isAtom(value) || isReaction(value) || isComputedValue(value);
+    if (value === null || value === undefined) return false
+    if (property !== undefined) {
+        if (isObservableArray(value) || isObservableMap(value)) throw new Error(getMessage("m019"))
+        else if (isObservableObject(value)) {
+            const o = <ObservableObjectAdministration>(value as any).$mobx
+            return o.values && !!o.values[property]
+        }
+        return false
+    }
+    // For first check, see #701
+    return (
+        isObservableObject(value) ||
+        !!value.$mobx ||
+        isAtom(value) ||
+        isReaction(value) ||
+        isComputedValue(value)
+    )
 }

--- a/src/api/observable.ts
+++ b/src/api/observable.ts
@@ -1,212 +1,210 @@
-import {invariant, fail} from "../utils/utils";
-import {isModifierDescriptor, IModifierDescriptor, deepEnhancer, referenceEnhancer, shallowEnhancer, deepStructEnhancer, refStructEnhancer, createModifierDescriptor} from "../types/modifiers";
-import {IObservableValue, ObservableValue} from "../types/observablevalue";
-import {IObservableArray, ObservableArray} from "../types/observablearray";
-import {createDecoratorForEnhancer} from "./observabledecorator";
-import {isObservable} from "./isobservable";
-import {IObservableObject, asObservableObject} from "../types/observableobject";
-import {extendObservable, extendShallowObservable} from "./extendobservable";
-import {IObservableMapInitialValues, ObservableMap, IMap} from "../types/observablemap";
-import {getMessage} from "../utils/messages";
+import { invariant, fail } from "../utils/utils"
+import {
+    isModifierDescriptor,
+    IModifierDescriptor,
+    deepEnhancer,
+    referenceEnhancer,
+    shallowEnhancer,
+    deepStructEnhancer,
+    refStructEnhancer,
+    createModifierDescriptor
+} from "../types/modifiers"
+import { IObservableValue, ObservableValue } from "../types/observablevalue"
+import { IObservableArray, ObservableArray } from "../types/observablearray"
+import { createDecoratorForEnhancer } from "./observabledecorator"
+import { isObservable } from "./isobservable"
+import { IObservableObject, asObservableObject } from "../types/observableobject"
+import { extendObservable, extendShallowObservable } from "./extendobservable"
+import { IObservableMapInitialValues, ObservableMap, IMap } from "../types/observablemap"
+import { getMessage } from "../utils/messages"
 
-
-const deepDecorator = createDecoratorForEnhancer(deepEnhancer);
-const shallowDecorator = createDecoratorForEnhancer(shallowEnhancer);
-const refDecorator = createDecoratorForEnhancer(referenceEnhancer);
-const deepStructDecorator = createDecoratorForEnhancer(deepStructEnhancer);
-const refStructDecorator = createDecoratorForEnhancer(refStructEnhancer);
+const deepDecorator = createDecoratorForEnhancer(deepEnhancer)
+const shallowDecorator = createDecoratorForEnhancer(shallowEnhancer)
+const refDecorator = createDecoratorForEnhancer(referenceEnhancer)
+const deepStructDecorator = createDecoratorForEnhancer(deepStructEnhancer)
+const refStructDecorator = createDecoratorForEnhancer(refStructEnhancer)
 
 /**
  * Turns an object, array or function into a reactive structure.
  * @param v the value which should become observable.
  */
 function createObservable(v: any = undefined) {
-	// @observable someProp;
-	if (typeof arguments[1] === "string")
-		return deepDecorator.apply(null, arguments);
+    // @observable someProp;
+    if (typeof arguments[1] === "string") return deepDecorator.apply(null, arguments)
 
-	invariant(arguments.length <= 1, getMessage("m021"));
-	invariant(!isModifierDescriptor(v), getMessage("m020"));
+    invariant(arguments.length <= 1, getMessage("m021"))
+    invariant(!isModifierDescriptor(v), getMessage("m020"))
 
-	// it is an observable already, done
-	if (isObservable(v))
-		return v;
+    // it is an observable already, done
+    if (isObservable(v)) return v
 
-	// something that can be converted and mutated?
-	const res = deepEnhancer(v, undefined, undefined);
+    // something that can be converted and mutated?
+    const res = deepEnhancer(v, undefined, undefined)
 
-	// this value could be converted to a new observable data structure, return it
-	if (res !== v)
-		return res;
+    // this value could be converted to a new observable data structure, return it
+    if (res !== v) return res
 
-	// otherwise, just box it
-	return observable.box(v);
+    // otherwise, just box it
+    return observable.box(v)
 }
 
 export interface IObservableFactory {
-	// observable overloads
-	<T>(): IObservableValue<T>;
-	<T>(wrapped: IModifierDescriptor<T>): T;
-	(target: Object, key: string, baseDescriptor?: PropertyDescriptor): any;
-	<T>(value: T[]): IObservableArray<T>;
-	(value: string): IObservableValue<string>;
-	(value: boolean): IObservableValue<boolean>;
-	(value: number): IObservableValue<number>;
-	(value: Date): IObservableValue<Date>;
-	(value: RegExp): IObservableValue<RegExp>;
-	(value: Function): IObservableValue<Function>;
-	<T>(value: null | undefined): IObservableValue<T>;
-	(value: null | undefined): IObservableValue<any>;
-	(): IObservableValue<any>;
-	<T>(value: IMap<string | number | boolean, T>): ObservableMap<T>;
-	<T extends Object>(value: T): T & IObservableObject;
-	<T>(value: T): IObservableValue<T>;
+    // observable overloads
+    <T>(): IObservableValue<T>
+    <T>(wrapped: IModifierDescriptor<T>): T
+    (target: Object, key: string, baseDescriptor?: PropertyDescriptor): any
+    <T>(value: T[]): IObservableArray<T>
+    (value: string): IObservableValue<string>
+    (value: boolean): IObservableValue<boolean>
+    (value: number): IObservableValue<number>
+    (value: Date): IObservableValue<Date>
+    (value: RegExp): IObservableValue<RegExp>
+    (value: Function): IObservableValue<Function>
+    <T>(value: null | undefined): IObservableValue<T>
+    (value: null | undefined): IObservableValue<any>
+    (): IObservableValue<any>
+    <T>(value: IMap<string | number | boolean, T>): ObservableMap<T>
+    <T extends Object>(value: T): T & IObservableObject
+    <T>(value: T): IObservableValue<T>
 }
 
 export class IObservableFactories {
-	box<T>(value?: T, name?: string): IObservableValue<T> {
-		if (arguments.length > 2)
-			incorrectlyUsedAsDecorator("box");
-		return new ObservableValue(value, deepEnhancer, name);
-	}
+    box<T>(value?: T, name?: string): IObservableValue<T> {
+        if (arguments.length > 2) incorrectlyUsedAsDecorator("box")
+        return new ObservableValue(value, deepEnhancer, name)
+    }
 
-	shallowBox<T>(value?: T, name?: string): IObservableValue<T> {
-		if (arguments.length > 2)
-			incorrectlyUsedAsDecorator("shallowBox");
-		return new ObservableValue(value, referenceEnhancer, name);
-	}
+    shallowBox<T>(value?: T, name?: string): IObservableValue<T> {
+        if (arguments.length > 2) incorrectlyUsedAsDecorator("shallowBox")
+        return new ObservableValue(value, referenceEnhancer, name)
+    }
 
-	array<T>(initialValues?: T[], name?: string): IObservableArray<T> {
-		if (arguments.length > 2)
-			incorrectlyUsedAsDecorator("array");
-		return new ObservableArray(initialValues, deepEnhancer, name) as any;
-	}
+    array<T>(initialValues?: T[], name?: string): IObservableArray<T> {
+        if (arguments.length > 2) incorrectlyUsedAsDecorator("array")
+        return new ObservableArray(initialValues, deepEnhancer, name) as any
+    }
 
-	shallowArray<T>(initialValues?: T[], name?: string): IObservableArray<T> {
-		if (arguments.length > 2)
-			incorrectlyUsedAsDecorator("shallowArray");
-		return new ObservableArray(initialValues, referenceEnhancer, name) as any;
-	}
+    shallowArray<T>(initialValues?: T[], name?: string): IObservableArray<T> {
+        if (arguments.length > 2) incorrectlyUsedAsDecorator("shallowArray")
+        return new ObservableArray(initialValues, referenceEnhancer, name) as any
+    }
 
-	map<T>(initialValues?: IObservableMapInitialValues<T>, name?: string): ObservableMap<T> {
-		if (arguments.length > 2)
-			incorrectlyUsedAsDecorator("map");
-		return new ObservableMap(initialValues, deepEnhancer, name);
-	}
+    map<T>(initialValues?: IObservableMapInitialValues<T>, name?: string): ObservableMap<T> {
+        if (arguments.length > 2) incorrectlyUsedAsDecorator("map")
+        return new ObservableMap(initialValues, deepEnhancer, name)
+    }
 
-	shallowMap<T>(initialValues?: IObservableMapInitialValues<T>, name?: string): ObservableMap<T> {
-		if (arguments.length > 2)
-			incorrectlyUsedAsDecorator("shallowMap");
-		return new ObservableMap(initialValues, referenceEnhancer, name);
-	}
+    shallowMap<T>(initialValues?: IObservableMapInitialValues<T>, name?: string): ObservableMap<T> {
+        if (arguments.length > 2) incorrectlyUsedAsDecorator("shallowMap")
+        return new ObservableMap(initialValues, referenceEnhancer, name)
+    }
 
-	object<T>(props: T, name?: string): T & IObservableObject {
-		if (arguments.length > 2)
-			incorrectlyUsedAsDecorator("object");
-		const res = {};
-		// convert to observable object
-		asObservableObject(res, name);
-		// add properties
-		extendObservable(res, props);
-		return res as any;
-	}
+    object<T>(props: T, name?: string): T & IObservableObject {
+        if (arguments.length > 2) incorrectlyUsedAsDecorator("object")
+        const res = {}
+        // convert to observable object
+        asObservableObject(res, name)
+        // add properties
+        extendObservable(res, props)
+        return res as any
+    }
 
-	shallowObject<T>(props: T, name?: string): T & IObservableObject {
-		if (arguments.length > 2)
-			incorrectlyUsedAsDecorator("shallowObject");
-		const res = {};
-		asObservableObject(res, name);
-		extendShallowObservable(res, props);
-		return res as any;
-	}
+    shallowObject<T>(props: T, name?: string): T & IObservableObject {
+        if (arguments.length > 2) incorrectlyUsedAsDecorator("shallowObject")
+        const res = {}
+        asObservableObject(res, name)
+        extendShallowObservable(res, props)
+        return res as any
+    }
 
-
-	/**
+    /**
 	 * Decorator that creates an observable that only observes the references, but doesn't try to turn the assigned value into an observable.ts.
 	 */
-	ref(target: Object, property: string, descriptor?: PropertyDescriptor): any;
-	ref<T>(initialValue: T): T;
-	ref() {
-		if (arguments.length < 2) {
-			// although ref creates actually a modifier descriptor, the type of the resultig properties
-			// of the object is `T` in the end, when the descriptors are interpreted
-			return createModifierDescriptor(referenceEnhancer, arguments[0]) as any;
-		} else {
-			return refDecorator.apply(null, arguments);
-		}
-	}
+    ref(target: Object, property: string, descriptor?: PropertyDescriptor): any
+    ref<T>(initialValue: T): T
+    ref() {
+        if (arguments.length < 2) {
+            // although ref creates actually a modifier descriptor, the type of the resultig properties
+            // of the object is `T` in the end, when the descriptors are interpreted
+            return createModifierDescriptor(referenceEnhancer, arguments[0]) as any
+        } else {
+            return refDecorator.apply(null, arguments)
+        }
+    }
 
-
-	/**
+    /**
 	 * Decorator that creates an observable converts its value (objects, maps or arrays) into a shallow observable structure
 	 */
-	shallow(target: Object, property: string, descriptor?: PropertyDescriptor): any;
-	shallow<T>(initialValues: T[]): IObservableArray<T>;
-	shallow<T>(initialValues: IMap<string | number | boolean, T>): ObservableMap<T>;
-	shallow<T extends Object>(value: T): T;
-	shallow() {
-		if (arguments.length < 2) {
-			// although ref creates actually a modifier descriptor, the type of the resultig properties
-			// of the object is `T` in the end, when the descriptors are interpreted
-			return createModifierDescriptor(shallowEnhancer, arguments[0]) as any;
-		} else {
-			return shallowDecorator.apply(null, arguments);
-		}
-	}
+    shallow(target: Object, property: string, descriptor?: PropertyDescriptor): any
+    shallow<T>(initialValues: T[]): IObservableArray<T>
+    shallow<T>(initialValues: IMap<string | number | boolean, T>): ObservableMap<T>
+    shallow<T extends Object>(value: T): T
+    shallow() {
+        if (arguments.length < 2) {
+            // although ref creates actually a modifier descriptor, the type of the resultig properties
+            // of the object is `T` in the end, when the descriptors are interpreted
+            return createModifierDescriptor(shallowEnhancer, arguments[0]) as any
+        } else {
+            return shallowDecorator.apply(null, arguments)
+        }
+    }
 
-	deep(target: Object, property: string, descriptor?: PropertyDescriptor): any;
-	deep<T>(initialValues: T[]): IObservableArray<T>;
-	deep<T>(initialValues: IMap<string | number | boolean, T>): ObservableMap<T>;
-	deep<T>(initialValue: T): T;
-	deep() {
-		if (arguments.length < 2) {
-			// although ref creates actually a modifier descriptor, the type of the resultig properties
-			// of the object is `T` in the end, when the descriptors are interpreted
-			return createModifierDescriptor(deepEnhancer, arguments[0]) as any;
-		} else {
-			return deepDecorator.apply(null, arguments);
-		}
-	}
+    deep(target: Object, property: string, descriptor?: PropertyDescriptor): any
+    deep<T>(initialValues: T[]): IObservableArray<T>
+    deep<T>(initialValues: IMap<string | number | boolean, T>): ObservableMap<T>
+    deep<T>(initialValue: T): T
+    deep() {
+        if (arguments.length < 2) {
+            // although ref creates actually a modifier descriptor, the type of the resultig properties
+            // of the object is `T` in the end, when the descriptors are interpreted
+            return createModifierDescriptor(deepEnhancer, arguments[0]) as any
+        } else {
+            return deepDecorator.apply(null, arguments)
+        }
+    }
 
-	struct(target: Object, property: string, descriptor?: PropertyDescriptor): any;
-	struct<T>(initialValues: T[]): IObservableArray<T>;
-	struct<T>(initialValues: IMap<string | number | boolean, T>): ObservableMap<T>;
-	struct<T>(initialValue: T): T;
-	struct() {
-		if (arguments.length < 2) {
-			// although ref creates actually a modifier descriptor, the type of the resultig properties
-			// of the object is `T` in the end, when the descriptors are interpreted
-			return createModifierDescriptor(deepStructEnhancer, arguments[0]) as any;
-		} else {
-			return deepStructDecorator.apply(null, arguments);
-		}
-	}
+    struct(target: Object, property: string, descriptor?: PropertyDescriptor): any
+    struct<T>(initialValues: T[]): IObservableArray<T>
+    struct<T>(initialValues: IMap<string | number | boolean, T>): ObservableMap<T>
+    struct<T>(initialValue: T): T
+    struct() {
+        if (arguments.length < 2) {
+            // although ref creates actually a modifier descriptor, the type of the resultig properties
+            // of the object is `T` in the end, when the descriptors are interpreted
+            return createModifierDescriptor(deepStructEnhancer, arguments[0]) as any
+        } else {
+            return deepStructDecorator.apply(null, arguments)
+        }
+    }
 }
 
-export const observable: IObservableFactory & IObservableFactories & {
-	deep: {
-		struct<T>(initialValue?: T): T
-	},
-	ref: {
-		struct<T>(initialValue?: T): T
-	}
-} = createObservable as any;
+export const observable: IObservableFactory &
+    IObservableFactories & {
+        deep: {
+            struct<T>(initialValue?: T): T
+        }
+        ref: {
+            struct<T>(initialValue?: T): T
+        }
+    } = createObservable as any
 
 // weird trick to keep our typings nicely with our funcs, and still extend the observable function
 // ES6 class methods aren't enumerable, can't use Object.keys
 Object.getOwnPropertyNames(IObservableFactories.prototype)
-	.filter(name => name !== "constructor")
-	.forEach(name => observable[name] = IObservableFactories.prototype[name]);
+    .filter(name => name !== "constructor")
+    .forEach(name => (observable[name] = IObservableFactories.prototype[name]))
 
-observable.deep.struct = observable.struct;
+observable.deep.struct = observable.struct
 observable.ref.struct = function() {
-	if (arguments.length < 2) {
-		return createModifierDescriptor(refStructEnhancer, arguments[0]) as any;
-	} else {
-		return refStructDecorator.apply(null, arguments);
-	}
-};
+    if (arguments.length < 2) {
+        return createModifierDescriptor(refStructEnhancer, arguments[0]) as any
+    } else {
+        return refStructDecorator.apply(null, arguments)
+    }
+}
 
 function incorrectlyUsedAsDecorator(methodName) {
-	fail(`Expected one or two arguments to observable.${methodName}. Did you accidentally try to use observable.${methodName} as decorator?`);
+    fail(
+        `Expected one or two arguments to observable.${methodName}. Did you accidentally try to use observable.${methodName} as decorator?`
+    )
 }

--- a/src/api/observabledecorator.ts
+++ b/src/api/observabledecorator.ts
@@ -1,30 +1,35 @@
-import {asObservableObject, defineObservableProperty, setPropertyValue} from "../types/observableobject";
-import {invariant, assertPropertyConfigurable} from "../utils/utils";
-import {createClassPropertyDecorator} from "../utils/decorators";
-import {IEnhancer} from "../types/modifiers";
-import {getMessage} from "../utils/messages";
-
+import {
+    asObservableObject,
+    defineObservableProperty,
+    setPropertyValue
+} from "../types/observableobject"
+import { invariant, assertPropertyConfigurable } from "../utils/utils"
+import { createClassPropertyDecorator } from "../utils/decorators"
+import { IEnhancer } from "../types/modifiers"
+import { getMessage } from "../utils/messages"
 
 export function createDecoratorForEnhancer(enhancer: IEnhancer<any>) {
-	invariant(!!enhancer, ":(");
-	return createClassPropertyDecorator(
-		(target, name, baseValue, _, baseDescriptor) => {
-			assertPropertyConfigurable(target, name);
-			invariant(!baseDescriptor || !baseDescriptor.get, getMessage("m022"));
+    invariant(!!enhancer, ":(")
+    return createClassPropertyDecorator(
+        (target, name, baseValue, _, baseDescriptor) => {
+            assertPropertyConfigurable(target, name)
+            invariant(!baseDescriptor || !baseDescriptor.get, getMessage("m022"))
 
-			const adm = asObservableObject(target, undefined);
-			defineObservableProperty(adm, name, baseValue, enhancer);
-		},
-		function (name) {
-			const observable = this.$mobx.values[name];
-			if (observable === undefined) // See #505
-				return undefined;
-			return observable.get();
-		},
-		function (name, value) {
-			setPropertyValue(this, name, value);
-		},
-		true,
-		false
-	);
+            const adm = asObservableObject(target, undefined)
+            defineObservableProperty(adm, name, baseValue, enhancer)
+        },
+        function(name) {
+            const observable = this.$mobx.values[name]
+            if (
+                observable === undefined // See #505
+            )
+                return undefined
+            return observable.get()
+        },
+        function(name, value) {
+            setPropertyValue(this, name, value)
+        },
+        true,
+        false
+    )
 }

--- a/src/api/observe.ts
+++ b/src/api/observe.ts
@@ -1,29 +1,54 @@
-import {IObservableArray, IArrayChange, IArraySplice} from "../types/observablearray";
-import {ObservableMap, IMapChange} from "../types/observablemap";
-import {IObjectChange} from "../types/observableobject";
-import {IComputedValue} from "../core/computedvalue";
+import { IObservableArray, IArrayChange, IArraySplice } from "../types/observablearray"
+import { ObservableMap, IMapChange } from "../types/observablemap"
+import { IObjectChange } from "../types/observableobject"
+import { IComputedValue } from "../core/computedvalue"
 
-import {IObservableValue, IValueDidChange} from "../types/observablevalue";
-import {Lambda} from "../utils/utils";
-import {getAdministration} from "../types/type-utils";
+import { IObservableValue, IValueDidChange } from "../types/observablevalue"
+import { Lambda } from "../utils/utils"
+import { getAdministration } from "../types/type-utils"
 
-export function observe<T>(value: IObservableValue<T> | IComputedValue<T>, listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda;
-export function observe<T>(observableArray: IObservableArray<T>, listener: (change: IArrayChange<T> | IArraySplice<T>) => void, fireImmediately?: boolean): Lambda;
-export function observe<T>(observableMap: ObservableMap<T>, listener: (change: IMapChange<T>) => void, fireImmediately?: boolean): Lambda;
-export function observe<T>(observableMap: ObservableMap<T>, property: string, listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda;
-export function observe(object: Object, listener: (change: IObjectChange) => void, fireImmediately?: boolean): Lambda;
-export function observe(object: Object, property: string, listener: (change: IValueDidChange<any>) => void, fireImmediately?: boolean): Lambda;
+export function observe<T>(
+    value: IObservableValue<T> | IComputedValue<T>,
+    listener: (change: IValueDidChange<T>) => void,
+    fireImmediately?: boolean
+): Lambda
+export function observe<T>(
+    observableArray: IObservableArray<T>,
+    listener: (change: IArrayChange<T> | IArraySplice<T>) => void,
+    fireImmediately?: boolean
+): Lambda
+export function observe<T>(
+    observableMap: ObservableMap<T>,
+    listener: (change: IMapChange<T>) => void,
+    fireImmediately?: boolean
+): Lambda
+export function observe<T>(
+    observableMap: ObservableMap<T>,
+    property: string,
+    listener: (change: IValueDidChange<T>) => void,
+    fireImmediately?: boolean
+): Lambda
+export function observe(
+    object: Object,
+    listener: (change: IObjectChange) => void,
+    fireImmediately?: boolean
+): Lambda
+export function observe(
+    object: Object,
+    property: string,
+    listener: (change: IValueDidChange<any>) => void,
+    fireImmediately?: boolean
+): Lambda
 export function observe(thing, propOrCb?, cbOrFire?, fireImmediately?): Lambda {
-	if (typeof cbOrFire === "function")
-		return observeObservableProperty(thing, propOrCb, cbOrFire, fireImmediately);
-	else
-		return observeObservable(thing, propOrCb, cbOrFire);
+    if (typeof cbOrFire === "function")
+        return observeObservableProperty(thing, propOrCb, cbOrFire, fireImmediately)
+    else return observeObservable(thing, propOrCb, cbOrFire)
 }
 
 function observeObservable(thing, listener, fireImmediately: boolean) {
-	return getAdministration(thing).observe(listener, fireImmediately);
+    return getAdministration(thing).observe(listener, fireImmediately)
 }
 
 function observeObservableProperty(thing, property, listener, fireImmediately: boolean) {
-	return getAdministration(thing, property).observe(listener, fireImmediately);
+    return getAdministration(thing, property).observe(listener, fireImmediately)
 }

--- a/src/api/tojs.ts
+++ b/src/api/tojs.ts
@@ -1,55 +1,47 @@
-import {isObservableArray} from "../types/observablearray";
-import {isObservableObject} from "../types/observableobject";
-import {isObservableMap} from "../types/observablemap";
-import {isObservableValue} from "../types/observablevalue";
-import {isObservable} from "./isobservable";
+import { isObservableArray } from "../types/observablearray"
+import { isObservableObject } from "../types/observableobject"
+import { isObservableMap } from "../types/observablemap"
+import { isObservableValue } from "../types/observablevalue"
+import { isObservable } from "./isobservable"
 
 /**
 	* Basically, a deep clone, so that no reactive property will exist anymore.
 	*/
-export function toJS<T>(source: T, detectCycles?: boolean): T;
-export function toJS(source: any, detectCycles?: boolean): any;
-export function toJS(source, detectCycles: boolean, __alreadySeen: [any, any][]); // internal overload
+export function toJS<T>(source: T, detectCycles?: boolean): T
+export function toJS(source: any, detectCycles?: boolean): any
+export function toJS(source, detectCycles: boolean, __alreadySeen: [any, any][]) // internal overload
 export function toJS(source, detectCycles: boolean = true, __alreadySeen: [any, any][] = []) {
-	// optimization: using ES6 map would be more efficient!
-	// optimization: lift this function outside toJS, this makes recursion expensive
-	function cache(value) {
-		if (detectCycles)
-			__alreadySeen.push([source, value]);
-		return value;
-	}
-	if (isObservable(source)) {
-		if (detectCycles && __alreadySeen === null)
-			__alreadySeen = [];
-		if (detectCycles && source !== null && typeof source === "object") {
-			for (let i = 0, l = __alreadySeen.length; i < l; i++)
-				if (__alreadySeen[i][0] === source)
-					return __alreadySeen[i][1];
-		}
+    // optimization: using ES6 map would be more efficient!
+    // optimization: lift this function outside toJS, this makes recursion expensive
+    function cache(value) {
+        if (detectCycles) __alreadySeen.push([source, value])
+        return value
+    }
+    if (isObservable(source)) {
+        if (detectCycles && __alreadySeen === null) __alreadySeen = []
+        if (detectCycles && source !== null && typeof source === "object") {
+            for (let i = 0, l = __alreadySeen.length; i < l; i++)
+                if (__alreadySeen[i][0] === source) return __alreadySeen[i][1]
+        }
 
-		if (isObservableArray(source)) {
-			const res = cache([]);
-			const toAdd = source.map(value => toJS(value, detectCycles, __alreadySeen));
-			res.length = toAdd.length;
-			for (let i = 0, l = toAdd.length; i < l; i++)
-				res[i] = toAdd[i];
-			return res;
-		}
-		if (isObservableObject(source)) {
-			const res = cache({});
-			for (let key in source)
-				res[key] = toJS(source[key], detectCycles, __alreadySeen);
-			return res;
-		}
-		if (isObservableMap(source)) {
-			const res = cache({});
-			source.forEach(
-				(value, key) => res[key] = toJS(value, detectCycles, __alreadySeen)
-			);
-			return res;
-		}
-		if (isObservableValue(source))
-			return toJS(source.get(), detectCycles, __alreadySeen);
-	}
-	return source;
+        if (isObservableArray(source)) {
+            const res = cache([])
+            const toAdd = source.map(value => toJS(value, detectCycles, __alreadySeen))
+            res.length = toAdd.length
+            for (let i = 0, l = toAdd.length; i < l; i++) res[i] = toAdd[i]
+            return res
+        }
+        if (isObservableObject(source)) {
+            const res = cache({})
+            for (let key in source) res[key] = toJS(source[key], detectCycles, __alreadySeen)
+            return res
+        }
+        if (isObservableMap(source)) {
+            const res = cache({})
+            source.forEach((value, key) => (res[key] = toJS(value, detectCycles, __alreadySeen)))
+            return res
+        }
+        if (isObservableValue(source)) return toJS(source.get(), detectCycles, __alreadySeen)
+    }
+    return source
 }

--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -1,7 +1,6 @@
-import {deprecated} from "../utils/utils";
-import {executeAction} from "../core/action";
-import {getMessage} from "../utils/messages";
-
+import { deprecated } from "../utils/utils"
+import { executeAction } from "../core/action"
+import { getMessage } from "../utils/messages"
 
 /**
  * @deprecated
@@ -14,10 +13,10 @@ import {getMessage} from "../utils/messages";
  * @returns any value that was returned by the 'action' parameter.
  */
 export function transaction<T>(action: () => T, thisArg = undefined): T {
-	deprecated(getMessage("m023"));
-	return runInTransaction.apply(undefined, arguments);
+    deprecated(getMessage("m023"))
+    return runInTransaction.apply(undefined, arguments)
 }
 
 export function runInTransaction<T>(action: () => T, thisArg = undefined): T {
-	return executeAction("", action);
+    return executeAction("", action)
 }

--- a/src/api/whyrun.ts
+++ b/src/api/whyrun.ts
@@ -1,30 +1,27 @@
-import {globalState} from "../core/globalstate";
-import {isComputedValue} from "../core/computedvalue";
-import {isReaction} from "../core/reaction";
-import {getAtom} from "../types/type-utils";
-import {fail} from "../utils/utils";
-import {getMessage} from "../utils/messages";
+import { globalState } from "../core/globalstate"
+import { isComputedValue } from "../core/computedvalue"
+import { isReaction } from "../core/reaction"
+import { getAtom } from "../types/type-utils"
+import { fail } from "../utils/utils"
+import { getMessage } from "../utils/messages"
 
 function log(msg: string): string {
-	console.log(msg);
-	return msg;
+    console.log(msg)
+    return msg
 }
 
 export function whyRun(thing?: any, prop?: string) {
-	switch (arguments.length) {
-		case 0:
-			thing = globalState.trackingDerivation;
-			if (!thing)
-				return log(getMessage("m024"));
-			break;
-		case 2:
-			thing = getAtom(thing, prop);
-			break;
-	}
-	thing = getAtom(thing);
-	if (isComputedValue(thing))
-		return log(thing.whyRun());
-	else if (isReaction(thing))
-		return log(thing.whyRun());
-	return fail(getMessage("m025"));
+    switch (arguments.length) {
+        case 0:
+            thing = globalState.trackingDerivation
+            if (!thing) return log(getMessage("m024"))
+            break
+        case 2:
+            thing = getAtom(thing, prop)
+            break
+    }
+    thing = getAtom(thing)
+    if (isComputedValue(thing)) return log(thing.whyRun())
+    else if (isReaction(thing)) return log(thing.whyRun())
+    return fail(getMessage("m025"))
 }

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -1,112 +1,117 @@
-import {IDerivation} from "./derivation";
-import {invariant} from "../utils/utils";
-import {untrackedStart, untrackedEnd} from "./derivation";
-import {startBatch, endBatch} from "./observable";
-import {isSpyEnabled, spyReportStart, spyReportEnd} from "./spy";
-import {globalState} from "./globalstate";
-import {getMessage} from "../utils/messages";
+import { IDerivation } from "./derivation"
+import { invariant } from "../utils/utils"
+import { untrackedStart, untrackedEnd } from "./derivation"
+import { startBatch, endBatch } from "./observable"
+import { isSpyEnabled, spyReportStart, spyReportEnd } from "./spy"
+import { globalState } from "./globalstate"
+import { getMessage } from "../utils/messages"
 
-export interface IAction{
-	originalFn: Function
-	isMobxAction: boolean
+export interface IAction {
+    originalFn: Function
+    isMobxAction: boolean
 }
 
 export function createAction(actionName: string, fn: Function): Function & IAction {
-	invariant(typeof fn === "function", getMessage("m026"));
-	invariant(typeof actionName === "string" && actionName.length > 0, `actions should have valid names, got: '${actionName}'`);
-	const res = function () {
-		return executeAction(actionName, fn, this, arguments);
-	};
-	(res as any).originalFn = fn;
-	(res as any).isMobxAction = true;
-	return res as any;
+    invariant(typeof fn === "function", getMessage("m026"))
+    invariant(
+        typeof actionName === "string" && actionName.length > 0,
+        `actions should have valid names, got: '${actionName}'`
+    )
+    const res = function() {
+        return executeAction(actionName, fn, this, arguments)
+    }
+    ;(res as any).originalFn = fn
+    ;(res as any).isMobxAction = true
+    return res as any
 }
 
 export function executeAction(actionName: string, fn: Function, scope?: any, args?: IArguments) {
-	const runInfo = startAction(actionName, fn, scope, args);
-	try {
-		return fn.apply(scope, args);
-	}
-	finally {
-		endAction(runInfo);
-	}
+    const runInfo = startAction(actionName, fn, scope, args)
+    try {
+        return fn.apply(scope, args)
+    } finally {
+        endAction(runInfo)
+    }
 }
 
 interface IActionRunInfo {
-	prevDerivation: IDerivation | null;
-	prevAllowStateChanges: boolean;
-	notifySpy: boolean;
-	startTime: number;
+    prevDerivation: IDerivation | null
+    prevAllowStateChanges: boolean
+    notifySpy: boolean
+    startTime: number
 }
 
-function startAction(actionName: string, fn: Function, scope: any, args?: IArguments): IActionRunInfo {
-	const notifySpy = isSpyEnabled() && !!actionName;
-	let startTime: number = 0;
-	if (notifySpy) {
-		startTime = Date.now();
-		const l = (args && args.length) || 0;
-		const flattendArgs = new Array(l);
-		if (l > 0) for (let i = 0; i < l; i++)
-			flattendArgs[i] = args![i];
-		spyReportStart({
-			type: "action",
-			name: actionName,
-			fn,
-			object: scope,
-			arguments: flattendArgs
-		});
-	}
-	const prevDerivation = untrackedStart();
-	startBatch();
-	const prevAllowStateChanges = allowStateChangesStart(true);
-	return {
-		prevDerivation,
-		prevAllowStateChanges,
-		notifySpy,
-		startTime
-	};
+function startAction(
+    actionName: string,
+    fn: Function,
+    scope: any,
+    args?: IArguments
+): IActionRunInfo {
+    const notifySpy = isSpyEnabled() && !!actionName
+    let startTime: number = 0
+    if (notifySpy) {
+        startTime = Date.now()
+        const l = (args && args.length) || 0
+        const flattendArgs = new Array(l)
+        if (l > 0) for (let i = 0; i < l; i++) flattendArgs[i] = args![i]
+        spyReportStart({
+            type: "action",
+            name: actionName,
+            fn,
+            object: scope,
+            arguments: flattendArgs
+        })
+    }
+    const prevDerivation = untrackedStart()
+    startBatch()
+    const prevAllowStateChanges = allowStateChangesStart(true)
+    return {
+        prevDerivation,
+        prevAllowStateChanges,
+        notifySpy,
+        startTime
+    }
 }
 
 function endAction(runInfo: IActionRunInfo) {
-	allowStateChangesEnd(runInfo.prevAllowStateChanges);
-	endBatch();
-	untrackedEnd(runInfo.prevDerivation);
-	if (runInfo.notifySpy)
-		spyReportEnd({ time: Date.now() - runInfo.startTime });
+    allowStateChangesEnd(runInfo.prevAllowStateChanges)
+    endBatch()
+    untrackedEnd(runInfo.prevDerivation)
+    if (runInfo.notifySpy) spyReportEnd({ time: Date.now() - runInfo.startTime })
 }
 
 export function useStrict(strict: boolean): void {
-	invariant(globalState.trackingDerivation === null, getMessage("m028"));
-	globalState.strictMode = strict;
-	globalState.allowStateChanges = !strict;
+    invariant(globalState.trackingDerivation === null, getMessage("m028"))
+    globalState.strictMode = strict
+    globalState.allowStateChanges = !strict
 }
 
 export function isStrictModeEnabled(): boolean {
-	return globalState.strictMode;
+    return globalState.strictMode
 }
 
 export function allowStateChanges<T>(allowStateChanges: boolean, func: () => T): T {
-	// TODO: deprecate / refactor this function in next major
-	// Currently only used by `@observer`
-	// Proposed change: remove first param, rename to `forbidStateChanges`,
-	// require error callback instead of the hardcoded error message now used
-	// Use `inAction` instead of allowStateChanges in derivation.ts to check strictMode
-	const prev = allowStateChangesStart(allowStateChanges);
-	let res;
-	try {
-		res = func();
-	} finally {
-		allowStateChangesEnd(prev);
-	}
-	return res;
+    // TODO: deprecate / refactor this function in next major
+    // Currently only used by `@observer`
+    // Proposed change: remove first param, rename to `forbidStateChanges`,
+    // require error callback instead of the hardcoded error message now used
+    // Use `inAction` instead of allowStateChanges in derivation.ts to check strictMode
+    const prev = allowStateChangesStart(allowStateChanges)
+    let res
+    try {
+        res = func()
+    } finally {
+        allowStateChangesEnd(prev)
+    }
+    return res
 }
 
 export function allowStateChangesStart(allowStateChanges: boolean) {
-	const prev = globalState.allowStateChanges;
-	globalState.allowStateChanges = allowStateChanges;
-	return prev;
+    const prev = globalState.allowStateChanges
+    globalState.allowStateChanges = allowStateChanges
+    return prev
 }
 
 export function allowStateChangesEnd(prev: boolean) {
-	globalState.allowStateChanges = prev;
+    globalState.allowStateChanges = prev
 }

--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -1,6 +1,4 @@
-
-export interface IAtom extends IObservable {
-}
+export interface IAtom extends IObservable {}
 
 /**
  * Anything that can be used to _store_ state is an Atom in mobx. Atoms have two important jobs
@@ -9,82 +7,85 @@ export interface IAtom extends IObservable {
  * 2) they should notify mobx whenever they have _changed_. This way mobx can re-run any functions (derivations) that are using this atom.
  */
 export class BaseAtom implements IAtom {
-	isPendingUnobservation = true; // for effective unobserving. BaseAtom has true, for extra optimization, so its onBecomeUnobserved never gets called, because it's not needed
-	observers = [];
-	observersIndexes = {};
+    isPendingUnobservation = true // for effective unobserving. BaseAtom has true, for extra optimization, so its onBecomeUnobserved never gets called, because it's not needed
+    observers = []
+    observersIndexes = {}
 
-	diffValue = 0;
-	lastAccessedBy = 0;
-	lowestObserverState = IDerivationState.NOT_TRACKING;
-	/**
+    diffValue = 0
+    lastAccessedBy = 0
+    lowestObserverState = IDerivationState.NOT_TRACKING
+    /**
 	 * Create a new atom. For debugging purposes it is recommended to give it a name.
 	 * The onBecomeObserved and onBecomeUnobserved callbacks can be used for resource management.
 	 */
-	constructor(public name = "Atom@" + getNextId()) { }
+    constructor(public name = "Atom@" + getNextId()) {}
 
-	public onBecomeUnobserved() {
-		// noop
-	}
+    public onBecomeUnobserved() {
+        // noop
+    }
 
-	/**
+    /**
 	 * Invoke this method to notify mobx that your atom has been used somehow.
 	 */
-	public reportObserved() {
-		reportObserved(this);
-	}
+    public reportObserved() {
+        reportObserved(this)
+    }
 
-	/**
+    /**
 	 * Invoke this method _after_ this method has changed to signal mobx that all its observers should invalidate.
 	 */
-	public reportChanged() {
-		startBatch();
-		propagateChanged(this);
-		endBatch();
-	}
+    public reportChanged() {
+        startBatch()
+        propagateChanged(this)
+        endBatch()
+    }
 
-	toString() {
-		return this.name;
-	}
+    toString() {
+        return this.name
+    }
 }
 
 export class Atom extends BaseAtom implements IAtom {
-	isPendingUnobservation = false; // for effective unobserving.
-	public isBeingTracked = false;
+    isPendingUnobservation = false // for effective unobserving.
+    public isBeingTracked = false
 
-	/**
+    /**
 	 * Create a new atom. For debugging purposes it is recommended to give it a name.
 	 * The onBecomeObserved and onBecomeUnobserved callbacks can be used for resource management.
 	 */
-	constructor(public name = "Atom@" + getNextId(), public onBecomeObservedHandler: () => void = noop, public onBecomeUnobservedHandler: () => void = noop) {
-		super(name);
-	}
+    constructor(
+        public name = "Atom@" + getNextId(),
+        public onBecomeObservedHandler: () => void = noop,
+        public onBecomeUnobservedHandler: () => void = noop
+    ) {
+        super(name)
+    }
 
-	public reportObserved(): boolean {
-		startBatch();
+    public reportObserved(): boolean {
+        startBatch()
 
-		super.reportObserved();
+        super.reportObserved()
 
-		if (!this.isBeingTracked) {
-			this.isBeingTracked = true;
-			this.onBecomeObservedHandler();
-		}
+        if (!this.isBeingTracked) {
+            this.isBeingTracked = true
+            this.onBecomeObservedHandler()
+        }
 
-		endBatch();
-		return !!globalState.trackingDerivation;
-		// return doesn't really give useful info, because it can be as well calling computed which calls atom (no reactions)
-		// also it could not trigger when calculating reaction dependent on Atom because Atom's value was cached by computed called by given reaction.
-	}
+        endBatch()
+        return !!globalState.trackingDerivation
+        // return doesn't really give useful info, because it can be as well calling computed which calls atom (no reactions)
+        // also it could not trigger when calculating reaction dependent on Atom because Atom's value was cached by computed called by given reaction.
+    }
 
-	public onBecomeUnobserved() {
-		this.isBeingTracked = false;
-		this.onBecomeUnobservedHandler();
-	}
+    public onBecomeUnobserved() {
+        this.isBeingTracked = false
+        this.onBecomeUnobservedHandler()
+    }
 }
 
+import { globalState } from "./globalstate"
+import { IObservable, propagateChanged, reportObserved, startBatch, endBatch } from "./observable"
+import { IDerivationState } from "./derivation"
+import { createInstanceofPredicate, noop, getNextId } from "../utils/utils"
 
-import {globalState} from "./globalstate";
-import {IObservable, propagateChanged, reportObserved, startBatch, endBatch} from "./observable";
-import {IDerivationState} from "./derivation";
-import {createInstanceofPredicate, noop, getNextId} from "../utils/utils";
-
-export const isAtom = createInstanceofPredicate("Atom", BaseAtom);
+export const isAtom = createInstanceofPredicate("Atom", BaseAtom)

--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -1,19 +1,45 @@
-import {IObservable, reportObserved, propagateMaybeChanged, propagateChangeConfirmed, startBatch, endBatch, getObservers} from "./observable";
-import {IDerivation, IDerivationState, trackDerivedFunction, clearObserving, untrackedStart, untrackedEnd, shouldCompute, CaughtException, isCaughtException} from "./derivation";
-import {globalState} from "./globalstate";
-import {createAction} from "./action";
-import {createInstanceofPredicate, getNextId, invariant, Lambda, unique, joinStrings, primitiveSymbol, toPrimitive} from "../utils/utils";
-import {isSpyEnabled, spyReport} from "./spy";
-import {autorun} from "../api/autorun";
-import {IEqualsComparer} from "../types/comparer";
-import {IValueDidChange} from "../types/observablevalue";
-import {getMessage} from "../utils/messages";
-
+import {
+    IObservable,
+    reportObserved,
+    propagateMaybeChanged,
+    propagateChangeConfirmed,
+    startBatch,
+    endBatch,
+    getObservers
+} from "./observable"
+import {
+    IDerivation,
+    IDerivationState,
+    trackDerivedFunction,
+    clearObserving,
+    untrackedStart,
+    untrackedEnd,
+    shouldCompute,
+    CaughtException,
+    isCaughtException
+} from "./derivation"
+import { globalState } from "./globalstate"
+import { createAction } from "./action"
+import {
+    createInstanceofPredicate,
+    getNextId,
+    invariant,
+    Lambda,
+    unique,
+    joinStrings,
+    primitiveSymbol,
+    toPrimitive
+} from "../utils/utils"
+import { isSpyEnabled, spyReport } from "./spy"
+import { autorun } from "../api/autorun"
+import { IEqualsComparer } from "../types/comparer"
+import { IValueDidChange } from "../types/observablevalue"
+import { getMessage } from "../utils/messages"
 
 export interface IComputedValue<T> {
-	get(): T;
-	set(value: T): void;
-	observe(listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda;
+    get(): T
+    set(value: T): void
+    observe(listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda
 }
 
 /**
@@ -34,26 +60,26 @@ export interface IComputedValue<T> {
  * If at any point it's outside batch and it isn't observed: reset everything and go to 1.
  */
 export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDerivation {
-	dependenciesState = IDerivationState.NOT_TRACKING;
-	observing = [];       // nodes we are looking at. Our value depends on these nodes
-	newObserving = null; // during tracking it's an array with new observed observers
+    dependenciesState = IDerivationState.NOT_TRACKING
+    observing = [] // nodes we are looking at. Our value depends on these nodes
+    newObserving = null // during tracking it's an array with new observed observers
 
-	isPendingUnobservation: boolean = false;
-	observers = [];
-	observersIndexes = {};
-	diffValue = 0;
-	runId = 0;
-	lastAccessedBy = 0;
-	lowestObserverState = IDerivationState.UP_TO_DATE;
-	unboundDepsCount = 0;
-	__mapid = "#" + getNextId();
-	protected value: T | undefined | CaughtException = new CaughtException(null);
-	name: string;
-	isComputing: boolean = false; // to check for cycles
-	isRunningSetter: boolean = false;
-	setter: (value: T) => void;
+    isPendingUnobservation: boolean = false
+    observers = []
+    observersIndexes = {}
+    diffValue = 0
+    runId = 0
+    lastAccessedBy = 0
+    lowestObserverState = IDerivationState.UP_TO_DATE
+    unboundDepsCount = 0
+    __mapid = "#" + getNextId()
+    protected value: T | undefined | CaughtException = new CaughtException(null)
+    name: string
+    isComputing: boolean = false // to check for cycles
+    isRunningSetter: boolean = false
+    setter: (value: T) => void
 
-	/**
+    /**
 	 * Create a new computed value based on a function expression.
 	 *
 	 * The `name` property is for debug purposes only.
@@ -65,158 +91,174 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
 	 * don't want to notify observers if it is structurally the same.
 	 * This is useful for working with vectors, mouse coordinates etc.
 	 */
-	constructor(public derivation: () => T, public scope: Object | undefined, private equals: IEqualsComparer<any>, name: string, setter?: (v: T) => void) {
-		this.name  = name || "ComputedValue@" + getNextId();
-		if (setter)
-			this.setter = createAction(name + "-setter", setter) as any;
-	}
+    constructor(
+        public derivation: () => T,
+        public scope: Object | undefined,
+        private equals: IEqualsComparer<any>,
+        name: string,
+        setter?: (v: T) => void
+    ) {
+        this.name = name || "ComputedValue@" + getNextId()
+        if (setter) this.setter = createAction(name + "-setter", setter) as any
+    }
 
-	onBecomeStale() {
-		propagateMaybeChanged(this);
-	}
+    onBecomeStale() {
+        propagateMaybeChanged(this)
+    }
 
-	onBecomeUnobserved() {
-		clearObserving(this);
-		this.value = undefined;
-	}
+    onBecomeUnobserved() {
+        clearObserving(this)
+        this.value = undefined
+    }
 
-	/**
+    /**
 	 * Returns the current value of this computed value.
 	 * Will evaluate its computation first if needed.
 	 */
-	public get(): T {
-		invariant(!this.isComputing, `Cycle detected in computation ${this.name}`, this.derivation);
-		if (globalState.inBatch === 0) {
-			// This is an minor optimization which could be omitted to simplify the code
-			// The computedValue is accessed outside of any mobx stuff. Batch observing should be enough and don't need
-			// tracking as it will never be called again inside this batch.
-			startBatch();
-			if (shouldCompute(this))
-				this.value = this.computeValue(false);
-			endBatch();
-		} else {
-			reportObserved(this);
-			if (shouldCompute(this))
-				if (this.trackAndCompute())
-					propagateChangeConfirmed(this);
-		}
-		const result = this.value!;
+    public get(): T {
+        invariant(!this.isComputing, `Cycle detected in computation ${this.name}`, this.derivation)
+        if (globalState.inBatch === 0) {
+            // This is an minor optimization which could be omitted to simplify the code
+            // The computedValue is accessed outside of any mobx stuff. Batch observing should be enough and don't need
+            // tracking as it will never be called again inside this batch.
+            startBatch()
+            if (shouldCompute(this)) this.value = this.computeValue(false)
+            endBatch()
+        } else {
+            reportObserved(this)
+            if (shouldCompute(this)) if (this.trackAndCompute()) propagateChangeConfirmed(this)
+        }
+        const result = this.value!
 
-		if (isCaughtException(result))
-			throw result.cause;
-		return result;
-	}
+        if (isCaughtException(result)) throw result.cause
+        return result
+    }
 
-	public peek(): T {
-		const res = this.computeValue(false);
-		if (isCaughtException(res))
-			throw res.cause;
-		return res;
-	}
+    public peek(): T {
+        const res = this.computeValue(false)
+        if (isCaughtException(res)) throw res.cause
+        return res
+    }
 
-	public set(value: T) {
-		if (this.setter) {
-			invariant(!this.isRunningSetter, `The setter of computed value '${this.name}' is trying to update itself. Did you intend to update an _observable_ value, instead of the computed property?`);
-			this.isRunningSetter = true;
-			try {
-				this.setter.call(this.scope, value);
-			} finally {
-				this.isRunningSetter = false;
-			}
-		}
-		else
-			invariant(false, `[ComputedValue '${this.name}'] It is not possible to assign a new value to a computed value.`);
-	}
+    public set(value: T) {
+        if (this.setter) {
+            invariant(
+                !this.isRunningSetter,
+                `The setter of computed value '${this
+                    .name}' is trying to update itself. Did you intend to update an _observable_ value, instead of the computed property?`
+            )
+            this.isRunningSetter = true
+            try {
+                this.setter.call(this.scope, value)
+            } finally {
+                this.isRunningSetter = false
+            }
+        } else
+            invariant(
+                false,
+                `[ComputedValue '${this
+                    .name}'] It is not possible to assign a new value to a computed value.`
+            )
+    }
 
-	private trackAndCompute(): boolean {
-		if (isSpyEnabled()) {
-			spyReport({
-				object: this.scope,
-				type: "compute",
-				fn: this.derivation
-			});
-		}
-		const oldValue = this.value;
-		const newValue = this.value = this.computeValue(true);
-		return (
-			isCaughtException(oldValue) ||
-			isCaughtException(newValue) ||
-			!this.equals(oldValue, newValue)
-		);
-	}
+    private trackAndCompute(): boolean {
+        if (isSpyEnabled()) {
+            spyReport({
+                object: this.scope,
+                type: "compute",
+                fn: this.derivation
+            })
+        }
+        const oldValue = this.value
+        const newValue = (this.value = this.computeValue(true))
+        return (
+            isCaughtException(oldValue) ||
+            isCaughtException(newValue) ||
+            !this.equals(oldValue, newValue)
+        )
+    }
 
-	computeValue(track: boolean) {
-		this.isComputing = true;
-		globalState.computationDepth++;
-		let res: T | CaughtException;
-		if (track) {
-			res = trackDerivedFunction(this, this.derivation, this.scope);
-		} else {
-			try {
-				res = this.derivation.call(this.scope);
-			} catch (e) {
-				res = new CaughtException(e);
-			}
-		}
-		globalState.computationDepth--;
-		this.isComputing = false;
-		return res;
-	};
+    computeValue(track: boolean) {
+        this.isComputing = true
+        globalState.computationDepth++
+        let res: T | CaughtException
+        if (track) {
+            res = trackDerivedFunction(this, this.derivation, this.scope)
+        } else {
+            try {
+                res = this.derivation.call(this.scope)
+            } catch (e) {
+                res = new CaughtException(e)
+            }
+        }
+        globalState.computationDepth--
+        this.isComputing = false
+        return res
+    }
 
-	observe(listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda {
-		let firstTime = true;
-		let prevValue: T | undefined = undefined;
-		return autorun(() => {
-			let newValue = this.get();
-			if (!firstTime || fireImmediately) {
-				const prevU = untrackedStart();
-				listener({
-					type: "update",
-					object: this,
-					newValue,
-					oldValue: prevValue
-				});
-				untrackedEnd(prevU);
-			}
-			firstTime = false;
-			prevValue = newValue;
-		});
-	}
+    observe(listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda {
+        let firstTime = true
+        let prevValue: T | undefined = undefined
+        return autorun(() => {
+            let newValue = this.get()
+            if (!firstTime || fireImmediately) {
+                const prevU = untrackedStart()
+                listener({
+                    type: "update",
+                    object: this,
+                    newValue,
+                    oldValue: prevValue
+                })
+                untrackedEnd(prevU)
+            }
+            firstTime = false
+            prevValue = newValue
+        })
+    }
 
-	toJSON() {
-		return this.get();
-	}
+    toJSON() {
+        return this.get()
+    }
 
-	toString() {
-		return `${this.name}[${this.derivation.toString()}]`;
-	}
+    toString() {
+        return `${this.name}[${this.derivation.toString()}]`
+    }
 
-	valueOf(): T {
-		return toPrimitive(this.get());
-	};
+    valueOf(): T {
+        return toPrimitive(this.get())
+    }
 
-	whyRun() {
-		const isTracking = Boolean(globalState.trackingDerivation);
-		const observing = unique(this.isComputing ? this.newObserving! : this.observing).map((dep: any) => dep.name);
-		const observers = unique(getObservers(this).map(dep => dep.name));
-		return (`
+    whyRun() {
+        const isTracking = Boolean(globalState.trackingDerivation)
+        const observing = unique(this.isComputing ? this.newObserving! : this.observing).map(
+            (dep: any) => dep.name
+        )
+        const observers = unique(getObservers(this).map(dep => dep.name))
+        return (
+            `
 WhyRun? computation '${this.name}':
- * Running because: ${isTracking ? "[active] the value of this computation is needed by a reaction" : this.isComputing ? "[get] The value of this computed was requested outside a reaction" : "[idle] not running at the moment"}
+ * Running because: ${isTracking
+     ? "[active] the value of this computation is needed by a reaction"
+     : this.isComputing
+       ? "[get] The value of this computed was requested outside a reaction"
+       : "[idle] not running at the moment"}
 ` +
-(this.dependenciesState === IDerivationState.NOT_TRACKING ? getMessage("m032")  :
-` * This computation will re-run if any of the following observables changes:
+            (this.dependenciesState === IDerivationState.NOT_TRACKING
+                ? getMessage("m032")
+                : ` * This computation will re-run if any of the following observables changes:
     ${joinStrings(observing)}
-    ${(this.isComputing && isTracking) ? " (... or any observable accessed during the remainder of the current run)" : ""}
+    ${this.isComputing && isTracking
+        ? " (... or any observable accessed during the remainder of the current run)"
+        : ""}
 	${getMessage("m038")}
 
   * If the outcome of this computation changes, the following observers will be re-run:
     ${joinStrings(observers)}
-`
-)
-		);
-	}
+`)
+        )
+    }
 }
 
-ComputedValue.prototype[primitiveSymbol()] = ComputedValue.prototype.valueOf;
+ComputedValue.prototype[primitiveSymbol()] = ComputedValue.prototype.valueOf
 
-export const isComputedValue = createInstanceofPredicate("ComputedValue", ComputedValue);
+export const isComputedValue = createInstanceofPredicate("ComputedValue", ComputedValue)

--- a/src/core/derivation.ts
+++ b/src/core/derivation.ts
@@ -1,29 +1,28 @@
-import {IObservable, IDepTreeNode, addObserver, removeObserver} from "./observable";
-import {IAtom} from "./atom";
-import {globalState} from "./globalstate";
-import {fail} from "../utils/utils";
-import {isComputedValue} from "./computedvalue";
-import {getMessage} from "../utils/messages";
-
+import { IObservable, IDepTreeNode, addObserver, removeObserver } from "./observable"
+import { IAtom } from "./atom"
+import { globalState } from "./globalstate"
+import { fail } from "../utils/utils"
+import { isComputedValue } from "./computedvalue"
+import { getMessage } from "../utils/messages"
 
 export enum IDerivationState {
-	// before being run or (outside batch and not being observed)
-	// at this point derivation is not holding any data about dependency tree
-	NOT_TRACKING = -1,
-	// no shallow dependency changed since last computation
-	// won't recalculate derivation
-	// this is what makes mobx fast
-	UP_TO_DATE = 0,
-	// some deep dependency changed, but don't know if shallow dependency changed
-	// will require to check first if UP_TO_DATE or POSSIBLY_STALE
-	// currently only ComputedValue will propagate POSSIBLY_STALE
-	//
-	// having this state is second big optimization:
-	// don't have to recompute on every dependency change, but only when it's needed
-	POSSIBLY_STALE = 1,
-	// A shallow dependency has changed since last computation and the derivation
-	// will need to recompute when it's needed next.
-	STALE = 2
+    // before being run or (outside batch and not being observed)
+    // at this point derivation is not holding any data about dependency tree
+    NOT_TRACKING = -1,
+    // no shallow dependency changed since last computation
+    // won't recalculate derivation
+    // this is what makes mobx fast
+    UP_TO_DATE = 0,
+    // some deep dependency changed, but don't know if shallow dependency changed
+    // will require to check first if UP_TO_DATE or POSSIBLY_STALE
+    // currently only ComputedValue will propagate POSSIBLY_STALE
+    //
+    // having this state is second big optimization:
+    // don't have to recompute on every dependency change, but only when it's needed
+    POSSIBLY_STALE = 1,
+    // A shallow dependency has changed since last computation and the derivation
+    // will need to recompute when it's needed next.
+    STALE = 2
 }
 
 /**
@@ -31,30 +30,30 @@ export enum IDerivationState {
  * See https://medium.com/@mweststrate/becoming-fully-reactive-an-in-depth-explanation-of-mobservable-55995262a254#.xvbh6qd74
  */
 export interface IDerivation extends IDepTreeNode {
-	observing: IObservable[];
-	newObserving: null | IObservable[];
-	dependenciesState: IDerivationState;
-	/**
+    observing: IObservable[]
+    newObserving: null | IObservable[]
+    dependenciesState: IDerivationState
+    /**
 	 * Id of the current run of a derivation. Each time the derivation is tracked
 	 * this number is increased by one. This number is globally unique
 	 */
-	runId: number;
-	/**
+    runId: number
+    /**
 	 * amount of dependencies used by the derivation in this run, which has not been bound yet.
 	 */
-	unboundDepsCount: number;
-	__mapid: string;
-	onBecomeStale();
+    unboundDepsCount: number
+    __mapid: string
+    onBecomeStale()
 }
 
 export class CaughtException {
-	constructor(public cause: any) {
-		// Empty
-	}
+    constructor(public cause: any) {
+        // Empty
+    }
 }
 
 export function isCaughtException(e): e is CaughtException {
-	return e instanceof CaughtException;
+    return e instanceof CaughtException
 }
 
 /**
@@ -69,49 +68,52 @@ export function isCaughtException(e): e is CaughtException {
  * up until accessing x-th dependency.
  */
 export function shouldCompute(derivation: IDerivation): boolean {
-	switch (derivation.dependenciesState) {
-		case IDerivationState.UP_TO_DATE: return false;
-		case IDerivationState.NOT_TRACKING: case IDerivationState.STALE: return true;
-		case IDerivationState.POSSIBLY_STALE: {
-			const prevUntracked = untrackedStart(); // no need for those computeds to be reported, they will be picked up in trackDerivedFunction.
-			const obs = derivation.observing, l = obs.length;
-			for (let i = 0; i < l; i++) {
-				const obj = obs[i];
-				if (isComputedValue(obj)) {
-					try {
-						obj.get();
-					} catch (e) {
-						// we are not interested in the value *or* exception at this moment, but if there is one, notify all
-						untrackedEnd(prevUntracked);
-						return true;
-					}
-					// if ComputedValue `obj` actually changed it will be computed and propagated to its observers.
-					// and `derivation` is an observer of `obj`
-					if ((derivation as any).dependenciesState === IDerivationState.STALE) {
-						untrackedEnd(prevUntracked);
-						return true;
-					}
-				}
-			}
-			changeDependenciesStateTo0(derivation);
-			untrackedEnd(prevUntracked);
-			return false;
-		}
-	}
+    switch (derivation.dependenciesState) {
+        case IDerivationState.UP_TO_DATE:
+            return false
+        case IDerivationState.NOT_TRACKING:
+        case IDerivationState.STALE:
+            return true
+        case IDerivationState.POSSIBLY_STALE: {
+            const prevUntracked = untrackedStart() // no need for those computeds to be reported, they will be picked up in trackDerivedFunction.
+            const obs = derivation.observing,
+                l = obs.length
+            for (let i = 0; i < l; i++) {
+                const obj = obs[i]
+                if (isComputedValue(obj)) {
+                    try {
+                        obj.get()
+                    } catch (e) {
+                        // we are not interested in the value *or* exception at this moment, but if there is one, notify all
+                        untrackedEnd(prevUntracked)
+                        return true
+                    }
+                    // if ComputedValue `obj` actually changed it will be computed and propagated to its observers.
+                    // and `derivation` is an observer of `obj`
+                    if ((derivation as any).dependenciesState === IDerivationState.STALE) {
+                        untrackedEnd(prevUntracked)
+                        return true
+                    }
+                }
+            }
+            changeDependenciesStateTo0(derivation)
+            untrackedEnd(prevUntracked)
+            return false
+        }
+    }
 }
 
 export function isComputingDerivation() {
-	return globalState.trackingDerivation !== null; // filter out actions inside computations
+    return globalState.trackingDerivation !== null // filter out actions inside computations
 }
 
 export function checkIfStateModificationsAreAllowed(atom: IAtom) {
-	const hasObservers = atom.observers.length > 0;
-	// Should never be possible to change an observed observable from inside computed, see #798
-	if (globalState.computationDepth > 0 && hasObservers)
-		fail(getMessage("m031") + atom.name);
-	// Should not be possible to change observed state outside strict mode, except during initialization, see #563
-	if (!globalState.allowStateChanges && hasObservers)
-		fail(getMessage(globalState.strictMode ? "m030a" : "m030b") + atom.name);
+    const hasObservers = atom.observers.length > 0
+    // Should never be possible to change an observed observable from inside computed, see #798
+    if (globalState.computationDepth > 0 && hasObservers) fail(getMessage("m031") + atom.name)
+    // Should not be possible to change observed state outside strict mode, except during initialization, see #563
+    if (!globalState.allowStateChanges && hasObservers)
+        fail(getMessage(globalState.strictMode ? "m030a" : "m030b") + atom.name)
 }
 
 /**
@@ -120,23 +122,23 @@ export function checkIfStateModificationsAreAllowed(atom: IAtom) {
  * as observer of any of the accessed observables.
  */
 export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T, context) {
-	// pre allocate array allocation + room for variation in deps
-	// array will be trimmed by bindDependencies
-	changeDependenciesStateTo0(derivation);
-	derivation.newObserving = new Array(derivation.observing.length + 100);
-	derivation.unboundDepsCount = 0;
-	derivation.runId = ++globalState.runId;
-	const prevTracking = globalState.trackingDerivation;
-	globalState.trackingDerivation = derivation;
-	let result;
-	try {
-		result = f.call(context);
-	} catch (e) {
-		result = new CaughtException(e);
-	}
-	globalState.trackingDerivation = prevTracking;
-	bindDependencies(derivation);
-	return result;
+    // pre allocate array allocation + room for variation in deps
+    // array will be trimmed by bindDependencies
+    changeDependenciesStateTo0(derivation)
+    derivation.newObserving = new Array(derivation.observing.length + 100)
+    derivation.unboundDepsCount = 0
+    derivation.runId = ++globalState.runId
+    const prevTracking = globalState.trackingDerivation
+    globalState.trackingDerivation = derivation
+    let result
+    try {
+        result = f.call(context)
+    } catch (e) {
+        result = new CaughtException(e)
+    }
+    globalState.trackingDerivation = prevTracking
+    bindDependencies(derivation)
+    return result
 }
 
 /**
@@ -145,91 +147,91 @@ export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T, con
  * notify observers that become observed/unobserved
  */
 function bindDependencies(derivation: IDerivation) {
-	// invariant(derivation.dependenciesState !== IDerivationState.NOT_TRACKING, "INTERNAL ERROR bindDependencies expects derivation.dependenciesState !== -1");
+    // invariant(derivation.dependenciesState !== IDerivationState.NOT_TRACKING, "INTERNAL ERROR bindDependencies expects derivation.dependenciesState !== -1");
 
-	const prevObserving = derivation.observing;
-	const observing = derivation.observing = derivation.newObserving!;
-	let lowestNewObservingDerivationState = IDerivationState.UP_TO_DATE;
+    const prevObserving = derivation.observing
+    const observing = (derivation.observing = derivation.newObserving!)
+    let lowestNewObservingDerivationState = IDerivationState.UP_TO_DATE
 
-	derivation.newObserving = null; // newObserving shouldn't be needed outside tracking
+    derivation.newObserving = null // newObserving shouldn't be needed outside tracking
 
-	// Go through all new observables and check diffValue: (this list can contain duplicates):
-	//   0: first occurrence, change to 1 and keep it
-	//   1: extra occurrence, drop it
-	let i0 = 0, l = derivation.unboundDepsCount;
-	for (let i = 0; i < l; i++) {
-		const dep = observing[i];
-		if (dep.diffValue === 0) {
-			dep.diffValue = 1;
-			if (i0 !== i) observing[i0] = dep;
-			i0++;
-		}
+    // Go through all new observables and check diffValue: (this list can contain duplicates):
+    //   0: first occurrence, change to 1 and keep it
+    //   1: extra occurrence, drop it
+    let i0 = 0,
+        l = derivation.unboundDepsCount
+    for (let i = 0; i < l; i++) {
+        const dep = observing[i]
+        if (dep.diffValue === 0) {
+            dep.diffValue = 1
+            if (i0 !== i) observing[i0] = dep
+            i0++
+        }
 
-		// Upcast is 'safe' here, because if dep is IObservable, `dependenciesState` will be undefined,
-		// not hitting the condition
-		if ((dep as any as IDerivation).dependenciesState > lowestNewObservingDerivationState) {
-			lowestNewObservingDerivationState = (dep as any as IDerivation).dependenciesState;
-		}
-	}
-	observing.length = i0;
+        // Upcast is 'safe' here, because if dep is IObservable, `dependenciesState` will be undefined,
+        // not hitting the condition
+        if (((dep as any) as IDerivation).dependenciesState > lowestNewObservingDerivationState) {
+            lowestNewObservingDerivationState = ((dep as any) as IDerivation).dependenciesState
+        }
+    }
+    observing.length = i0
 
-	// Go through all old observables and check diffValue: (it is unique after last bindDependencies)
-	//   0: it's not in new observables, unobserve it
-	//   1: it keeps being observed, don't want to notify it. change to 0
-	l = prevObserving.length;
-	while (l--) {
-		const dep = prevObserving[l];
-		if (dep.diffValue === 0) {
-			removeObserver(dep, derivation);
-		}
-		dep.diffValue = 0;
-	}
+    // Go through all old observables and check diffValue: (it is unique after last bindDependencies)
+    //   0: it's not in new observables, unobserve it
+    //   1: it keeps being observed, don't want to notify it. change to 0
+    l = prevObserving.length
+    while (l--) {
+        const dep = prevObserving[l]
+        if (dep.diffValue === 0) {
+            removeObserver(dep, derivation)
+        }
+        dep.diffValue = 0
+    }
 
-	// Go through all new observables and check diffValue: (now it should be unique)
-	//   0: it was set to 0 in last loop. don't need to do anything.
-	//   1: it wasn't observed, let's observe it. set back to 0
-	while (i0--) {
-		const dep = observing[i0];
-		if (dep.diffValue === 1) {
-			dep.diffValue = 0;
-			addObserver(dep, derivation);
-		}
-	}
+    // Go through all new observables and check diffValue: (now it should be unique)
+    //   0: it was set to 0 in last loop. don't need to do anything.
+    //   1: it wasn't observed, let's observe it. set back to 0
+    while (i0--) {
+        const dep = observing[i0]
+        if (dep.diffValue === 1) {
+            dep.diffValue = 0
+            addObserver(dep, derivation)
+        }
+    }
 
-	// Some new observed derivations might become stale during this derivation computation
-	// so say had no chance to propagate staleness (#916)
-	if (lowestNewObservingDerivationState !== IDerivationState.UP_TO_DATE) {
-		derivation.dependenciesState = lowestNewObservingDerivationState;
-		derivation.onBecomeStale();
-	}
+    // Some new observed derivations might become stale during this derivation computation
+    // so say had no chance to propagate staleness (#916)
+    if (lowestNewObservingDerivationState !== IDerivationState.UP_TO_DATE) {
+        derivation.dependenciesState = lowestNewObservingDerivationState
+        derivation.onBecomeStale()
+    }
 }
 
 export function clearObserving(derivation: IDerivation) {
-	// invariant(globalState.inBatch > 0, "INTERNAL ERROR clearObserving should be called only inside batch");
-	const obs = derivation.observing;
-	derivation.observing = [];
-	let i = obs.length;
-	while (i--)
-		removeObserver(obs[i], derivation);
+    // invariant(globalState.inBatch > 0, "INTERNAL ERROR clearObserving should be called only inside batch");
+    const obs = derivation.observing
+    derivation.observing = []
+    let i = obs.length
+    while (i--) removeObserver(obs[i], derivation)
 
-	derivation.dependenciesState = IDerivationState.NOT_TRACKING;
+    derivation.dependenciesState = IDerivationState.NOT_TRACKING
 }
 
 export function untracked<T>(action: () => T): T {
-	const prev = untrackedStart();
-	const res = action();
-	untrackedEnd(prev);
-	return res;
+    const prev = untrackedStart()
+    const res = action()
+    untrackedEnd(prev)
+    return res
 }
 
 export function untrackedStart(): IDerivation | null {
-	const prev = globalState.trackingDerivation;
-	globalState.trackingDerivation = null;
-	return prev;
+    const prev = globalState.trackingDerivation
+    globalState.trackingDerivation = null
+    return prev
 }
 
 export function untrackedEnd(prev: IDerivation | null) {
-	globalState.trackingDerivation = prev;
+    globalState.trackingDerivation = prev
 }
 
 /**
@@ -237,11 +239,10 @@ export function untrackedEnd(prev: IDerivation | null) {
  *
  */
 export function changeDependenciesStateTo0(derivation: IDerivation) {
-	if (derivation.dependenciesState === IDerivationState.UP_TO_DATE) return;
-	derivation.dependenciesState = IDerivationState.UP_TO_DATE;
+    if (derivation.dependenciesState === IDerivationState.UP_TO_DATE) return
+    derivation.dependenciesState = IDerivationState.UP_TO_DATE
 
-	const obs = derivation.observing;
-	let i = obs.length;
-	while (i--)
-		obs[i].lowestObserverState = IDerivationState.UP_TO_DATE;
+    const obs = derivation.observing
+    let i = obs.length
+    while (i--) obs[i].lowestObserverState = IDerivationState.UP_TO_DATE
 }

--- a/src/core/observable.ts
+++ b/src/core/observable.ts
@@ -1,107 +1,114 @@
-import {IDerivation, IDerivationState} from "./derivation";
-import {globalState} from "./globalstate";
-import {invariant} from "../utils/utils";
-import {runReactions} from "./reaction";
+import { IDerivation, IDerivationState } from "./derivation"
+import { globalState } from "./globalstate"
+import { invariant } from "../utils/utils"
+import { runReactions } from "./reaction"
 
 export interface IDepTreeNode {
-	name: string;
-	observing?: IObservable[];
+    name: string
+    observing?: IObservable[]
 }
 
 export interface IObservable extends IDepTreeNode {
-	diffValue: number;
-	/**
+    diffValue: number
+    /**
 	 * Id of the derivation *run* that last accessed this observable.
 	 * If this id equals the *run* id of the current derivation,
 	 * the dependency is already established
 	 */
-	lastAccessedBy: number;
+    lastAccessedBy: number
 
-	lowestObserverState: IDerivationState; // Used to avoid redundant propagations
-	isPendingUnobservation: boolean; // Used to push itself to global.pendingUnobservations at most once per batch.
+    lowestObserverState: IDerivationState // Used to avoid redundant propagations
+    isPendingUnobservation: boolean // Used to push itself to global.pendingUnobservations at most once per batch.
 
-	observers: IDerivation[]; // maintain _observers in raw array for for way faster iterating in propagation.
-	observersIndexes: {}; // map derivation.__mapid to _observers.indexOf(derivation) (see removeObserver)
+    observers: IDerivation[] // maintain _observers in raw array for for way faster iterating in propagation.
+    observersIndexes: {} // map derivation.__mapid to _observers.indexOf(derivation) (see removeObserver)
 
-	onBecomeUnobserved();
+    onBecomeUnobserved()
 }
 
 export function hasObservers(observable: IObservable): boolean {
-	return observable.observers && observable.observers.length > 0;
+    return observable.observers && observable.observers.length > 0
 }
 
 export function getObservers(observable: IObservable): IDerivation[] {
-	return observable.observers;
+    return observable.observers
 }
 
 function invariantObservers(observable: IObservable) {
-	const list = observable.observers;
-	const map = observable.observersIndexes;
-	const l = list.length;
-	for (let i = 0; i < l; i++) {
-		const id = list[i].__mapid;
-		if (i) {
-			invariant(map[id] === i, "INTERNAL ERROR maps derivation.__mapid to index in list"); // for performance
-		} else {
-			invariant(!(id in map), "INTERNAL ERROR observer on index 0 shouldn't be held in map."); // for performance
-		}
-	}
-	invariant(list.length === 0 || Object.keys(map).length === list.length - 1, "INTERNAL ERROR there is no junk in map");
+    const list = observable.observers
+    const map = observable.observersIndexes
+    const l = list.length
+    for (let i = 0; i < l; i++) {
+        const id = list[i].__mapid
+        if (i) {
+            invariant(map[id] === i, "INTERNAL ERROR maps derivation.__mapid to index in list") // for performance
+        } else {
+            invariant(!(id in map), "INTERNAL ERROR observer on index 0 shouldn't be held in map.") // for performance
+        }
+    }
+    invariant(
+        list.length === 0 || Object.keys(map).length === list.length - 1,
+        "INTERNAL ERROR there is no junk in map"
+    )
 }
 export function addObserver(observable: IObservable, node: IDerivation) {
-	// invariant(node.dependenciesState !== -1, "INTERNAL ERROR, can add only dependenciesState !== -1");
-	// invariant(observable._observers.indexOf(node) === -1, "INTERNAL ERROR add already added node");
-	// invariantObservers(observable);
+    // invariant(node.dependenciesState !== -1, "INTERNAL ERROR, can add only dependenciesState !== -1");
+    // invariant(observable._observers.indexOf(node) === -1, "INTERNAL ERROR add already added node");
+    // invariantObservers(observable);
 
-	const l = observable.observers.length;
-	if (l) { // because object assignment is relatively expensive, let's not store data about index 0.
-		observable.observersIndexes[node.__mapid] = l;
-	}
-	observable.observers[l] = node;
+    const l = observable.observers.length
+    if (l) {
+        // because object assignment is relatively expensive, let's not store data about index 0.
+        observable.observersIndexes[node.__mapid] = l
+    }
+    observable.observers[l] = node
 
-	if (observable.lowestObserverState > node.dependenciesState) observable.lowestObserverState = node.dependenciesState;
+    if (observable.lowestObserverState > node.dependenciesState)
+        observable.lowestObserverState = node.dependenciesState
 
-	// invariantObservers(observable);
-	// invariant(observable._observers.indexOf(node) !== -1, "INTERNAL ERROR didn't add node");
+    // invariantObservers(observable);
+    // invariant(observable._observers.indexOf(node) !== -1, "INTERNAL ERROR didn't add node");
 }
 
 export function removeObserver(observable: IObservable, node: IDerivation) {
-	// invariant(globalState.inBatch > 0, "INTERNAL ERROR, remove should be called only inside batch");
-	// invariant(observable._observers.indexOf(node) !== -1, "INTERNAL ERROR remove already removed node");
-	// invariantObservers(observable);
+    // invariant(globalState.inBatch > 0, "INTERNAL ERROR, remove should be called only inside batch");
+    // invariant(observable._observers.indexOf(node) !== -1, "INTERNAL ERROR remove already removed node");
+    // invariantObservers(observable);
 
-	if (observable.observers.length === 1) {
-		// deleting last observer
-		observable.observers.length = 0;
+    if (observable.observers.length === 1) {
+        // deleting last observer
+        observable.observers.length = 0
 
-		queueForUnobservation(observable);
-	} else {
-		// deleting from _observersIndexes is straight forward, to delete from _observers, let's swap `node` with last element
-		const list = observable.observers;
-		const map = observable.observersIndexes;
-		const filler = list.pop()!; // get last element, which should fill the place of `node`, so the array doesn't have holes
-		if (filler !== node) { // otherwise node was the last element, which already got removed from array
-			const index = map[node.__mapid] || 0; // getting index of `node`. this is the only place we actually use map.
-			if (index) { // map store all indexes but 0, see comment in `addObserver`
-				map[filler.__mapid] = index;
-			} else {
-				delete map[filler.__mapid];
-			}
-			list[index] = filler;
-		}
-		delete map[node.__mapid];
-	}
-	// invariantObservers(observable);
-	// invariant(observable._observers.indexOf(node) === -1, "INTERNAL ERROR remove already removed node2");
+        queueForUnobservation(observable)
+    } else {
+        // deleting from _observersIndexes is straight forward, to delete from _observers, let's swap `node` with last element
+        const list = observable.observers
+        const map = observable.observersIndexes
+        const filler = list.pop()! // get last element, which should fill the place of `node`, so the array doesn't have holes
+        if (filler !== node) {
+            // otherwise node was the last element, which already got removed from array
+            const index = map[node.__mapid] || 0 // getting index of `node`. this is the only place we actually use map.
+            if (index) {
+                // map store all indexes but 0, see comment in `addObserver`
+                map[filler.__mapid] = index
+            } else {
+                delete map[filler.__mapid]
+            }
+            list[index] = filler
+        }
+        delete map[node.__mapid]
+    }
+    // invariantObservers(observable);
+    // invariant(observable._observers.indexOf(node) === -1, "INTERNAL ERROR remove already removed node2");
 }
 
 export function queueForUnobservation(observable: IObservable) {
-	if (!observable.isPendingUnobservation) {
-		// invariant(globalState.inBatch > 0, "INTERNAL ERROR, remove should be called only inside batch");
-		// invariant(observable._observers.length === 0, "INTERNAL ERROR, should only queue for unobservation unobserved observables");
-		observable.isPendingUnobservation = true;
-		globalState.pendingUnobservations.push(observable);
-	}
+    if (!observable.isPendingUnobservation) {
+        // invariant(globalState.inBatch > 0, "INTERNAL ERROR, remove should be called only inside batch");
+        // invariant(observable._observers.length === 0, "INTERNAL ERROR, should only queue for unobservation unobserved observables");
+        observable.isPendingUnobservation = true
+        globalState.pendingUnobservations.push(observable)
+    }
 }
 
 /**
@@ -110,51 +117,55 @@ export function queueForUnobservation(observable: IObservable) {
  * Avoids unnecessary recalculations.
  */
 export function startBatch() {
-	globalState.inBatch++;
+    globalState.inBatch++
 }
 
 export function endBatch() {
-	if (--globalState.inBatch === 0) {
-		runReactions();
-		// the batch is actually about to finish, all unobserving should happen here.
-		const list = globalState.pendingUnobservations;
-		for (let i = 0; i < list.length; i++) {
-			const observable = list[i];
-			observable.isPendingUnobservation = false;
-			if (observable.observers.length === 0) {
-				observable.onBecomeUnobserved();
-				// NOTE: onBecomeUnobserved might push to `pendingUnobservations`
-			}
-		}
-		globalState.pendingUnobservations = [];
-	}
+    if (--globalState.inBatch === 0) {
+        runReactions()
+        // the batch is actually about to finish, all unobserving should happen here.
+        const list = globalState.pendingUnobservations
+        for (let i = 0; i < list.length; i++) {
+            const observable = list[i]
+            observable.isPendingUnobservation = false
+            if (observable.observers.length === 0) {
+                observable.onBecomeUnobserved()
+                // NOTE: onBecomeUnobserved might push to `pendingUnobservations`
+            }
+        }
+        globalState.pendingUnobservations = []
+    }
 }
 
 export function reportObserved(observable: IObservable) {
-	const derivation = globalState.trackingDerivation;
-	if (derivation !== null) {
-		/**
+    const derivation = globalState.trackingDerivation
+    if (derivation !== null) {
+        /**
 		 * Simple optimization, give each derivation run an unique id (runId)
 		 * Check if last time this observable was accessed the same runId is used
 		 * if this is the case, the relation is already known
 		 */
-		if (derivation.runId !== observable.lastAccessedBy) {
-			observable.lastAccessedBy = derivation.runId;
-			derivation.newObserving![derivation.unboundDepsCount++] = observable;
-		}
-	} else if (observable.observers.length === 0) {
-		queueForUnobservation(observable);
-	}
+        if (derivation.runId !== observable.lastAccessedBy) {
+            observable.lastAccessedBy = derivation.runId
+            derivation.newObserving![derivation.unboundDepsCount++] = observable
+        }
+    } else if (observable.observers.length === 0) {
+        queueForUnobservation(observable)
+    }
 }
 
 function invariantLOS(observable: IObservable, msg) {
-	// it's expensive so better not run it in produciton. but temporarily helpful for testing
-	const min = getObservers(observable).reduce(
-		(a, b) => Math.min(a, b.dependenciesState),
-		2
-	);
-	if (min >= observable.lowestObserverState) return; // <- the only assumption about `lowestObserverState`
-	throw new Error("lowestObserverState is wrong for " + msg + " because " + min  + " < " + observable.lowestObserverState);
+    // it's expensive so better not run it in produciton. but temporarily helpful for testing
+    const min = getObservers(observable).reduce((a, b) => Math.min(a, b.dependenciesState), 2)
+    if (min >= observable.lowestObserverState) return // <- the only assumption about `lowestObserverState`
+    throw new Error(
+        "lowestObserverState is wrong for " +
+            msg +
+            " because " +
+            min +
+            " < " +
+            observable.lowestObserverState
+    )
 }
 
 /**
@@ -167,53 +178,54 @@ function invariantLOS(observable: IObservable, msg) {
 
 // Called by Atom when its value changes
 export function propagateChanged(observable: IObservable) {
-	// invariantLOS(observable, "changed start");
-	if (observable.lowestObserverState === IDerivationState.STALE) return;
-	observable.lowestObserverState = IDerivationState.STALE;
+    // invariantLOS(observable, "changed start");
+    if (observable.lowestObserverState === IDerivationState.STALE) return
+    observable.lowestObserverState = IDerivationState.STALE
 
-	const observers = observable.observers;
-	let i = observers.length;
-	while (i--) {
-		const d = observers[i];
-		if (d.dependenciesState === IDerivationState.UP_TO_DATE)
-			d.onBecomeStale();
-		d.dependenciesState = IDerivationState.STALE;
-	}
-	// invariantLOS(observable, "changed end");
+    const observers = observable.observers
+    let i = observers.length
+    while (i--) {
+        const d = observers[i]
+        if (d.dependenciesState === IDerivationState.UP_TO_DATE) d.onBecomeStale()
+        d.dependenciesState = IDerivationState.STALE
+    }
+    // invariantLOS(observable, "changed end");
 }
 
 // Called by ComputedValue when it recalculate and its value changed
 export function propagateChangeConfirmed(observable: IObservable) {
-	// invariantLOS(observable, "confirmed start");
-	if (observable.lowestObserverState === IDerivationState.STALE) return;
-	observable.lowestObserverState = IDerivationState.STALE;
+    // invariantLOS(observable, "confirmed start");
+    if (observable.lowestObserverState === IDerivationState.STALE) return
+    observable.lowestObserverState = IDerivationState.STALE
 
-	const observers = observable.observers;
-	let i = observers.length;
-	while (i--) {
-		const d = observers[i];
-		if (d.dependenciesState === IDerivationState.POSSIBLY_STALE)
-			d.dependenciesState = IDerivationState.STALE;
-		else if (d.dependenciesState === IDerivationState.UP_TO_DATE) // this happens during computing of `d`, just keep lowestObserverState up to date.
-			observable.lowestObserverState = IDerivationState.UP_TO_DATE;
-	}
-	// invariantLOS(observable, "confirmed end");
+    const observers = observable.observers
+    let i = observers.length
+    while (i--) {
+        const d = observers[i]
+        if (d.dependenciesState === IDerivationState.POSSIBLY_STALE)
+            d.dependenciesState = IDerivationState.STALE
+        else if (
+            d.dependenciesState === IDerivationState.UP_TO_DATE // this happens during computing of `d`, just keep lowestObserverState up to date.
+        )
+            observable.lowestObserverState = IDerivationState.UP_TO_DATE
+    }
+    // invariantLOS(observable, "confirmed end");
 }
 
 // Used by computed when its dependency changed, but we don't wan't to immediately recompute.
 export function propagateMaybeChanged(observable: IObservable) {
-	// invariantLOS(observable, "maybe start");
-	if (observable.lowestObserverState !== IDerivationState.UP_TO_DATE) return;
-	observable.lowestObserverState = IDerivationState.POSSIBLY_STALE;
+    // invariantLOS(observable, "maybe start");
+    if (observable.lowestObserverState !== IDerivationState.UP_TO_DATE) return
+    observable.lowestObserverState = IDerivationState.POSSIBLY_STALE
 
-	const observers = observable.observers;
-	let i = observers.length;
-	while (i--) {
-		const d = observers[i];
-		if (d.dependenciesState === IDerivationState.UP_TO_DATE) {
-			d.dependenciesState = IDerivationState.POSSIBLY_STALE;
-			d.onBecomeStale();
-		}
-	}
-	// invariantLOS(observable, "maybe end");
+    const observers = observable.observers
+    let i = observers.length
+    while (i--) {
+        const d = observers[i]
+        if (d.dependenciesState === IDerivationState.UP_TO_DATE) {
+            d.dependenciesState = IDerivationState.POSSIBLY_STALE
+            d.onBecomeStale()
+        }
+    }
+    // invariantLOS(observable, "maybe end");
 }

--- a/src/core/spy.ts
+++ b/src/core/spy.ts
@@ -1,37 +1,32 @@
-import {globalState} from "./globalstate";
-import {objectAssign, once, Lambda} from "../utils/utils";
+import { globalState } from "./globalstate"
+import { objectAssign, once, Lambda } from "../utils/utils"
 
 export function isSpyEnabled() {
-	return !!globalState.spyListeners.length;
+    return !!globalState.spyListeners.length
 }
 
 export function spyReport(event) {
-	if (!globalState.spyListeners.length)
-		return;
-	const listeners = globalState.spyListeners;
-	for (let i = 0, l = listeners.length; i < l; i++)
-		listeners[i](event);
+    if (!globalState.spyListeners.length) return
+    const listeners = globalState.spyListeners
+    for (let i = 0, l = listeners.length; i < l; i++) listeners[i](event)
 }
 
 export function spyReportStart(event) {
-	const change = objectAssign({}, event, { spyReportStart: true });
-	spyReport(change);
+    const change = objectAssign({}, event, { spyReportStart: true })
+    spyReport(change)
 }
 
-const END_EVENT = { spyReportEnd: true };
+const END_EVENT = { spyReportEnd: true }
 
 export function spyReportEnd(change?) {
-	if (change)
-		spyReport(objectAssign({}, change, END_EVENT));
-	else
-		spyReport(END_EVENT);
+    if (change) spyReport(objectAssign({}, change, END_EVENT))
+    else spyReport(END_EVENT)
 }
 
 export function spy(listener: (change: any) => void): Lambda {
-	globalState.spyListeners.push(listener);
-	return once(() => {
-		const idx = globalState.spyListeners.indexOf(listener);
-		if (idx !== -1)
-			globalState.spyListeners.splice(idx, 1);
-	});
+    globalState.spyListeners.push(listener)
+    return once(() => {
+        const idx = globalState.spyListeners.indexOf(listener)
+        if (idx !== -1) globalState.spyListeners.splice(idx, 1)
+    })
 }

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -16,191 +16,265 @@
  *
  */
 
-
-export { IObservable, IDepTreeNode                            } from "./core/observable";
-export { Reaction, IReactionPublic, IReactionDisposer         } from "./core/reaction";
-export { IDerivation, untracked, IDerivationState             } from "./core/derivation";
+export { IObservable, IDepTreeNode } from "./core/observable"
+export { Reaction, IReactionPublic, IReactionDisposer } from "./core/reaction"
+export { IDerivation, untracked, IDerivationState } from "./core/derivation"
 
 // NOTE: For some reason, rollup's dependency tracker gets confused
 // if this line is above the previous 3, and will produce out of order
 // class definitions where BaseAtom is undefined, causing an error.
 // It's not ideal, but for now we can just make sure this line comes after
 // the ones above
-export { IAtom, Atom, BaseAtom                                } from "./core/atom";
+export { IAtom, Atom, BaseAtom } from "./core/atom"
 
-export { useStrict, isStrictModeEnabled, IAction              } from "./core/action";
-export { spy                                                  } from "./core/spy";
-export { IComputedValue                                       } from "./core/computedvalue";
+export { useStrict, isStrictModeEnabled, IAction } from "./core/action"
+export { spy } from "./core/spy"
+export { IComputedValue } from "./core/computedvalue"
 
-export { IEqualsComparer, comparer 							  } from "./types/comparer";
-export { asReference, asFlat, asStructure, asMap              } from "./types/modifiers-old";
-export { IModifierDescriptor, IEnhancer, isModifierDescriptor } from "./types/modifiers";
-export { IInterceptable, IInterceptor                         } from "./types/intercept-utils";
-export { IListenable                                          } from "./types/listen-utils";
-export { IObjectWillChange, IObjectChange, IObservableObject, isObservableObject } from "./types/observableobject";
+export { IEqualsComparer, comparer } from "./types/comparer"
+export { asReference, asFlat, asStructure, asMap } from "./types/modifiers-old"
+export { IModifierDescriptor, IEnhancer, isModifierDescriptor } from "./types/modifiers"
+export { IInterceptable, IInterceptor } from "./types/intercept-utils"
+export { IListenable } from "./types/listen-utils"
+export {
+    IObjectWillChange,
+    IObjectChange,
+    IObservableObject,
+    isObservableObject
+} from "./types/observableobject"
 
-export { IValueDidChange, IValueWillChange, IObservableValue, isObservableValue as isBoxedObservable } from "./types/observablevalue";
-export { IObservableArray, IArrayWillChange, IArrayWillSplice, IArrayChange, IArraySplice, isObservableArray } from "./types/observablearray";
-export { IKeyValueMap, ObservableMap, IMapEntries, IMapEntry, IMapWillChange, IMapChange, IMapChangeUpdate, IMapChangeAdd, IMapChangeBase, IMapChangeDelete, isObservableMap, map, IObservableMapInitialValues, IMap } from "./types/observablemap";
+export {
+    IValueDidChange,
+    IValueWillChange,
+    IObservableValue,
+    isObservableValue as isBoxedObservable
+} from "./types/observablevalue"
+export {
+    IObservableArray,
+    IArrayWillChange,
+    IArrayWillSplice,
+    IArrayChange,
+    IArraySplice,
+    isObservableArray
+} from "./types/observablearray"
+export {
+    IKeyValueMap,
+    ObservableMap,
+    IMapEntries,
+    IMapEntry,
+    IMapWillChange,
+    IMapChange,
+    IMapChangeUpdate,
+    IMapChangeAdd,
+    IMapChangeBase,
+    IMapChangeDelete,
+    isObservableMap,
+    map,
+    IObservableMapInitialValues,
+    IMap
+} from "./types/observablemap"
 
-export { transaction                                          } from "./api/transaction";
-export { observable, IObservableFactory, IObservableFactories } from "./api/observable";
-export { computed, IComputed, IComputedValueOptions           } from "./api/computed";
-export { isObservable                                         } from "./api/isobservable";
-export { isComputed                                           } from "./api/iscomputed";
-export { extendObservable, extendShallowObservable            } from "./api/extendobservable";
-export { observe                                              } from "./api/observe";
-export { intercept                                            } from "./api/intercept";
-export { autorun, autorunAsync, when, reaction, IReactionOptions  } from "./api/autorun";
-export { action, isAction, runInAction, IActionFactory        } from "./api/action";
+export { transaction } from "./api/transaction"
+export { observable, IObservableFactory, IObservableFactories } from "./api/observable"
+export { computed, IComputed, IComputedValueOptions } from "./api/computed"
+export { isObservable } from "./api/isobservable"
+export { isComputed } from "./api/iscomputed"
+export { extendObservable, extendShallowObservable } from "./api/extendobservable"
+export { observe } from "./api/observe"
+export { intercept } from "./api/intercept"
+export { autorun, autorunAsync, when, reaction, IReactionOptions } from "./api/autorun"
+export { action, isAction, runInAction, IActionFactory } from "./api/action"
 
-export { expr                                                 } from "./api/expr";
-export { toJS                                                 } from "./api/tojs";
-export { ITransformer, createTransformer                      } from "./api/createtransformer";
-export { whyRun                                               } from "./api/whyrun";
+export { expr } from "./api/expr"
+export { toJS } from "./api/tojs"
+export { ITransformer, createTransformer } from "./api/createtransformer"
+export { whyRun } from "./api/whyrun"
 
-export { Lambda, isArrayLike                                  } from "./utils/utils";
-export { Iterator                                             } from "./utils/iterable";
-export { IObserverTree, IDependencyTree                       } from "./api/extras";
+export { Lambda, isArrayLike } from "./utils/utils"
+export { Iterator } from "./utils/iterable"
+export { IObserverTree, IDependencyTree } from "./api/extras"
 
-import { resetGlobalState, shareGlobalState, getGlobalState, isolateGlobalState } from "./core/globalstate";
-import { IDerivation } from "./core/derivation";
-import { IDepTreeNode } from "./core/observable";
-import { IObserverTree, IDependencyTree, getDependencyTree, getObserverTree } from "./api/extras";
-import { getDebugName, getAtom, getAdministration } from "./types/type-utils";
-import { allowStateChanges } from "./core/action";
-import { spyReport, spyReportEnd, spyReportStart, isSpyEnabled } from "./core/spy";
-import { Lambda, deepEqual } from "./utils/utils";
-import { isComputingDerivation } from "./core/derivation";
-import { setReactionScheduler, onReactionError } from "./core/reaction";
-import { reserveArrayBuffer, IObservableArray } from "./types/observablearray";
-import { interceptReads } from "./api/intercept-read";
-import { ObservableMap } from "./types/observablemap";
-import { IObservableValue } from "./types/observablevalue";
-import {registerGlobals} from "./core/globalstate";
+import {
+    resetGlobalState,
+    shareGlobalState,
+    getGlobalState,
+    isolateGlobalState
+} from "./core/globalstate"
+import { IDerivation } from "./core/derivation"
+import { IDepTreeNode } from "./core/observable"
+import { IObserverTree, IDependencyTree, getDependencyTree, getObserverTree } from "./api/extras"
+import { getDebugName, getAtom, getAdministration } from "./types/type-utils"
+import { allowStateChanges } from "./core/action"
+import { spyReport, spyReportEnd, spyReportStart, isSpyEnabled } from "./core/spy"
+import { Lambda, deepEqual } from "./utils/utils"
+import { isComputingDerivation } from "./core/derivation"
+import { setReactionScheduler, onReactionError } from "./core/reaction"
+import { reserveArrayBuffer, IObservableArray } from "./types/observablearray"
+import { interceptReads } from "./api/intercept-read"
+import { ObservableMap } from "./types/observablemap"
+import { IObservableValue } from "./types/observablevalue"
+import { registerGlobals } from "./core/globalstate"
 
 // This line should come after all the imports as well, for the same reason
 // as noted above. I will file a bug with rollupjs - @rossipedia
-registerGlobals();
+registerGlobals()
 
 export const extras = {
-	allowStateChanges,
-	deepEqual,
-	getAtom,
-	getDebugName,
-	getDependencyTree,
-	getAdministration,
-	getGlobalState,
-	getObserverTree,
-	interceptReads,
-	isComputingDerivation,
-	isSpyEnabled,
-	onReactionError,
-	reserveArrayBuffer, // See #734
-	resetGlobalState,
-	isolateGlobalState,
-	shareGlobalState,
-	spyReport,
-	spyReportEnd,
-	spyReportStart,
-	setReactionScheduler
-};
-
+    allowStateChanges,
+    deepEqual,
+    getAtom,
+    getDebugName,
+    getDependencyTree,
+    getAdministration,
+    getGlobalState,
+    getObserverTree,
+    interceptReads,
+    isComputingDerivation,
+    isSpyEnabled,
+    onReactionError,
+    reserveArrayBuffer, // See #734
+    resetGlobalState,
+    isolateGlobalState,
+    shareGlobalState,
+    spyReport,
+    spyReportEnd,
+    spyReportStart,
+    setReactionScheduler
+}
 
 // Deprecated default export (will be removed in 4.0)
 
-import { IObservable                                          } from "./core/observable";
-import { Reaction, IReactionPublic, IReactionDisposer         } from "./core/reaction";
-import { untracked, IDerivationState                          } from "./core/derivation";
-import { IAtom, Atom, BaseAtom                                } from "./core/atom";
-import { useStrict, isStrictModeEnabled, IAction              } from "./core/action";
-import { spy                                                  } from "./core/spy";
-import { IComputedValue                                       } from "./core/computedvalue";
-import { IEqualsComparer, comparer 							  } from "./types/comparer";
-import { asReference, asFlat, asStructure, asMap              } from "./types/modifiers-old";
-import { IModifierDescriptor, IEnhancer, isModifierDescriptor } from "./types/modifiers";
-import { IInterceptable, IInterceptor                         } from "./types/intercept-utils";
-import { IListenable                                          } from "./types/listen-utils";
-import { IObjectWillChange, IObjectChange, IObservableObject, isObservableObject } from "./types/observableobject";
-import { IValueDidChange, IValueWillChange, isObservableValue as isBoxedObservable } from "./types/observablevalue";
-import { IArrayWillChange, IArrayWillSplice, IArrayChange, IArraySplice, isObservableArray } from "./types/observablearray";
-import { IKeyValueMap, IMapEntries, IMapEntry, IMapWillChange, IMapChange, IMapChangeUpdate, IMapChangeAdd, IMapChangeBase, IMapChangeDelete, isObservableMap, map, IObservableMapInitialValues, IMap } from "./types/observablemap";
-import { transaction                                          } from "./api/transaction";
-import { observable, IObservableFactory, IObservableFactories } from "./api/observable";
-import { computed, IComputed, IComputedValueOptions           } from "./api/computed";
-import { isObservable                                         } from "./api/isobservable";
-import { isComputed                                           } from "./api/iscomputed";
-import { extendObservable, extendShallowObservable            } from "./api/extendobservable";
-import { observe                                              } from "./api/observe";
-import { intercept                                            } from "./api/intercept";
-import { autorun, autorunAsync, when, reaction, IReactionOptions  } from "./api/autorun";
-import { action, isAction, runInAction, IActionFactory        } from "./api/action";
-import { expr                                                 } from "./api/expr";
-import { toJS                                                 } from "./api/tojs";
-import { ITransformer, createTransformer                      } from "./api/createtransformer";
-import { whyRun                                               } from "./api/whyrun";
-import { isArrayLike                                          } from "./utils/utils";
-import { Iterator                                             } from "./utils/iterable";
+import { IObservable } from "./core/observable"
+import { Reaction, IReactionPublic, IReactionDisposer } from "./core/reaction"
+import { untracked, IDerivationState } from "./core/derivation"
+import { IAtom, Atom, BaseAtom } from "./core/atom"
+import { useStrict, isStrictModeEnabled, IAction } from "./core/action"
+import { spy } from "./core/spy"
+import { IComputedValue } from "./core/computedvalue"
+import { IEqualsComparer, comparer } from "./types/comparer"
+import { asReference, asFlat, asStructure, asMap } from "./types/modifiers-old"
+import { IModifierDescriptor, IEnhancer, isModifierDescriptor } from "./types/modifiers"
+import { IInterceptable, IInterceptor } from "./types/intercept-utils"
+import { IListenable } from "./types/listen-utils"
+import {
+    IObjectWillChange,
+    IObjectChange,
+    IObservableObject,
+    isObservableObject
+} from "./types/observableobject"
+import {
+    IValueDidChange,
+    IValueWillChange,
+    isObservableValue as isBoxedObservable
+} from "./types/observablevalue"
+import {
+    IArrayWillChange,
+    IArrayWillSplice,
+    IArrayChange,
+    IArraySplice,
+    isObservableArray
+} from "./types/observablearray"
+import {
+    IKeyValueMap,
+    IMapEntries,
+    IMapEntry,
+    IMapWillChange,
+    IMapChange,
+    IMapChangeUpdate,
+    IMapChangeAdd,
+    IMapChangeBase,
+    IMapChangeDelete,
+    isObservableMap,
+    map,
+    IObservableMapInitialValues,
+    IMap
+} from "./types/observablemap"
+import { transaction } from "./api/transaction"
+import { observable, IObservableFactory, IObservableFactories } from "./api/observable"
+import { computed, IComputed, IComputedValueOptions } from "./api/computed"
+import { isObservable } from "./api/isobservable"
+import { isComputed } from "./api/iscomputed"
+import { extendObservable, extendShallowObservable } from "./api/extendobservable"
+import { observe } from "./api/observe"
+import { intercept } from "./api/intercept"
+import { autorun, autorunAsync, when, reaction, IReactionOptions } from "./api/autorun"
+import { action, isAction, runInAction, IActionFactory } from "./api/action"
+import { expr } from "./api/expr"
+import { toJS } from "./api/tojs"
+import { ITransformer, createTransformer } from "./api/createtransformer"
+import { whyRun } from "./api/whyrun"
+import { isArrayLike } from "./utils/utils"
+import { Iterator } from "./utils/iterable"
 
 const everything = {
-	Reaction,
-	untracked,
-	Atom, BaseAtom,
-	useStrict, isStrictModeEnabled,
-	spy,
-	comparer,
-	asReference, asFlat, asStructure, asMap,
-	isModifierDescriptor,
-	isObservableObject,
-	isBoxedObservable,
-	isObservableArray,
-	ObservableMap, isObservableMap, map,
-	transaction,
-	observable,
-	computed,
-	isObservable,
-	isComputed,
-	extendObservable, extendShallowObservable,
-	observe,
-	intercept,
-	autorun, autorunAsync, when, reaction,
-	action, isAction, runInAction,
-	expr,
-	toJS,
-	createTransformer,
-	whyRun,
-	isArrayLike,
-	extras,
-};
+    Reaction,
+    untracked,
+    Atom,
+    BaseAtom,
+    useStrict,
+    isStrictModeEnabled,
+    spy,
+    comparer,
+    asReference,
+    asFlat,
+    asStructure,
+    asMap,
+    isModifierDescriptor,
+    isObservableObject,
+    isBoxedObservable,
+    isObservableArray,
+    ObservableMap,
+    isObservableMap,
+    map,
+    transaction,
+    observable,
+    computed,
+    isObservable,
+    isComputed,
+    extendObservable,
+    extendShallowObservable,
+    observe,
+    intercept,
+    autorun,
+    autorunAsync,
+    when,
+    reaction,
+    action,
+    isAction,
+    runInAction,
+    expr,
+    toJS,
+    createTransformer,
+    whyRun,
+    isArrayLike,
+    extras
+}
 
-
-let warnedAboutDefaultExport = false;
+let warnedAboutDefaultExport = false
 
 for (let p in everything) {
-	let val = everything[p];
-	Object.defineProperty(everything, p, {
-		get: () => {
-			if (!warnedAboutDefaultExport) {
-				warnedAboutDefaultExport = true;
-				console.warn(
-					'Using default export (`import mobx from \'mobx\'`) is deprecated ' +
-					'and won’t work in mobx@4.0.0\n' +
-					'Use `import * as mobx from \'mobx\'` instead'
-				);
-			}
-			return val;
-		}
-	});
+    let val = everything[p]
+    Object.defineProperty(everything, p, {
+        get: () => {
+            if (!warnedAboutDefaultExport) {
+                warnedAboutDefaultExport = true
+                console.warn(
+                    "Using default export (`import mobx from 'mobx'`) is deprecated " +
+                        "and won’t work in mobx@4.0.0\n" +
+                        "Use `import * as mobx from 'mobx'` instead"
+                )
+            }
+            return val
+        }
+    })
 }
 
 // TODO: remove in 4.0, temporarily incompatibility fix for mobx-react@4.1.0 which accidentally uses default exports
-export default everything;
-
+export default everything
 
 // Devtools support
 
-declare var __MOBX_DEVTOOLS_GLOBAL_HOOK__: { injectMobx: ((any) => void)};
+declare var __MOBX_DEVTOOLS_GLOBAL_HOOK__: { injectMobx: ((any) => void) }
 if (typeof __MOBX_DEVTOOLS_GLOBAL_HOOK__ === "object") {
-	__MOBX_DEVTOOLS_GLOBAL_HOOK__.injectMobx({ spy, extras })
+    __MOBX_DEVTOOLS_GLOBAL_HOOK__.injectMobx({ spy, extras })
 }
-

--- a/src/types/comparer.ts
+++ b/src/types/comparer.ts
@@ -1,29 +1,29 @@
-import { deepEqual } from '../utils/utils';
+import { deepEqual } from "../utils/utils"
 
 export interface IEqualsComparer<T> {
-	(a: T, b: T): boolean;
+    (a: T, b: T): boolean
 }
 
 function identityComparer(a: any, b: any): boolean {
-	return a === b;
+    return a === b
 }
 
 function structuralComparer(a: any, b: any): boolean {
-	if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) {
-		return true;
-	}
-	return deepEqual(a, b);
+    if (typeof a === "number" && typeof b === "number" && isNaN(a) && isNaN(b)) {
+        return true
+    }
+    return deepEqual(a, b)
 }
 
 function defaultComparer(a: any, b: any): boolean {
-	if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) {
-		return true;
-	}
-	return identityComparer(a, b);
+    if (typeof a === "number" && typeof b === "number" && isNaN(a) && isNaN(b)) {
+        return true
+    }
+    return identityComparer(a, b)
 }
 
 export const comparer = {
-	identity: identityComparer,
-	structural: structuralComparer,
-	default: defaultComparer
-};
+    identity: identityComparer,
+    structural: structuralComparer,
+    default: defaultComparer
+}

--- a/src/types/intercept-utils.ts
+++ b/src/types/intercept-utils.ts
@@ -1,39 +1,47 @@
-import {Lambda, once, invariant} from "../utils/utils";
-import {untrackedStart, untrackedEnd} from "../core/derivation";
+import { Lambda, once, invariant } from "../utils/utils"
+import { untrackedStart, untrackedEnd } from "../core/derivation"
 
-export type IInterceptor<T> = (change: T) => T | null;
+export type IInterceptor<T> = (change: T) => T | null
 
 export interface IInterceptable<T> {
-	interceptors: IInterceptor<T>[] | null;
-	intercept(handler: IInterceptor<T>): Lambda;
+    interceptors: IInterceptor<T>[] | null
+    intercept(handler: IInterceptor<T>): Lambda
 }
 
 export function hasInterceptors(interceptable: IInterceptable<any>) {
-	return (interceptable.interceptors && interceptable.interceptors.length > 0);
+    return interceptable.interceptors && interceptable.interceptors.length > 0
 }
 
-export function registerInterceptor<T>(interceptable: IInterceptable<T>, handler: IInterceptor<T>): Lambda {
-	const interceptors = interceptable.interceptors || (interceptable.interceptors = []);
-	interceptors.push(handler);
-	return once(() => {
-		const idx = interceptors.indexOf(handler);
-		if (idx !== -1)
-			interceptors.splice(idx, 1);
-	});
+export function registerInterceptor<T>(
+    interceptable: IInterceptable<T>,
+    handler: IInterceptor<T>
+): Lambda {
+    const interceptors = interceptable.interceptors || (interceptable.interceptors = [])
+    interceptors.push(handler)
+    return once(() => {
+        const idx = interceptors.indexOf(handler)
+        if (idx !== -1) interceptors.splice(idx, 1)
+    })
 }
 
-export function interceptChange<T>(interceptable: IInterceptable<T | null>, change: T | null): T | null {
-	const prevU = untrackedStart();
-	try {
-		const interceptors = interceptable.interceptors;
-		if (interceptors) for (let i = 0, l = interceptors.length; i < l; i++) {
-			change = interceptors[i](change);
-			invariant(!change || (change as any).type, "Intercept handlers should return nothing or a change object");
-			if (!change)
-				break;
-		}
-		return change;
-	} finally {
-		untrackedEnd(prevU);
-	}
+export function interceptChange<T>(
+    interceptable: IInterceptable<T | null>,
+    change: T | null
+): T | null {
+    const prevU = untrackedStart()
+    try {
+        const interceptors = interceptable.interceptors
+        if (interceptors)
+            for (let i = 0, l = interceptors.length; i < l; i++) {
+                change = interceptors[i](change)
+                invariant(
+                    !change || (change as any).type,
+                    "Intercept handlers should return nothing or a change object"
+                )
+                if (!change) break
+            }
+        return change
+    } finally {
+        untrackedEnd(prevU)
+    }
 }

--- a/src/types/listen-utils.ts
+++ b/src/types/listen-utils.ts
@@ -1,33 +1,31 @@
-import {Lambda, once} from "../utils/utils";
-import {untrackedStart, untrackedEnd} from "../core/derivation";
+import { Lambda, once } from "../utils/utils"
+import { untrackedStart, untrackedEnd } from "../core/derivation"
 
 export interface IListenable {
-	changeListeners: Function[] | null;
-	observe(handler: (change: any, oldValue?: any) => void, fireImmediately?: boolean): Lambda;
+    changeListeners: Function[] | null
+    observe(handler: (change: any, oldValue?: any) => void, fireImmediately?: boolean): Lambda
 }
 
 export function hasListeners(listenable: IListenable) {
-	return listenable.changeListeners && listenable.changeListeners.length > 0;
+    return listenable.changeListeners && listenable.changeListeners.length > 0
 }
 
 export function registerListener<T>(listenable: IListenable, handler: Function): Lambda {
-	const listeners = listenable.changeListeners || (listenable.changeListeners = []);
-	listeners.push(handler);
-	return once(() => {
-		const idx = listeners.indexOf(handler);
-		if (idx !== -1)
-			listeners.splice(idx, 1);
-	});
+    const listeners = listenable.changeListeners || (listenable.changeListeners = [])
+    listeners.push(handler)
+    return once(() => {
+        const idx = listeners.indexOf(handler)
+        if (idx !== -1) listeners.splice(idx, 1)
+    })
 }
 
 export function notifyListeners<T>(listenable: IListenable, change: T) {
-	const prevU = untrackedStart();
-	let listeners = listenable.changeListeners;
-	if (!listeners)
-		return;
-	listeners = listeners.slice();
-	for (let i = 0, l = listeners.length; i < l; i++) {
-		listeners[i](change);
-	}
-	untrackedEnd(prevU);
+    const prevU = untrackedStart()
+    let listeners = listenable.changeListeners
+    if (!listeners) return
+    listeners = listeners.slice()
+    for (let i = 0, l = listeners.length; i < l; i++) {
+        listeners[i](change)
+    }
+    untrackedEnd(prevU)
 }

--- a/src/types/modifiers-old.ts
+++ b/src/types/modifiers-old.ts
@@ -1,27 +1,29 @@
-import {observable} from "../api/observable";
-import {ObservableMap, IMapEntries, IKeyValueMap} from "./observablemap";
-import {deprecated} from "../utils/utils";
+import { observable } from "../api/observable"
+import { ObservableMap, IMapEntries, IKeyValueMap } from "./observablemap"
+import { deprecated } from "../utils/utils"
 
 export function asReference<T>(value: T): T {
-	deprecated("asReference is deprecated, use observable.ref instead");
-	return observable.ref(value);
+    deprecated("asReference is deprecated, use observable.ref instead")
+    return observable.ref(value)
 }
 
 export function asStructure<T>(value: T): T {
-	deprecated("asStructure is deprecated. Use observable.struct, computed.struct or reaction options instead.");
-	return observable.struct(value);
+    deprecated(
+        "asStructure is deprecated. Use observable.struct, computed.struct or reaction options instead."
+    )
+    return observable.struct(value)
 }
 
 export function asFlat<T>(value: T): T {
-	deprecated("asFlat is deprecated, use observable.shallow instead");
-	return observable.shallow(value);
+    deprecated("asFlat is deprecated, use observable.shallow instead")
+    return observable.shallow(value)
 }
 
-export function asMap(): ObservableMap<any>;
-export function asMap<T>(): ObservableMap<T>;
-export function asMap<T>(entries: IMapEntries<T>): ObservableMap<T>;
-export function asMap<T>(data: IKeyValueMap<T>): ObservableMap<T>;
+export function asMap(): ObservableMap<any>
+export function asMap<T>(): ObservableMap<T>
+export function asMap<T>(entries: IMapEntries<T>): ObservableMap<T>
+export function asMap<T>(data: IKeyValueMap<T>): ObservableMap<T>
 export function asMap(data?): ObservableMap<any> {
-	deprecated("asMap is deprecated, use observable.map or observable.shallowMap instead");
-	return observable.map(data || {});
+    deprecated("asMap is deprecated, use observable.map or observable.shallowMap instead")
+    return observable.map(data || {})
 }

--- a/src/types/modifiers.ts
+++ b/src/types/modifiers.ts
@@ -1,103 +1,98 @@
 export interface IEnhancer<T> {
-	(newValue: T, oldValue: T | undefined, name: string): T;
+    (newValue: T, oldValue: T | undefined, name: string): T
 }
 
 export interface IModifierDescriptor<T> {
-	isMobxModifierDescriptor: boolean;
-	initialValue: T | undefined;
-	enhancer: IEnhancer<T>;
+    isMobxModifierDescriptor: boolean
+    initialValue: T | undefined
+    enhancer: IEnhancer<T>
 }
 
 export function isModifierDescriptor(thing): thing is IModifierDescriptor<any> {
-	return typeof thing === "object" && thing !== null && thing.isMobxModifierDescriptor === true;
+    return typeof thing === "object" && thing !== null && thing.isMobxModifierDescriptor === true
 }
 
-export function createModifierDescriptor<T>(enhancer: IEnhancer<T>, initialValue: T): IModifierDescriptor<T> {
-	invariant(!isModifierDescriptor(initialValue), "Modifiers cannot be nested");
-	return {
-		isMobxModifierDescriptor: true,
-		initialValue,
-		enhancer
-	};
+export function createModifierDescriptor<T>(
+    enhancer: IEnhancer<T>,
+    initialValue: T
+): IModifierDescriptor<T> {
+    invariant(!isModifierDescriptor(initialValue), "Modifiers cannot be nested")
+    return {
+        isMobxModifierDescriptor: true,
+        initialValue,
+        enhancer
+    }
 }
 
 export function deepEnhancer(v, _, name) {
-	if (isModifierDescriptor(v))
-		fail("You tried to assign a modifier wrapped value to a collection, please define modifiers when creating the collection, not when modifying it");
+    if (isModifierDescriptor(v))
+        fail(
+            "You tried to assign a modifier wrapped value to a collection, please define modifiers when creating the collection, not when modifying it"
+        )
 
-	// it is an observable already, done
-	if (isObservable(v))
-		return v;
+    // it is an observable already, done
+    if (isObservable(v)) return v
 
-	// something that can be converted and mutated?
-	if (Array.isArray(v))
-		return observable.array(v, name);
-	if (isPlainObject(v))
-		return observable.object(v, name);
-	if (isES6Map(v))
-		return observable.map(v, name);
+    // something that can be converted and mutated?
+    if (Array.isArray(v)) return observable.array(v, name)
+    if (isPlainObject(v)) return observable.object(v, name)
+    if (isES6Map(v)) return observable.map(v, name)
 
-	return v;
+    return v
 }
 
 export function shallowEnhancer(v, _, name): any {
-	if (isModifierDescriptor(v))
-		fail("You tried to assign a modifier wrapped value to a collection, please define modifiers when creating the collection, not when modifying it");
+    if (isModifierDescriptor(v))
+        fail(
+            "You tried to assign a modifier wrapped value to a collection, please define modifiers when creating the collection, not when modifying it"
+        )
 
-	if (v === undefined || v === null)
-		return v;
-	if (isObservableObject(v) || isObservableArray(v) || isObservableMap(v))
-		return v;
-	if (Array.isArray(v))
-		return observable.shallowArray(v, name);
-	if (isPlainObject(v))
-		return observable.shallowObject(v, name);
-	if (isES6Map(v))
-		return observable.shallowMap(v, name);
+    if (v === undefined || v === null) return v
+    if (isObservableObject(v) || isObservableArray(v) || isObservableMap(v)) return v
+    if (Array.isArray(v)) return observable.shallowArray(v, name)
+    if (isPlainObject(v)) return observable.shallowObject(v, name)
+    if (isES6Map(v)) return observable.shallowMap(v, name)
 
-	return fail("The shallow modifier / decorator can only used in combination with arrays, objects and maps");
+    return fail(
+        "The shallow modifier / decorator can only used in combination with arrays, objects and maps"
+    )
 }
 
 export function referenceEnhancer(newValue?) {
-	// never turn into an observable
-	return newValue;
+    // never turn into an observable
+    return newValue
 }
 
 export function deepStructEnhancer(v, oldValue, name): any {
-	// don't confuse structurally compare enhancer with ref enhancer! The latter is probably
-	// more suited for immutable objects
-	if (deepEqual(v, oldValue))
-		return oldValue;
+    // don't confuse structurally compare enhancer with ref enhancer! The latter is probably
+    // more suited for immutable objects
+    if (deepEqual(v, oldValue)) return oldValue
 
-	// it is an observable already, done
-	if (isObservable(v))
-		return v;
+    // it is an observable already, done
+    if (isObservable(v)) return v
 
-	// something that can be converted and mutated?
-	if (Array.isArray(v))
-		return new ObservableArray(v, deepStructEnhancer, name);
-	if (isES6Map(v))
-		return new ObservableMap(v, deepStructEnhancer, name);
-	if (isPlainObject(v)) {
-		const res = {};
-		asObservableObject(res, name);
-		extendObservableHelper(res, deepStructEnhancer, [v]);
-		return res;
-	}
+    // something that can be converted and mutated?
+    if (Array.isArray(v)) return new ObservableArray(v, deepStructEnhancer, name)
+    if (isES6Map(v)) return new ObservableMap(v, deepStructEnhancer, name)
+    if (isPlainObject(v)) {
+        const res = {}
+        asObservableObject(res, name)
+        extendObservableHelper(res, deepStructEnhancer, [v])
+        return res
+    }
 
-	return v;
+    return v
 }
 
 export function refStructEnhancer(v, oldValue, name): any {
-	if (deepEqual(v, oldValue))
-		return oldValue;
-	return v;
+    if (deepEqual(v, oldValue)) return oldValue
+    return v
 }
 
-import { isObservable } from "../api/isobservable";
-import { observable } from "../api/observable";
-import { extendObservableHelper } from "../api/extendobservable";
-import { fail, isPlainObject, invariant, isES6Map, deepEqual } from "../utils/utils";
-import { isObservableObject, asObservableObject } from "./observableobject";
-import { isObservableArray, ObservableArray } from "./observablearray";
-import { isObservableMap, ObservableMap } from "./observablemap";
+import { isObservable } from "../api/isobservable"
+import { observable } from "../api/observable"
+import { extendObservableHelper } from "../api/extendobservable"
+import { fail, isPlainObject, invariant, isES6Map, deepEqual } from "../utils/utils"
+import { isObservableObject, asObservableObject } from "./observableobject"
+import { isObservableArray, ObservableArray } from "./observablearray"
+import { isObservableMap, ObservableMap } from "./observablemap"

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -1,71 +1,102 @@
-import {isObject, createInstanceofPredicate, getNextId, makeNonEnumerable, Lambda, EMPTY_ARRAY, addHiddenFinalProp, addHiddenProp, invariant} from "../utils/utils";
-import {BaseAtom} from "../core/atom";
-import {checkIfStateModificationsAreAllowed} from "../core/derivation";
-import {IInterceptable, IInterceptor, hasInterceptors, registerInterceptor, interceptChange} from "./intercept-utils";
-import {IListenable, registerListener, hasListeners, notifyListeners} from "./listen-utils";
-import {isSpyEnabled, spyReportStart, spyReportEnd} from "../core/spy";
-import {arrayAsIterator, declareIterator} from "../utils/iterable";
-import {IEnhancer} from "./modifiers";
+import {
+    isObject,
+    createInstanceofPredicate,
+    getNextId,
+    makeNonEnumerable,
+    Lambda,
+    EMPTY_ARRAY,
+    addHiddenFinalProp,
+    addHiddenProp,
+    invariant
+} from "../utils/utils"
+import { BaseAtom } from "../core/atom"
+import { checkIfStateModificationsAreAllowed } from "../core/derivation"
+import {
+    IInterceptable,
+    IInterceptor,
+    hasInterceptors,
+    registerInterceptor,
+    interceptChange
+} from "./intercept-utils"
+import { IListenable, registerListener, hasListeners, notifyListeners } from "./listen-utils"
+import { isSpyEnabled, spyReportStart, spyReportEnd } from "../core/spy"
+import { arrayAsIterator, declareIterator } from "../utils/iterable"
+import { IEnhancer } from "./modifiers"
 
-const MAX_SPLICE_SIZE = 10000; // See e.g. https://github.com/mobxjs/mobx/issues/859
+const MAX_SPLICE_SIZE = 10000 // See e.g. https://github.com/mobxjs/mobx/issues/859
 
 // Detects bug in safari 9.1.1 (or iOS 9 safari mobile). See #364
 const safariPrototypeSetterInheritanceBug = (() => {
-	let v = false;
-	const p = {};
-	Object.defineProperty(p, "0", { set: () => { v = true; } });
-	Object.create(p)["0"] = 1;
-	return v === false;
-})();
+    let v = false
+    const p = {}
+    Object.defineProperty(p, "0", {
+        set: () => {
+            v = true
+        }
+    })
+    Object.create(p)["0"] = 1
+    return v === false
+})()
 
 export interface IObservableArray<T> extends Array<T> {
-	spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[];
-	observe(listener: (changeData: IArrayChange<T>|IArraySplice<T>) => void, fireImmediately?: boolean): Lambda;
-	intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda;
-	intercept(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda; // TODO: remove in 4.0
-	intercept<T>(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda; // TODO: remove in 4.0
-	clear(): T[];
-	peek(): T[];
-	replace(newItems: T[]): T[];
-	find(predicate: (item: T, index: number, array: IObservableArray<T>) => boolean, thisArg?: any, fromIndex?: number): T;
-	findIndex(predicate: (item: T, index: number, array: IObservableArray<T>) => boolean, thisArg?: any, fromIndex?: number): number;
-	remove(value: T): boolean;
-	move(fromIndex: number, toIndex: number): void;
+    spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[]
+    observe(
+        listener: (changeData: IArrayChange<T> | IArraySplice<T>) => void,
+        fireImmediately?: boolean
+    ): Lambda
+    intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda
+    intercept(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda // TODO: remove in 4.0
+    intercept<T>(handler: IInterceptor<IArrayChange<T> | IArraySplice<T>>): Lambda // TODO: remove in 4.0
+    clear(): T[]
+    peek(): T[]
+    replace(newItems: T[]): T[]
+    find(
+        predicate: (item: T, index: number, array: IObservableArray<T>) => boolean,
+        thisArg?: any,
+        fromIndex?: number
+    ): T
+    findIndex(
+        predicate: (item: T, index: number, array: IObservableArray<T>) => boolean,
+        thisArg?: any,
+        fromIndex?: number
+    ): number
+    remove(value: T): boolean
+    move(fromIndex: number, toIndex: number): void
 }
 
 // In 3.0, change to IArrayDidChange
 export interface IArrayChange<T> {
-	type: "update";
-	object: IObservableArray<T>;
-	index: number;
-	newValue: T;
-	oldValue: T;
+    type: "update"
+    object: IObservableArray<T>
+    index: number
+    newValue: T
+    oldValue: T
 }
 
 // In 3.0, change to IArrayDidSplice
 export interface IArraySplice<T> {
-	type: "splice";
-	object: IObservableArray<T>;
-	index: number;
-	added: T[];
-	addedCount: number;
-	removed: T[];
-	removedCount: number;
+    type: "splice"
+    object: IObservableArray<T>
+    index: number
+    added: T[]
+    addedCount: number
+    removed: T[]
+    removedCount: number
 }
 
 export interface IArrayWillChange<T> {
-	type: "update";
-	object: IObservableArray<T>;
-	index: number;
-	newValue: T;
+    type: "update"
+    object: IObservableArray<T>
+    index: number
+    newValue: T
 }
 
 export interface IArrayWillSplice<T> {
-	type: "splice";
-	object: IObservableArray<T>;
-	index: number;
-	added: T[];
-	removedCount: number;
+    type: "splice"
+    object: IObservableArray<T>
+    index: number
+    added: T[]
+    removedCount: number
 }
 
 /**
@@ -73,511 +104,552 @@ export interface IArrayWillSplice<T> {
  * can recycle their property definitions, which significantly improves performance of creating
  * properties on the fly.
  */
-let OBSERVABLE_ARRAY_BUFFER_SIZE = 0;
+let OBSERVABLE_ARRAY_BUFFER_SIZE = 0
 
 // Typescript workaround to make sure ObservableArray extends Array
-export class StubArray { }
+export class StubArray {}
 function inherit(ctor, proto) {
-	if (typeof Object["setPrototypeOf"] !== "undefined") {
-		Object["setPrototypeOf"](ctor.prototype, proto);
-	} else if (typeof ctor.prototype.__proto__ !== "undefined") {
-		ctor.prototype.__proto__ = proto;
-	} else {
-		ctor["prototype"] = proto;
-	}
+    if (typeof Object["setPrototypeOf"] !== "undefined") {
+        Object["setPrototypeOf"](ctor.prototype, proto)
+    } else if (typeof ctor.prototype.__proto__ !== "undefined") {
+        ctor.prototype.__proto__ = proto
+    } else {
+        ctor["prototype"] = proto
+    }
 }
-inherit(StubArray, Array.prototype);
+inherit(StubArray, Array.prototype)
 
+class ObservableArrayAdministration<T>
+    implements IInterceptable<IArrayWillChange<T> | IArrayWillSplice<T>>, IListenable {
+    atom: BaseAtom
+    values: T[] = []
+    lastKnownLength: number = 0
+    interceptors = null
+    changeListeners = null
+    enhancer: (newV: T, oldV: T | undefined) => T
+    dehancer: any
 
+    constructor(
+        name,
+        enhancer: IEnhancer<T>,
+        public array: IObservableArray<T>,
+        public owned: boolean
+    ) {
+        this.atom = new BaseAtom(name || "ObservableArray@" + getNextId())
+        this.enhancer = (newV, oldV) => enhancer(newV, oldV, name + "[..]")
+    }
 
-class ObservableArrayAdministration<T> implements IInterceptable<IArrayWillChange<T> | IArrayWillSplice<T>>, IListenable {
-	atom: BaseAtom;
-	values: T[] = [];
-	lastKnownLength: number = 0;
-	interceptors = null;
-	changeListeners = null;
-	enhancer: (newV: T, oldV: T | undefined) => T;
-	dehancer: any
+    dehanceValue(value: T): T {
+        if (this.dehancer !== undefined) return this.dehancer(value)
+        return value
+    }
 
-	constructor(name, enhancer: IEnhancer<T>, public array: IObservableArray<T>, public owned: boolean) {
-		this.atom = new BaseAtom(name || ("ObservableArray@" + getNextId()));
-		this.enhancer = (newV, oldV) => enhancer(newV, oldV, name + "[..]");
-	}
+    dehanceValues(values: T[]): T[] {
+        if (this.dehancer !== undefined) return values.map(this.dehancer) as any
+        return values
+    }
 
-	dehanceValue(value: T): T {
-		if (this.dehancer !== undefined)
-			return this.dehancer(value);
-		return value;
-	}
+    intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda {
+        return registerInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>(this, handler)
+    }
 
-	dehanceValues(values: T[]): T[] {
-		if (this.dehancer !== undefined)
-			return values.map(this.dehancer) as any;
-		return values;
-	}
+    observe(
+        listener: (changeData: IArrayChange<T> | IArraySplice<T>) => void,
+        fireImmediately = false
+    ): Lambda {
+        if (fireImmediately) {
+            listener(
+                <IArraySplice<T>>{
+                    object: this.array,
+                    type: "splice",
+                    index: 0,
+                    added: this.values.slice(),
+                    addedCount: this.values.length,
+                    removed: [],
+                    removedCount: 0
+                }
+            )
+        }
+        return registerListener(this, listener)
+    }
 
-	intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda {
-		return registerInterceptor<IArrayWillChange<T>|IArrayWillSplice<T>>(this, handler);
-	}
+    getArrayLength(): number {
+        this.atom.reportObserved()
+        return this.values.length
+    }
 
-	observe(listener: (changeData: IArrayChange<T>|IArraySplice<T>) => void, fireImmediately = false): Lambda {
-		if (fireImmediately) {
-			listener(<IArraySplice<T>>{
-				object: this.array,
-				type: "splice",
-				index: 0,
-				added: this.values.slice(),
-				addedCount: this.values.length,
-				removed: [],
-				removedCount: 0
-			});
-		}
-		return registerListener(this, listener);
-	}
+    setArrayLength(newLength: number) {
+        if (typeof newLength !== "number" || newLength < 0)
+            throw new Error("[mobx.array] Out of range: " + newLength)
+        let currentLength = this.values.length
+        if (newLength === currentLength) return
+        else if (newLength > currentLength) {
+            const newItems = new Array(newLength - currentLength)
+            for (let i = 0; i < newLength - currentLength; i++) newItems[i] = undefined // No Array.fill everywhere...
+            this.spliceWithArray(currentLength, 0, newItems)
+        } else this.spliceWithArray(newLength, currentLength - newLength)
+    }
 
-	getArrayLength(): number {
-		this.atom.reportObserved();
-		return this.values.length;
-	}
+    // adds / removes the necessary numeric properties to this object
+    updateArrayLength(oldLength: number, delta: number) {
+        if (oldLength !== this.lastKnownLength)
+            throw new Error(
+                "[mobx] Modification exception: the internal structure of an observable array was changed. Did you use peek() to change it?"
+            )
+        this.lastKnownLength += delta
+        if (delta > 0 && oldLength + delta + 1 > OBSERVABLE_ARRAY_BUFFER_SIZE)
+            reserveArrayBuffer(oldLength + delta + 1)
+    }
 
-	setArrayLength(newLength: number) {
-		if (typeof newLength !== "number" || newLength < 0)
-			throw new Error("[mobx.array] Out of range: " + newLength);
-		let currentLength = this.values.length;
-		if (newLength === currentLength)
-			return;
-		else if (newLength > currentLength) {
-			const newItems = new Array(newLength - currentLength);
-			for (let i = 0; i < newLength - currentLength; i++)
-				newItems[i] = undefined; // No Array.fill everywhere...
-			this.spliceWithArray(currentLength, 0, newItems);
-		}
-		else
-			this.spliceWithArray(newLength, currentLength - newLength);
-	}
+    spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[] {
+        checkIfStateModificationsAreAllowed(this.atom)
+        const length = this.values.length
 
-	// adds / removes the necessary numeric properties to this object
-	updateArrayLength(oldLength: number, delta: number) {
-		if (oldLength !== this.lastKnownLength)
-			throw new Error("[mobx] Modification exception: the internal structure of an observable array was changed. Did you use peek() to change it?");
-		this.lastKnownLength += delta;
-		if (delta > 0 && oldLength + delta + 1 > OBSERVABLE_ARRAY_BUFFER_SIZE)
-			reserveArrayBuffer(oldLength + delta + 1);
-	}
+        if (index === undefined) index = 0
+        else if (index > length) index = length
+        else if (index < 0) index = Math.max(0, length + index)
 
-	spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[] {
-		checkIfStateModificationsAreAllowed(this.atom);
-		const length = this.values.length;
+        if (arguments.length === 1) deleteCount = length - index
+        else if (deleteCount === undefined || deleteCount === null) deleteCount = 0
+        else deleteCount = Math.max(0, Math.min(deleteCount, length - index))
 
-		if (index === undefined)
-			index = 0;
-		else if (index > length)
-			index = length;
-		else if (index < 0)
-			index = Math.max(0, length + index);
+        if (newItems === undefined) newItems = []
 
-		if (arguments.length === 1)
-			deleteCount = length - index;
-		else if (deleteCount === undefined || deleteCount === null)
-			deleteCount = 0;
-		else
-			deleteCount = Math.max(0, Math.min(deleteCount, length - index));
+        if (hasInterceptors(this)) {
+            const change = interceptChange<IArrayWillSplice<T>>(this as any, {
+                object: this.array,
+                type: "splice",
+                index,
+                removedCount: deleteCount,
+                added: newItems
+            })
+            if (!change) return EMPTY_ARRAY
+            deleteCount = change.removedCount
+            newItems = change.added
+        }
 
-		if (newItems === undefined)
-			newItems = [];
+        newItems = <T[]>newItems.map(v => this.enhancer(v, undefined))
+        const lengthDelta = newItems.length - deleteCount
+        this.updateArrayLength(length, lengthDelta) // create or remove new entries
+        const res = this.spliceItemsIntoValues(index, deleteCount, newItems)
 
-		if (hasInterceptors(this)) {
-			const change = interceptChange<IArrayWillSplice<T>>(this as any, {
-				object: this.array,
-				type: "splice",
-				index,
-				removedCount: deleteCount,
-				added: newItems
-			});
-			if (!change)
-				return EMPTY_ARRAY;
-			deleteCount = change.removedCount;
-			newItems = change.added;
-		}
+        if (deleteCount !== 0 || newItems.length !== 0) this.notifyArraySplice(index, newItems, res)
+        return this.dehanceValues(res)
+    }
 
-		newItems = <T[]> newItems.map(v => this.enhancer(v, undefined));
-		const lengthDelta = newItems.length - deleteCount;
-		this.updateArrayLength(length, lengthDelta); // create or remove new entries
-		const res = this.spliceItemsIntoValues(index, deleteCount, newItems);
+    spliceItemsIntoValues(index, deleteCount, newItems: T[]): T[] {
+        if (newItems.length < MAX_SPLICE_SIZE) {
+            return this.values.splice(index, deleteCount, ...newItems)
+        } else {
+            const res = this.values.slice(index, index + deleteCount)
+            this.values = this.values
+                .slice(0, index)
+                .concat(newItems, this.values.slice(index + deleteCount))
+            return res
+        }
+    }
 
-		if (deleteCount !== 0 || newItems.length !== 0)
-			this.notifyArraySplice(index, newItems, res);
-		return this.dehanceValues(res);
-	}
+    notifyArrayChildUpdate<T>(index: number, newValue: T, oldValue: T) {
+        const notifySpy = !this.owned && isSpyEnabled()
+        const notify = hasListeners(this)
+        const change =
+            notify || notifySpy
+                ? {
+                      object: this.array,
+                      type: "update",
+                      index,
+                      newValue,
+                      oldValue
+                  }
+                : null
 
-	spliceItemsIntoValues(index, deleteCount, newItems: T[]): T[] {
-		if (newItems.length < MAX_SPLICE_SIZE) {
-			return this.values.splice(index, deleteCount, ...newItems);
-		} else {
-			const res = this.values.slice(index, index + deleteCount)
-			this.values = this.values.slice(0, index).concat(newItems, this.values.slice(index + deleteCount ))
-			return res;
-		}
-	}
+        if (notifySpy) spyReportStart(change)
+        this.atom.reportChanged()
+        if (notify) notifyListeners(this, change)
+        if (notifySpy) spyReportEnd()
+    }
 
-	notifyArrayChildUpdate<T>(index: number, newValue: T, oldValue: T) {
-		const notifySpy = !this.owned && isSpyEnabled();
-		const notify = hasListeners(this);
-		const change = notify || notifySpy ? {
-				object: this.array,
-				type: "update",
-				index, newValue, oldValue
-			} : null;
+    notifyArraySplice<T>(index: number, added: T[], removed: T[]) {
+        const notifySpy = !this.owned && isSpyEnabled()
+        const notify = hasListeners(this)
+        const change =
+            notify || notifySpy
+                ? {
+                      object: this.array,
+                      type: "splice",
+                      index,
+                      removed,
+                      added,
+                      removedCount: removed.length,
+                      addedCount: added.length
+                  }
+                : null
 
-		if (notifySpy)
-			spyReportStart(change);
-		this.atom.reportChanged();
-		if (notify)
-			notifyListeners(this, change);
-		if (notifySpy)
-			spyReportEnd();
-	}
-
-	notifyArraySplice<T>(index: number, added: T[], removed: T[]) {
-		const notifySpy = !this.owned && isSpyEnabled();
-		const notify = hasListeners(this);
-		const change = notify || notifySpy ? {
-				object: this.array,
-				type: "splice",
-				index, removed, added,
-				removedCount: removed.length,
-				addedCount: added.length
-			} : null;
-
-		if (notifySpy)
-			spyReportStart(change);
-		this.atom.reportChanged();
-		// conform: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/observe
-		if (notify)
-			notifyListeners(this, change);
-		if (notifySpy)
-			spyReportEnd();
-	}
+        if (notifySpy) spyReportStart(change)
+        this.atom.reportChanged()
+        // conform: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/observe
+        if (notify) notifyListeners(this, change)
+        if (notifySpy) spyReportEnd()
+    }
 }
 
 export class ObservableArray<T> extends StubArray {
-	private $mobx: ObservableArrayAdministration<T>;
+    private $mobx: ObservableArrayAdministration<T>
 
-	constructor(initialValues: T[] | undefined, enhancer: IEnhancer<T>, name = "ObservableArray@" + getNextId(), owned = false) {
-		super();
+    constructor(
+        initialValues: T[] | undefined,
+        enhancer: IEnhancer<T>,
+        name = "ObservableArray@" + getNextId(),
+        owned = false
+    ) {
+        super()
 
-		const adm = new ObservableArrayAdministration<T>(name, enhancer, this as any, owned);
-		addHiddenFinalProp(this, "$mobx", adm);
+        const adm = new ObservableArrayAdministration<T>(name, enhancer, this as any, owned)
+        addHiddenFinalProp(this, "$mobx", adm)
 
-		if (initialValues && initialValues.length) {
-			this.spliceWithArray(0, 0, initialValues)
-		}
+        if (initialValues && initialValues.length) {
+            this.spliceWithArray(0, 0, initialValues)
+        }
 
-		if (safariPrototypeSetterInheritanceBug) {
-			// Seems that Safari won't use numeric prototype setter untill any * numeric property is
-			// defined on the instance. After that it works fine, even if this property is deleted.
-			Object.defineProperty(adm.array, "0", ENTRY_0);
-		}
-	}
+        if (safariPrototypeSetterInheritanceBug) {
+            // Seems that Safari won't use numeric prototype setter untill any * numeric property is
+            // defined on the instance. After that it works fine, even if this property is deleted.
+            Object.defineProperty(adm.array, "0", ENTRY_0)
+        }
+    }
 
-	intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda {
-		return this.$mobx.intercept(handler);
-	}
+    intercept(handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>): Lambda {
+        return this.$mobx.intercept(handler)
+    }
 
-	observe(listener: (changeData: IArrayChange<T>|IArraySplice<T>) => void, fireImmediately = false): Lambda {
-		return this.$mobx.observe(listener, fireImmediately);
-	}
+    observe(
+        listener: (changeData: IArrayChange<T> | IArraySplice<T>) => void,
+        fireImmediately = false
+    ): Lambda {
+        return this.$mobx.observe(listener, fireImmediately)
+    }
 
-	clear(): T[] {
-		return this.splice(0);
-	}
+    clear(): T[] {
+        return this.splice(0)
+    }
 
-	concat(...arrays: T[][]): T[] {
-		this.$mobx.atom.reportObserved();
-		return Array.prototype.concat.apply((this as any).peek(), arrays.map(a => isObservableArray(a) ? a.peek() : a));
-	}
+    concat(...arrays: T[][]): T[] {
+        this.$mobx.atom.reportObserved()
+        return Array.prototype.concat.apply(
+            (this as any).peek(),
+            arrays.map(a => (isObservableArray(a) ? a.peek() : a))
+        )
+    }
 
-	replace(newItems: T[]) {
-		return this.$mobx.spliceWithArray(0, this.$mobx.values.length, newItems);
-	}
+    replace(newItems: T[]) {
+        return this.$mobx.spliceWithArray(0, this.$mobx.values.length, newItems)
+    }
 
-	/**
+    /**
 	 * Converts this array back to a (shallow) javascript structure.
 	 * For a deep clone use mobx.toJS
 	 */
-	toJS(): T[] {
-		return (this as any).slice();
-	}
+    toJS(): T[] {
+        return (this as any).slice()
+    }
 
-	toJSON(): T[] {
-		// Used by JSON.stringify
-		return this.toJS();
-	}
+    toJSON(): T[] {
+        // Used by JSON.stringify
+        return this.toJS()
+    }
 
-	peek(): T[] {
-		this.$mobx.atom.reportObserved();
-		return this.$mobx.dehanceValues(this.$mobx.values);
-	}
+    peek(): T[] {
+        this.$mobx.atom.reportObserved()
+        return this.$mobx.dehanceValues(this.$mobx.values)
+    }
 
-	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
-	find(predicate: (item: T, index: number, array: ObservableArray<T>) => boolean, thisArg?, fromIndex = 0): T | undefined {
-		const idx = this.findIndex.apply(this, arguments);
-		return idx === -1 ? undefined : this.get(idx);
-	}
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
+    find(
+        predicate: (item: T, index: number, array: ObservableArray<T>) => boolean,
+        thisArg?,
+        fromIndex = 0
+    ): T | undefined {
+        const idx = this.findIndex.apply(this, arguments)
+        return idx === -1 ? undefined : this.get(idx)
+    }
 
-	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
-	findIndex(predicate: (item: T, index: number, array: ObservableArray<T>) => boolean, thisArg?, fromIndex = 0): number {
-		const items = this.peek(), l = items.length;
-		for (let i = fromIndex; i < l; i++)
-			if (predicate.call(thisArg, items[i], i, this))
-				return i;
-		return -1;
-	}
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
+    findIndex(
+        predicate: (item: T, index: number, array: ObservableArray<T>) => boolean,
+        thisArg?,
+        fromIndex = 0
+    ): number {
+        const items = this.peek(),
+            l = items.length
+        for (let i = fromIndex; i < l; i++) if (predicate.call(thisArg, items[i], i, this)) return i
+        return -1
+    }
 
-	/*
+    /*
 		functions that do alter the internal structure of the array, (based on lib.es6.d.ts)
 		since these functions alter the inner structure of the array, the have side effects.
 		Because the have side effects, they should not be used in computed function,
 		and for that reason the do not call dependencyState.notifyObserved
 		*/
-	splice(index: number, deleteCount?: number, ...newItems: T[]): T[] {
-		switch (arguments.length) {
-			case 0:
-				return [];
-			case 1:
-				return this.$mobx.spliceWithArray(index);
-			case 2:
-				return this.$mobx.spliceWithArray(index, deleteCount);
-		}
-		return this.$mobx.spliceWithArray(index, deleteCount, newItems);
-	}
+    splice(index: number, deleteCount?: number, ...newItems: T[]): T[] {
+        switch (arguments.length) {
+            case 0:
+                return []
+            case 1:
+                return this.$mobx.spliceWithArray(index)
+            case 2:
+                return this.$mobx.spliceWithArray(index, deleteCount)
+        }
+        return this.$mobx.spliceWithArray(index, deleteCount, newItems)
+    }
 
-	spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[] {
-		return this.$mobx.spliceWithArray(index, deleteCount, newItems);
-	}
+    spliceWithArray(index: number, deleteCount?: number, newItems?: T[]): T[] {
+        return this.$mobx.spliceWithArray(index, deleteCount, newItems)
+    }
 
+    push(...items: T[]): number {
+        const adm = this.$mobx
+        adm.spliceWithArray(adm.values.length, 0, items)
+        return adm.values.length
+    }
 
-	push(...items: T[]): number {
-		const adm = this.$mobx;
-		adm.spliceWithArray(adm.values.length, 0, items);
-		return adm.values.length;
-	}
+    pop(): T | undefined {
+        return this.splice(Math.max(this.$mobx.values.length - 1, 0), 1)[0]
+    }
 
-	pop(): T | undefined {
-		return this.splice(Math.max(this.$mobx.values.length - 1, 0), 1)[0];
-	}
+    shift(): T | undefined {
+        return this.splice(0, 1)[0]
+    }
 
-	shift(): T | undefined {
-		return this.splice(0, 1)[0];
-	}
+    unshift(...items: T[]): number {
+        const adm = this.$mobx
+        adm.spliceWithArray(0, 0, items)
+        return adm.values.length
+    }
 
-	unshift(...items: T[]): number {
-		const adm = this.$mobx;
-		adm.spliceWithArray(0, 0, items);
-		return adm.values.length;
-	}
+    reverse(): T[] {
+        // reverse by default mutates in place before returning the result
+        // which makes it both a 'derivation' and a 'mutation'.
+        // so we deviate from the default and just make it an dervitation
+        const clone = (<any>this).slice()
+        return clone.reverse.apply(clone, arguments)
+    }
 
-	reverse(): T[] {
-		// reverse by default mutates in place before returning the result
-		// which makes it both a 'derivation' and a 'mutation'.
-		// so we deviate from the default and just make it an dervitation
-		const clone = (<any>this).slice();
-		return clone.reverse.apply(clone, arguments);
-	}
+    sort(compareFn?: (a: T, b: T) => number): T[] {
+        // sort by default mutates in place before returning the result
+        // which goes against all good practices. Let's not change the array in place!
+        const clone = (<any>this).slice()
+        return clone.sort.apply(clone, arguments)
+    }
 
-	sort(compareFn?: (a: T, b: T) => number): T[] {
-		// sort by default mutates in place before returning the result
-		// which goes against all good practices. Let's not change the array in place!
-		const clone = (<any>this).slice();
-		return clone.sort.apply(clone, arguments);
-	}
+    remove(value: T): boolean {
+        const idx = this.$mobx.dehanceValues(this.$mobx.values).indexOf(value)
+        if (idx > -1) {
+            this.splice(idx, 1)
+            return true
+        }
+        return false
+    }
 
-	remove(value: T): boolean {
-		const idx = this.$mobx.dehanceValues(this.$mobx.values).indexOf(value);
-		if (idx > -1) {
-			this.splice(idx, 1);
-			return true;
-		}
-		return false;
-	}
+    move(fromIndex: number, toIndex: number): void {
+        function checkIndex(index: number) {
+            if (index < 0) {
+                throw new Error(`[mobx.array] Index out of bounds: ${index} is negative`)
+            }
+            const length = this.$mobx.values.length
+            if (index >= length) {
+                throw new Error(
+                    `[mobx.array] Index out of bounds: ${index} is not smaller than ${length}`
+                )
+            }
+        }
+        checkIndex.call(this, fromIndex)
+        checkIndex.call(this, toIndex)
+        if (fromIndex === toIndex) {
+            return
+        }
+        const oldItems = this.$mobx.values
+        let newItems: T[]
+        if (fromIndex < toIndex) {
+            newItems = [
+                ...oldItems.slice(0, fromIndex),
+                ...oldItems.slice(fromIndex + 1, toIndex + 1),
+                oldItems[fromIndex],
+                ...oldItems.slice(toIndex + 1)
+            ]
+        } else {
+            // toIndex < fromIndex
+            newItems = [
+                ...oldItems.slice(0, toIndex),
+                oldItems[fromIndex],
+                ...oldItems.slice(toIndex, fromIndex),
+                ...oldItems.slice(fromIndex + 1)
+            ]
+        }
+        this.replace(newItems)
+    }
 
-	move(fromIndex: number, toIndex: number): void {
-		function checkIndex(index: number) {
-			if (index < 0) {
-				throw new Error(`[mobx.array] Index out of bounds: ${index} is negative`);
-			}
-			const length = this.$mobx.values.length;
-			if (index >= length) {
-				throw new Error(`[mobx.array] Index out of bounds: ${index} is not smaller than ${length}`);
-			}
-		}
-		checkIndex.call(this, fromIndex);
-		checkIndex.call(this, toIndex);
-		if (fromIndex === toIndex) {
-			return;
-		}
-		const oldItems = this.$mobx.values;
-		let newItems: T[];
-		if (fromIndex < toIndex) {
-			newItems = [...oldItems.slice(0, fromIndex), ...oldItems.slice(fromIndex + 1, toIndex + 1), oldItems[fromIndex], ...oldItems.slice(toIndex + 1)];
-		} else {	// toIndex < fromIndex
-			newItems = [...oldItems.slice(0, toIndex), oldItems[fromIndex], ...oldItems.slice(toIndex, fromIndex), ...oldItems.slice(fromIndex + 1)];
-		}
-		this.replace(newItems);
-	}
+    // See #734, in case property accessors are unreliable...
+    get(index: number): T | undefined {
+        const impl = <ObservableArrayAdministration<any>>this.$mobx
+        if (impl) {
+            if (index < impl.values.length) {
+                impl.atom.reportObserved()
+                return impl.dehanceValue(impl.values[index])
+            }
+            console.warn(
+                `[mobx.array] Attempt to read an array index (${index}) that is out of bounds (${impl
+                    .values
+                    .length}). Please check length first. Out of bound indices will not be tracked by MobX`
+            )
+        }
+        return undefined
+    }
 
-	// See #734, in case property accessors are unreliable...
-	get(index: number): T | undefined {
-		const impl = <ObservableArrayAdministration<any>> this.$mobx;
-		if (impl) {
-			if (index < impl.values.length) {
-				impl.atom.reportObserved();
-				return impl.dehanceValue(impl.values[index]);
-			}
-			console.warn(`[mobx.array] Attempt to read an array index (${index}) that is out of bounds (${impl.values.length}). Please check length first. Out of bound indices will not be tracked by MobX`);
-		}
-		return undefined;
-	}
-
-	// See #734, in case property accessors are unreliable...
-	set(index: number, newValue: T) {
-		const adm = <ObservableArrayAdministration<T>> this.$mobx;
-		const values = adm.values;
-		if (index < values.length) {
-			// update at index in range
-			checkIfStateModificationsAreAllowed(adm.atom);
-			const oldValue = values[index];
-			if (hasInterceptors(adm)) {
-				const change = interceptChange<IArrayWillChange<T>>(adm as any, {
-					type: "update",
-					object: this as any,
-					index, newValue
-				});
-				if (!change)
-					return;
-				newValue = change.newValue;
-			}
-			newValue = adm.enhancer(newValue, oldValue);
-			const changed = newValue !== oldValue;
-			if (changed) {
-				values[index] = newValue;
-				adm.notifyArrayChildUpdate(index, newValue, oldValue);
-			}
-		} else if (index === values.length) {
-			// add a new item
-			adm.spliceWithArray(index, 0, [newValue]);
-		} else {
-			// out of bounds
-			throw new Error(`[mobx.array] Index out of bounds, ${index} is larger than ${values.length}`);
-		}
-	}
-
+    // See #734, in case property accessors are unreliable...
+    set(index: number, newValue: T) {
+        const adm = <ObservableArrayAdministration<T>>this.$mobx
+        const values = adm.values
+        if (index < values.length) {
+            // update at index in range
+            checkIfStateModificationsAreAllowed(adm.atom)
+            const oldValue = values[index]
+            if (hasInterceptors(adm)) {
+                const change = interceptChange<IArrayWillChange<T>>(adm as any, {
+                    type: "update",
+                    object: this as any,
+                    index,
+                    newValue
+                })
+                if (!change) return
+                newValue = change.newValue
+            }
+            newValue = adm.enhancer(newValue, oldValue)
+            const changed = newValue !== oldValue
+            if (changed) {
+                values[index] = newValue
+                adm.notifyArrayChildUpdate(index, newValue, oldValue)
+            }
+        } else if (index === values.length) {
+            // add a new item
+            adm.spliceWithArray(index, 0, [newValue])
+        } else {
+            // out of bounds
+            throw new Error(
+                `[mobx.array] Index out of bounds, ${index} is larger than ${values.length}`
+            )
+        }
+    }
 }
 
 declareIterator(ObservableArray.prototype, function() {
-	return arrayAsIterator(this.slice());
-});
+    return arrayAsIterator(this.slice())
+})
 
 Object.defineProperty(ObservableArray.prototype, "length", {
-	enumerable: false,
-	configurable: true,
-	get: function(): number {
-		return this.$mobx.getArrayLength();
-	},
-	set: function(newLength: number) {
-		this.$mobx.setArrayLength(newLength);
-	}
-});
-
+    enumerable: false,
+    configurable: true,
+    get: function(): number {
+        return this.$mobx.getArrayLength()
+    },
+    set: function(newLength: number) {
+        this.$mobx.setArrayLength(newLength)
+    }
+})
 
 /**
  * Wrap function from prototype
  */
-[
-	"every",
-	"filter",
-	"forEach",
-	"indexOf",
-	"join",
-	"lastIndexOf",
-	"map",
-	"reduce",
-	"reduceRight",
-	"slice",
-	"some",
-	"toString",
-	"toLocaleString"
+;[
+    "every",
+    "filter",
+    "forEach",
+    "indexOf",
+    "join",
+    "lastIndexOf",
+    "map",
+    "reduce",
+    "reduceRight",
+    "slice",
+    "some",
+    "toString",
+    "toLocaleString"
 ].forEach(funcName => {
-	const baseFunc = Array.prototype[funcName];
-	invariant(typeof baseFunc === "function", `Base function not defined on Array prototype: '${funcName}'`);
-	addHiddenProp(ObservableArray.prototype, funcName, function() {
-		return baseFunc.apply(this.peek(), arguments);
-	});
-});
-
+    const baseFunc = Array.prototype[funcName]
+    invariant(
+        typeof baseFunc === "function",
+        `Base function not defined on Array prototype: '${funcName}'`
+    )
+    addHiddenProp(ObservableArray.prototype, funcName, function() {
+        return baseFunc.apply(this.peek(), arguments)
+    })
+})
 
 /**
  * We don't want those to show up in `for (const key in ar)` ...
  */
 makeNonEnumerable(ObservableArray.prototype, [
-	"constructor",
-	"intercept",
-	"observe",
-	"clear",
-	"concat",
-	"get",
-	"replace",
-	"toJS",
-	"toJSON",
-	"peek",
-	"find",
-	"findIndex",
-	"splice",
-	"spliceWithArray",
-	"push",
-	"pop",
-	"set",
-	"shift",
-	"unshift",
-	"reverse",
-	"sort",
-	"remove",
-	"move",
-	"toString",
-	"toLocaleString"
-]);
+    "constructor",
+    "intercept",
+    "observe",
+    "clear",
+    "concat",
+    "get",
+    "replace",
+    "toJS",
+    "toJSON",
+    "peek",
+    "find",
+    "findIndex",
+    "splice",
+    "spliceWithArray",
+    "push",
+    "pop",
+    "set",
+    "shift",
+    "unshift",
+    "reverse",
+    "sort",
+    "remove",
+    "move",
+    "toString",
+    "toLocaleString"
+])
 
 // See #364
-const ENTRY_0 = createArrayEntryDescriptor(0);
+const ENTRY_0 = createArrayEntryDescriptor(0)
 
 function createArrayEntryDescriptor(index: number) {
-	return {
-		enumerable: false,
-		configurable: false,
-		get: function() {
-			// TODO: Check `this`?, see #752?
-			return this.get(index);
-		},
-		set: function(value) {
-			this.set(index, value);
-		}
-	};
+    return {
+        enumerable: false,
+        configurable: false,
+        get: function() {
+            // TODO: Check `this`?, see #752?
+            return this.get(index)
+        },
+        set: function(value) {
+            this.set(index, value)
+        }
+    }
 }
 
 function createArrayBufferItem(index: number) {
-	Object.defineProperty(ObservableArray.prototype, "" + index, createArrayEntryDescriptor(index));
+    Object.defineProperty(ObservableArray.prototype, "" + index, createArrayEntryDescriptor(index))
 }
 
 export function reserveArrayBuffer(max: number) {
-	for (let index = OBSERVABLE_ARRAY_BUFFER_SIZE; index < max; index++)
-		createArrayBufferItem(index);
-	OBSERVABLE_ARRAY_BUFFER_SIZE = max;
+    for (let index = OBSERVABLE_ARRAY_BUFFER_SIZE; index < max; index++)
+        createArrayBufferItem(index)
+    OBSERVABLE_ARRAY_BUFFER_SIZE = max
 }
 
-reserveArrayBuffer(1000);
+reserveArrayBuffer(1000)
 
-const isObservableArrayAdministration = createInstanceofPredicate("ObservableArrayAdministration", ObservableArrayAdministration);
+const isObservableArrayAdministration = createInstanceofPredicate(
+    "ObservableArrayAdministration",
+    ObservableArrayAdministration
+)
 
 export function isObservableArray(thing): thing is IObservableArray<any> {
-	return isObject(thing) && isObservableArrayAdministration(thing.$mobx);
+    return isObject(thing) && isObservableArrayAdministration(thing.$mobx)
 }

--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -1,17 +1,31 @@
-import {IEnhancer, deepEnhancer} from "./modifiers";
-import {untracked} from "../core/derivation";
-import {IObservableArray, ObservableArray} from "./observablearray";
-import {ObservableValue, UNCHANGED} from "./observablevalue";
-import {createInstanceofPredicate, isPlainObject, getNextId, Lambda, invariant, deprecated, isES6Map, fail} from "../utils/utils";
-import {IInterceptable, IInterceptor, hasInterceptors, registerInterceptor, interceptChange} from "./intercept-utils";
-import {IListenable, registerListener, hasListeners, notifyListeners} from "./listen-utils";
-import {isSpyEnabled, spyReportStart, spyReportEnd} from "../core/spy";
-import {arrayAsIterator, declareIterator, Iterator} from "../utils/iterable";
-import {observable} from "../api/observable";
-import {runInTransaction} from "../api/transaction";
-import {referenceEnhancer} from "./modifiers";
-import {getMessage} from "../utils/messages";
-
+import { IEnhancer, deepEnhancer } from "./modifiers"
+import { untracked } from "../core/derivation"
+import { IObservableArray, ObservableArray } from "./observablearray"
+import { ObservableValue, UNCHANGED } from "./observablevalue"
+import {
+    createInstanceofPredicate,
+    isPlainObject,
+    getNextId,
+    Lambda,
+    invariant,
+    deprecated,
+    isES6Map,
+    fail
+} from "../utils/utils"
+import {
+    IInterceptable,
+    IInterceptor,
+    hasInterceptors,
+    registerInterceptor,
+    interceptChange
+} from "./intercept-utils"
+import { IListenable, registerListener, hasListeners, notifyListeners } from "./listen-utils"
+import { isSpyEnabled, spyReportStart, spyReportEnd } from "../core/spy"
+import { arrayAsIterator, declareIterator, Iterator } from "../utils/iterable"
+import { observable } from "../api/observable"
+import { runInTransaction } from "../api/transaction"
+import { referenceEnhancer } from "./modifiers"
+import { getMessage } from "../utils/messages"
 
 /**
  * Map as defined by Typescript's lib.es2015.collection.d.ts
@@ -19,330 +33,350 @@ import {getMessage} from "../utils/messages";
  * Imported here to not require consumers to have these libs enabled in their tsconfig if not actually using maps
  */
 export interface IMap<K, V> {
-	clear(): void;
-	delete(key: K): boolean;
-	forEach(callbackfn: (value: V, index: K, map: IMap<K, V>) => void, thisArg?: any): void;
-	get(key: K): V | undefined;
-	has(key: K): boolean;
-	set(key: K, value?: V): this;
-	readonly size: number;
+    clear(): void
+    delete(key: K): boolean
+    forEach(callbackfn: (value: V, index: K, map: IMap<K, V>) => void, thisArg?: any): void
+    get(key: K): V | undefined
+    has(key: K): boolean
+    set(key: K, value?: V): this
+    readonly size: number
 }
-
 
 export interface IKeyValueMap<V> {
-	[key: string]: V;
+    [key: string]: V
 }
 
-export type IMapEntry<V> = [string, V];
-export type IMapEntries<V> = IMapEntry<V>[];
+export type IMapEntry<V> = [string, V]
+export type IMapEntries<V> = IMapEntry<V>[]
 
 // In 3.0, change to IObjectMapChange
-export type IMapChange<T> = IMapChangeUpdate<T> | IMapChangeAdd<T> | IMapChangeDelete<T>;
+export type IMapChange<T> = IMapChangeUpdate<T> | IMapChangeAdd<T> | IMapChangeDelete<T>
 
 export interface IMapChangeBase<T> {
-	object: ObservableMap<T>;
-	name: string;
+    object: ObservableMap<T>
+    name: string
 }
 
 export interface IMapChangeUpdate<T> extends IMapChangeBase<T> {
-	type: "update";
-	newValue: T;
-	oldValue: T;
+    type: "update"
+    newValue: T
+    oldValue: T
 }
 
 export interface IMapChangeAdd<T> extends IMapChangeBase<T> {
-	type: "add";
-	newValue: T;
+    type: "add"
+    newValue: T
 }
 
-export interface IMapChangeDelete<T>  extends IMapChangeBase<T> {
-	type: "delete";
-	oldValue: T;
+export interface IMapChangeDelete<T> extends IMapChangeBase<T> {
+    type: "delete"
+    oldValue: T
 }
 
 export interface IMapWillChange<T> {
-	object: ObservableMap<T>;
-	type: "update" | "add" | "delete";
-	name: string;
-	newValue?: T;
+    object: ObservableMap<T>
+    type: "update" | "add" | "delete"
+    name: string
+    newValue?: T
 }
 
-const ObservableMapMarker = {};
+const ObservableMapMarker = {}
 
-export type IObservableMapInitialValues<V> = IMapEntries<V> | IKeyValueMap<V> | IMap<string, V>;
+export type IObservableMapInitialValues<V> = IMapEntries<V> | IKeyValueMap<V> | IMap<string, V>
 
-export class ObservableMap<V> implements IInterceptable<IMapWillChange<V>>, IListenable, IMap<string, V> {
-	$mobx = ObservableMapMarker;
-	private _data: { [key: string]: ObservableValue<V | undefined> } = Object.create(null);
-	private _hasMap: { [key: string]: ObservableValue<boolean> } = Object.create(null); // hasMap, not hashMap >-).
-	private _keys: IObservableArray<string> = <any> new ObservableArray(undefined, referenceEnhancer, `${this.name}.keys()`, true);
-	interceptors = null;
-	changeListeners = null;
-	dehancer: any = undefined;
+export class ObservableMap<V>
+    implements IInterceptable<IMapWillChange<V>>, IListenable, IMap<string, V> {
+    $mobx = ObservableMapMarker
+    private _data: { [key: string]: ObservableValue<V | undefined> } = Object.create(null)
+    private _hasMap: { [key: string]: ObservableValue<boolean> } = Object.create(null) // hasMap, not hashMap >-).
+    private _keys: IObservableArray<string> = <any>new ObservableArray(
+        undefined,
+        referenceEnhancer,
+        `${this.name}.keys()`,
+        true
+    )
+    interceptors = null
+    changeListeners = null
+    dehancer: any = undefined
 
-	constructor(initialData?: IObservableMapInitialValues<V>, public enhancer: IEnhancer<V> = deepEnhancer, public name = "ObservableMap@" + getNextId()) {
-		this.merge(initialData);
-	}
+    constructor(
+        initialData?: IObservableMapInitialValues<V>,
+        public enhancer: IEnhancer<V> = deepEnhancer,
+        public name = "ObservableMap@" + getNextId()
+    ) {
+        this.merge(initialData)
+    }
 
-	private _has(key: string): boolean {
-		return typeof this._data[key] !== "undefined";
-	}
+    private _has(key: string): boolean {
+        return typeof this._data[key] !== "undefined"
+    }
 
-	has(key: string): boolean {
-		if (!this.isValidKey(key))
-			return false;
-		key = "" + key;
-		if (this._hasMap[key])
-			return this._hasMap[key].get();
-		return this._updateHasMapEntry(key, false).get();
-	}
+    has(key: string): boolean {
+        if (!this.isValidKey(key)) return false
+        key = "" + key
+        if (this._hasMap[key]) return this._hasMap[key].get()
+        return this._updateHasMapEntry(key, false).get()
+    }
 
-	set(key: string, value?: V | undefined) {
-		this.assertValidKey(key);
-		key = "" + key;
-		const hasKey = this._has(key);
-		if (hasInterceptors(this)) {
-			const change = interceptChange<IMapWillChange<V>>(this, {
-				type: hasKey ? "update" : "add",
-				object: this,
-				newValue: value,
-				name: key
-			});
-			if (!change)
-				return this;
-			value = change.newValue;
-		}
-		if (hasKey) {
-			this._updateValue(key, value);
-		} else {
-			this._addValue(key, value);
-		}
-		return this;
-	}
+    set(key: string, value?: V | undefined) {
+        this.assertValidKey(key)
+        key = "" + key
+        const hasKey = this._has(key)
+        if (hasInterceptors(this)) {
+            const change = interceptChange<IMapWillChange<V>>(this, {
+                type: hasKey ? "update" : "add",
+                object: this,
+                newValue: value,
+                name: key
+            })
+            if (!change) return this
+            value = change.newValue
+        }
+        if (hasKey) {
+            this._updateValue(key, value)
+        } else {
+            this._addValue(key, value)
+        }
+        return this
+    }
 
-	delete(key: string): boolean {
-		this.assertValidKey(key);
-		key = "" + key;
-		if (hasInterceptors(this)) {
-			const change = interceptChange<IMapWillChange<V>>(this, {
-				type: "delete",
-				object: this,
-				name: key
-			});
-			if (!change)
-				return false;
-		}
+    delete(key: string): boolean {
+        this.assertValidKey(key)
+        key = "" + key
+        if (hasInterceptors(this)) {
+            const change = interceptChange<IMapWillChange<V>>(this, {
+                type: "delete",
+                object: this,
+                name: key
+            })
+            if (!change) return false
+        }
 
-		if (this._has(key)) {
-			const notifySpy = isSpyEnabled();
-			const notify = hasListeners(this);
-			const change = notify || notifySpy ? <IMapChange<V>>{
-					type: "delete",
-					object: this,
-					oldValue: (<any>this._data[key]).value,
-					name: key
-				} : null;
+        if (this._has(key)) {
+            const notifySpy = isSpyEnabled()
+            const notify = hasListeners(this)
+            const change =
+                notify || notifySpy
+                    ? <IMapChange<V>>{
+                          type: "delete",
+                          object: this,
+                          oldValue: (<any>this._data[key]).value,
+                          name: key
+                      }
+                    : null
 
-			if (notifySpy)
-				spyReportStart(change);
-			runInTransaction(() => {
-				this._keys.remove(key);
-				this._updateHasMapEntry(key, false);
-				const observable = this._data[key]!;
-				observable.setNewValue(undefined as any);
-				this._data[key] = undefined as any;
-			});
-			if (notify)
-				notifyListeners(this, change);
-			if (notifySpy)
-				spyReportEnd();
-			return true;
-		}
-		return false;
-	}
+            if (notifySpy) spyReportStart(change)
+            runInTransaction(() => {
+                this._keys.remove(key)
+                this._updateHasMapEntry(key, false)
+                const observable = this._data[key]!
+                observable.setNewValue(undefined as any)
+                this._data[key] = undefined as any
+            })
+            if (notify) notifyListeners(this, change)
+            if (notifySpy) spyReportEnd()
+            return true
+        }
+        return false
+    }
 
-	private _updateHasMapEntry(key: string, value: boolean): ObservableValue<boolean> {
-		// optimization; don't fill the hasMap if we are not observing, or remove entry if there are no observers anymore
-		let entry = this._hasMap[key];
-		if (entry) {
-			entry.setNewValue(value);
-		} else {
-			entry = this._hasMap[key] = new ObservableValue(value, referenceEnhancer, `${this.name}.${key}?`, false);
-		}
-		return entry;
-	}
+    private _updateHasMapEntry(key: string, value: boolean): ObservableValue<boolean> {
+        // optimization; don't fill the hasMap if we are not observing, or remove entry if there are no observers anymore
+        let entry = this._hasMap[key]
+        if (entry) {
+            entry.setNewValue(value)
+        } else {
+            entry = this._hasMap[key] = new ObservableValue(
+                value,
+                referenceEnhancer,
+                `${this.name}.${key}?`,
+                false
+            )
+        }
+        return entry
+    }
 
-	private _updateValue(name: string, newValue: V | undefined) {
-		const observable = this._data[name]!;
-		newValue = (observable as any).prepareNewValue(newValue) as V;
-		if (newValue !== UNCHANGED) {
-			const notifySpy = isSpyEnabled();
-			const notify = hasListeners(this);
-			const change = notify || notifySpy ? <IMapChange<V>>{
-					type: "update",
-					object: this,
-					oldValue: (observable as any).value,
-					name, newValue
-				} : null;
+    private _updateValue(name: string, newValue: V | undefined) {
+        const observable = this._data[name]!
+        newValue = (observable as any).prepareNewValue(newValue) as V
+        if (newValue !== UNCHANGED) {
+            const notifySpy = isSpyEnabled()
+            const notify = hasListeners(this)
+            const change =
+                notify || notifySpy
+                    ? <IMapChange<V>>{
+                          type: "update",
+                          object: this,
+                          oldValue: (observable as any).value,
+                          name,
+                          newValue
+                      }
+                    : null
 
-			if (notifySpy)
-				spyReportStart(change);
-			observable.setNewValue(newValue as V);
-			if (notify)
-				notifyListeners(this, change);
-			if (notifySpy)
-				spyReportEnd();
-		}
-	}
+            if (notifySpy) spyReportStart(change)
+            observable.setNewValue(newValue as V)
+            if (notify) notifyListeners(this, change)
+            if (notifySpy) spyReportEnd()
+        }
+    }
 
-	private _addValue(name: string, newValue: V | undefined) {
-		runInTransaction(() => {
-			const observable = this._data[name] = new ObservableValue(newValue, this.enhancer, `${this.name}.${name}`, false);
-			newValue = (observable as any).value; // value might have been changed
-			this._updateHasMapEntry(name, true);
-			this._keys.push(name);
-		});
+    private _addValue(name: string, newValue: V | undefined) {
+        runInTransaction(() => {
+            const observable = (this._data[name] = new ObservableValue(
+                newValue,
+                this.enhancer,
+                `${this.name}.${name}`,
+                false
+            ))
+            newValue = (observable as any).value // value might have been changed
+            this._updateHasMapEntry(name, true)
+            this._keys.push(name)
+        })
 
-		const notifySpy = isSpyEnabled();
-		const notify = hasListeners(this);
-		const change = notify || notifySpy ? <IMapChange<V>>{
-				type: "add",
-				object: this,
-				name,
-				newValue
-			} : null;
+        const notifySpy = isSpyEnabled()
+        const notify = hasListeners(this)
+        const change =
+            notify || notifySpy
+                ? <IMapChange<V>>{
+                      type: "add",
+                      object: this,
+                      name,
+                      newValue
+                  }
+                : null
 
-		if (notifySpy)
-			spyReportStart(change);
-		if (notify)
-			notifyListeners(this, change);
-		if (notifySpy)
-			spyReportEnd();
-	}
+        if (notifySpy) spyReportStart(change)
+        if (notify) notifyListeners(this, change)
+        if (notifySpy) spyReportEnd()
+    }
 
-	get(key: string): V | undefined {
-		key = "" + key;
-		if (this.has(key))
-			return this.dehanceValue(this._data[key]!.get());
-		return this.dehanceValue(undefined);
-	}
+    get(key: string): V | undefined {
+        key = "" + key
+        if (this.has(key)) return this.dehanceValue(this._data[key]!.get())
+        return this.dehanceValue(undefined)
+    }
 
-	private dehanceValue<X extends V | undefined>(value: X): X {
-		if (this.dehancer !== undefined) {
-			return this.dehancer(value);
-		}
-		return value;
-	}
+    private dehanceValue<X extends V | undefined>(value: X): X {
+        if (this.dehancer !== undefined) {
+            return this.dehancer(value)
+        }
+        return value
+    }
 
-	keys(): string[] & Iterator<string> {
-		return arrayAsIterator(this._keys.slice());
-	}
+    keys(): string[] & Iterator<string> {
+        return arrayAsIterator(this._keys.slice())
+    }
 
-	values(): V[] & Iterator<V> {
-		return (arrayAsIterator as any)(this._keys.map(this.get, this));
-	}
+    values(): V[] & Iterator<V> {
+        return (arrayAsIterator as any)(this._keys.map(this.get, this))
+    }
 
-	entries(): IMapEntries<V> & Iterator<IMapEntry<V>> {
-		return arrayAsIterator(this._keys.map(key => <[string, V]>[key, this.get(key)]));
-	}
+    entries(): IMapEntries<V> & Iterator<IMapEntry<V>> {
+        return arrayAsIterator(this._keys.map(key => <[string, V]>[key, this.get(key)]))
+    }
 
-	forEach(callback: (value: V, key: string, object: IMap<string, V>) => void, thisArg?) {
-		this.keys().forEach(key => callback.call(thisArg, this.get(key), key, this));
-	}
+    forEach(callback: (value: V, key: string, object: IMap<string, V>) => void, thisArg?) {
+        this.keys().forEach(key => callback.call(thisArg, this.get(key), key, this))
+    }
 
-	/** Merge another object into this object, returns this. */
-	merge(other: ObservableMap<V> | IKeyValueMap<V> | any): ObservableMap<V> {
-		if (isObservableMap(other)) {
-			other = other.toJS();
-		}
-		runInTransaction(() => {
-			if (isPlainObject(other))
-				Object.keys(other).forEach(key => this.set(key, other[key]));
-			else if (Array.isArray(other))
-				other.forEach(([key, value]) => this.set(key, value));
-			else if (isES6Map(other))
-				other.forEach((value, key) => this.set(key, value));
-			else if (other !== null && other !== undefined)
-				fail("Cannot initialize map from " + other);
-		});
-		return this;
-	}
+    /** Merge another object into this object, returns this. */
+    merge(other: ObservableMap<V> | IKeyValueMap<V> | any): ObservableMap<V> {
+        if (isObservableMap(other)) {
+            other = other.toJS()
+        }
+        runInTransaction(() => {
+            if (isPlainObject(other)) Object.keys(other).forEach(key => this.set(key, other[key]))
+            else if (Array.isArray(other)) other.forEach(([key, value]) => this.set(key, value))
+            else if (isES6Map(other)) other.forEach((value, key) => this.set(key, value))
+            else if (other !== null && other !== undefined)
+                fail("Cannot initialize map from " + other)
+        })
+        return this
+    }
 
-	clear() {
-		runInTransaction(() => {
-			untracked(() => {
-				this.keys().forEach(this.delete, this);
-			});
-		});
-	}
+    clear() {
+        runInTransaction(() => {
+            untracked(() => {
+                this.keys().forEach(this.delete, this)
+            })
+        })
+    }
 
-	replace(values: ObservableMap<V> | IKeyValueMap<V> | any): ObservableMap<V> {
-		runInTransaction(() => {
-			this.clear();
-			this.merge(values);
-		});
-		return this;
-	}
+    replace(values: ObservableMap<V> | IKeyValueMap<V> | any): ObservableMap<V> {
+        runInTransaction(() => {
+            this.clear()
+            this.merge(values)
+        })
+        return this
+    }
 
-	get size(): number {
-		return this._keys.length;
-	}
+    get size(): number {
+        return this._keys.length
+    }
 
-	/**
+    /**
 	 * Returns a shallow non observable object clone of this map.
 	 * Note that the values might still be observable. For a deep clone use mobx.toJS.
 	 */
-	toJS(): IKeyValueMap<V> {
-		const res: IKeyValueMap<V> = {};
-		this.keys().forEach(key => res[key] = this.get(key)!);
-		return res;
-	}
+    toJS(): IKeyValueMap<V> {
+        const res: IKeyValueMap<V> = {}
+        this.keys().forEach(key => (res[key] = this.get(key)!))
+        return res
+    }
 
-	toJSON(): IKeyValueMap<V> {
-		// Used by JSON.stringify
-		return this.toJS();
-	}
+    toJSON(): IKeyValueMap<V> {
+        // Used by JSON.stringify
+        return this.toJS()
+    }
 
-	private isValidKey(key: string) {
-		if (key === null || key === undefined)
-			return false;
-		if (typeof key === "string" || typeof key === "number" || typeof key === "boolean")
-			return true;
-		return false;
-	}
+    private isValidKey(key: string) {
+        if (key === null || key === undefined) return false
+        if (typeof key === "string" || typeof key === "number" || typeof key === "boolean")
+            return true
+        return false
+    }
 
-	private assertValidKey(key: string) {
-		if (!this.isValidKey(key))
-			throw new Error(`[mobx.map] Invalid key: '${key}', only strings, numbers and booleans are accepted as key in observable maps.`);
-	}
+    private assertValidKey(key: string) {
+        if (!this.isValidKey(key))
+            throw new Error(
+                `[mobx.map] Invalid key: '${key}', only strings, numbers and booleans are accepted as key in observable maps.`
+            )
+    }
 
-	toString(): string {
-		return this.name + "[{ " + this.keys().map(key => `${key}: ${"" + this.get(key)}`).join(", ") + " }]";
-	}
+    toString(): string {
+        return (
+            this.name +
+            "[{ " +
+            this.keys().map(key => `${key}: ${"" + this.get(key)}`).join(", ") +
+            " }]"
+        )
+    }
 
-	/**
+    /**
 	 * Observes this object. Triggers for the events 'add', 'update' and 'delete'.
 	 * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/observe
 	 * for callback details
 	 */
-	observe(listener: (changes: IMapChange<V>) => void, fireImmediately?: boolean): Lambda {
-		invariant(fireImmediately !== true, getMessage("m033"));
-		return registerListener(this, listener);
-	}
+    observe(listener: (changes: IMapChange<V>) => void, fireImmediately?: boolean): Lambda {
+        invariant(fireImmediately !== true, getMessage("m033"))
+        return registerListener(this, listener)
+    }
 
-	intercept(handler: IInterceptor<IMapWillChange<V>>): Lambda {
-		return registerInterceptor(this, handler);
-	}
+    intercept(handler: IInterceptor<IMapWillChange<V>>): Lambda {
+        return registerInterceptor(this, handler)
+    }
 }
 
 declareIterator(ObservableMap.prototype, function() {
-	return this.entries();
-});
+    return this.entries()
+})
 
 export function map<V>(initialValues?: IObservableMapInitialValues<V>): ObservableMap<V> {
-	deprecated("`mobx.map` is deprecated, use `new ObservableMap` or `mobx.observable.map` instead");
-	return observable.map<V>(initialValues);
+    deprecated("`mobx.map` is deprecated, use `new ObservableMap` or `mobx.observable.map` instead")
+    return observable.map<V>(initialValues)
 }
 
 /* 'var' fixes small-build issue */
-export var isObservableMap = createInstanceofPredicate("ObservableMap", ObservableMap) as (thing: any) => thing is ObservableMap<any>;
+export var isObservableMap = createInstanceofPredicate("ObservableMap", ObservableMap) as (
+    thing: any
+) => thing is ObservableMap<any>

--- a/src/types/observableobject.ts
+++ b/src/types/observableobject.ts
@@ -1,256 +1,310 @@
-import {ObservableValue, UNCHANGED} from "./observablevalue";
-import {isComputedValue, ComputedValue} from "../core/computedvalue";
-import {createInstanceofPredicate, isObject, Lambda, getNextId, invariant, assertPropertyConfigurable, isPlainObject, addHiddenFinalProp} from "../utils/utils";
-import {runLazyInitializers} from "../utils/decorators";
-import {hasInterceptors, IInterceptable, registerInterceptor, interceptChange} from "./intercept-utils";
-import {IListenable, registerListener, hasListeners, notifyListeners} from "./listen-utils";
-import {isSpyEnabled, spyReportStart, spyReportEnd} from "../core/spy";
-import {IEqualsComparer, comparer} from "./comparer";
-import {IEnhancer, isModifierDescriptor, IModifierDescriptor} from "./modifiers";
-import {isAction, defineBoundAction} from "../api/action";
-import {getMessage} from "../utils/messages";
-
+import { ObservableValue, UNCHANGED } from "./observablevalue"
+import { isComputedValue, ComputedValue } from "../core/computedvalue"
+import {
+    createInstanceofPredicate,
+    isObject,
+    Lambda,
+    getNextId,
+    invariant,
+    assertPropertyConfigurable,
+    isPlainObject,
+    addHiddenFinalProp
+} from "../utils/utils"
+import { runLazyInitializers } from "../utils/decorators"
+import {
+    hasInterceptors,
+    IInterceptable,
+    registerInterceptor,
+    interceptChange
+} from "./intercept-utils"
+import { IListenable, registerListener, hasListeners, notifyListeners } from "./listen-utils"
+import { isSpyEnabled, spyReportStart, spyReportEnd } from "../core/spy"
+import { IEqualsComparer, comparer } from "./comparer"
+import { IEnhancer, isModifierDescriptor, IModifierDescriptor } from "./modifiers"
+import { isAction, defineBoundAction } from "../api/action"
+import { getMessage } from "../utils/messages"
 
 export interface IObservableObject {
-	"observable-object": IObservableObject;
+    "observable-object": IObservableObject
 }
 
 // In 3.0, change to IObjectDidChange
 export interface IObjectChange {
-	name: string;
-	object: any;
-	type: "update" | "add";
-	oldValue?: any;
-	newValue: any;
+    name: string
+    object: any
+    type: "update" | "add"
+    oldValue?: any
+    newValue: any
 }
 
 export interface IObjectWillChange {
-	object: any;
-	type: "update" | "add";
-	name: string;
-	newValue: any;
+    object: any
+    type: "update" | "add"
+    name: string
+    newValue: any
 }
 
-export class ObservableObjectAdministration implements IInterceptable<IObjectWillChange>, IListenable {
-	values: {[key: string]: ObservableValue<any>|ComputedValue<any>} = {};
-	changeListeners = null;
-	interceptors = null;
+export class ObservableObjectAdministration
+    implements IInterceptable<IObjectWillChange>, IListenable {
+    values: { [key: string]: ObservableValue<any> | ComputedValue<any> } = {}
+    changeListeners = null
+    interceptors = null
 
-	constructor(public target: any, public name: string) { }
+    constructor(public target: any, public name: string) {}
 
-	/**
+    /**
 		* Observes this object. Triggers for the events 'add', 'update' and 'delete'.
 		* See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/observe
 		* for callback details
 		*/
-	observe(callback: (changes: IObjectChange) => void, fireImmediately?: boolean): Lambda {
-		invariant(fireImmediately !== true, "`observe` doesn't support the fire immediately property for observable objects.");
-		return registerListener(this, callback);
-	}
+    observe(callback: (changes: IObjectChange) => void, fireImmediately?: boolean): Lambda {
+        invariant(
+            fireImmediately !== true,
+            "`observe` doesn't support the fire immediately property for observable objects."
+        )
+        return registerListener(this, callback)
+    }
 
-	intercept(handler): Lambda {
-		return registerInterceptor(this, handler);
-	}
+    intercept(handler): Lambda {
+        return registerInterceptor(this, handler)
+    }
 }
 
 export interface IIsObservableObject {
-	$mobx: ObservableObjectAdministration;
+    $mobx: ObservableObjectAdministration
 }
 
 export function asObservableObject(target, name?: string): ObservableObjectAdministration {
-	if (isObservableObject(target) && target.hasOwnProperty('$mobx'))
-		return (target as any).$mobx;
+    if (isObservableObject(target) && target.hasOwnProperty("$mobx")) return (target as any).$mobx
 
-	invariant(Object.isExtensible(target), getMessage("m035"));
-	if (!isPlainObject(target))
-		name = (target.constructor.name || "ObservableObject") + "@" + getNextId();
-	if (!name)
-		name = "ObservableObject@" + getNextId();
+    invariant(Object.isExtensible(target), getMessage("m035"))
+    if (!isPlainObject(target))
+        name = (target.constructor.name || "ObservableObject") + "@" + getNextId()
+    if (!name) name = "ObservableObject@" + getNextId()
 
-	const adm = new ObservableObjectAdministration(target, name);
-	addHiddenFinalProp(target, "$mobx", adm);
-	return adm;
+    const adm = new ObservableObjectAdministration(target, name)
+    addHiddenFinalProp(target, "$mobx", adm)
+    return adm
 }
 
-export function defineObservablePropertyFromDescriptor(adm: ObservableObjectAdministration, propName: string, descriptor: PropertyDescriptor, defaultEnhancer: IEnhancer<any>) {
-	if (adm.values[propName]) {
-		// already observable property
-		invariant("value" in descriptor, `The property ${propName} in ${adm.name} is already observable, cannot redefine it as computed property`);
-		adm.target[propName] = descriptor.value; // the property setter will make 'value' reactive if needed.
-		return;
-	}
+export function defineObservablePropertyFromDescriptor(
+    adm: ObservableObjectAdministration,
+    propName: string,
+    descriptor: PropertyDescriptor,
+    defaultEnhancer: IEnhancer<any>
+) {
+    if (adm.values[propName]) {
+        // already observable property
+        invariant(
+            "value" in descriptor,
+            `The property ${propName} in ${adm.name} is already observable, cannot redefine it as computed property`
+        )
+        adm.target[propName] = descriptor.value // the property setter will make 'value' reactive if needed.
+        return
+    }
 
-	// not yet observable property
+    // not yet observable property
 
-	if ("value" in descriptor) {
-		// not a computed value
-		if (isModifierDescriptor(descriptor.value)) {
-			// x : ref(someValue)
-			const modifierDescriptor = descriptor.value as IModifierDescriptor<any>;
-			defineObservableProperty(adm, propName, modifierDescriptor.initialValue, modifierDescriptor.enhancer);
-		}
-		else if (isAction(descriptor.value) && descriptor.value.autoBind === true) {
-			defineBoundAction(adm.target, propName, descriptor.value.originalFn);
-		} else if (isComputedValue(descriptor.value)) {
-			// x: computed(someExpr)
-			defineComputedPropertyFromComputedValue(adm, propName, descriptor.value);
-		} else {
-			// x: someValue
-			defineObservableProperty(adm, propName, descriptor.value, defaultEnhancer);
-		}
-	} else {
-		// get x() { return 3 } set x(v) { }
-		defineComputedProperty(adm, propName, descriptor.get, descriptor.set, comparer.default, true);
-	}
+    if ("value" in descriptor) {
+        // not a computed value
+        if (isModifierDescriptor(descriptor.value)) {
+            // x : ref(someValue)
+            const modifierDescriptor = descriptor.value as IModifierDescriptor<any>
+            defineObservableProperty(
+                adm,
+                propName,
+                modifierDescriptor.initialValue,
+                modifierDescriptor.enhancer
+            )
+        } else if (isAction(descriptor.value) && descriptor.value.autoBind === true) {
+            defineBoundAction(adm.target, propName, descriptor.value.originalFn)
+        } else if (isComputedValue(descriptor.value)) {
+            // x: computed(someExpr)
+            defineComputedPropertyFromComputedValue(adm, propName, descriptor.value)
+        } else {
+            // x: someValue
+            defineObservableProperty(adm, propName, descriptor.value, defaultEnhancer)
+        }
+    } else {
+        // get x() { return 3 } set x(v) { }
+        defineComputedProperty(
+            adm,
+            propName,
+            descriptor.get,
+            descriptor.set,
+            comparer.default,
+            true
+        )
+    }
 }
 
 export function defineObservableProperty(
-	adm: ObservableObjectAdministration,
-	propName: string,
-	newValue,
-	enhancer: IEnhancer<any>
+    adm: ObservableObjectAdministration,
+    propName: string,
+    newValue,
+    enhancer: IEnhancer<any>
 ) {
-	assertPropertyConfigurable(adm.target, propName);
+    assertPropertyConfigurable(adm.target, propName)
 
-	if (hasInterceptors(adm)) {
-		const change = interceptChange<IObjectWillChange>(adm, {
-			object: adm.target,
-			name: propName,
-			type: "add",
-			newValue
-		});
-		if (!change)
-			return;
-		newValue = change.newValue;
-	}
-	const observable = adm.values[propName] = new ObservableValue(newValue, enhancer, `${adm.name}.${propName}`, false);
-	newValue = (observable as any).value; // observableValue might have changed it
+    if (hasInterceptors(adm)) {
+        const change = interceptChange<IObjectWillChange>(adm, {
+            object: adm.target,
+            name: propName,
+            type: "add",
+            newValue
+        })
+        if (!change) return
+        newValue = change.newValue
+    }
+    const observable = (adm.values[propName] = new ObservableValue(
+        newValue,
+        enhancer,
+        `${adm.name}.${propName}`,
+        false
+    ))
+    newValue = (observable as any).value // observableValue might have changed it
 
-	Object.defineProperty(adm.target, propName, generateObservablePropConfig(propName));
-	notifyPropertyAddition(adm, adm.target, propName, newValue);
+    Object.defineProperty(adm.target, propName, generateObservablePropConfig(propName))
+    notifyPropertyAddition(adm, adm.target, propName, newValue)
 }
 
 export function defineComputedProperty(
-	adm: ObservableObjectAdministration,
-	propName: string,
-	getter,
-	setter,
-	equals: IEqualsComparer<any>,
-	asInstanceProperty: boolean
+    adm: ObservableObjectAdministration,
+    propName: string,
+    getter,
+    setter,
+    equals: IEqualsComparer<any>,
+    asInstanceProperty: boolean
 ) {
-	if (asInstanceProperty)
-		assertPropertyConfigurable(adm.target, propName);
+    if (asInstanceProperty) assertPropertyConfigurable(adm.target, propName)
 
-	adm.values[propName] = new ComputedValue(getter, adm.target, equals, `${adm.name}.${propName}`, setter);
-	if (asInstanceProperty) {
-		Object.defineProperty(adm.target, propName, generateComputedPropConfig(propName));
-	}
+    adm.values[propName] = new ComputedValue(
+        getter,
+        adm.target,
+        equals,
+        `${adm.name}.${propName}`,
+        setter
+    )
+    if (asInstanceProperty) {
+        Object.defineProperty(adm.target, propName, generateComputedPropConfig(propName))
+    }
 }
 
-export function defineComputedPropertyFromComputedValue(adm: ObservableObjectAdministration, propName: string, computedValue: ComputedValue<any>) {
-	let name = `${adm.name}.${propName}`;
-	computedValue.name = name;
-	if (!computedValue.scope)
-		computedValue.scope = adm.target;
+export function defineComputedPropertyFromComputedValue(
+    adm: ObservableObjectAdministration,
+    propName: string,
+    computedValue: ComputedValue<any>
+) {
+    let name = `${adm.name}.${propName}`
+    computedValue.name = name
+    if (!computedValue.scope) computedValue.scope = adm.target
 
-	adm.values[propName] = computedValue;
-	Object.defineProperty(adm.target, propName, generateComputedPropConfig(propName));
+    adm.values[propName] = computedValue
+    Object.defineProperty(adm.target, propName, generateComputedPropConfig(propName))
 }
 
-const observablePropertyConfigs = {};
-const computedPropertyConfigs = {};
+const observablePropertyConfigs = {}
+const computedPropertyConfigs = {}
 
 export function generateObservablePropConfig(propName) {
-	return observablePropertyConfigs[propName] || (
-		observablePropertyConfigs[propName] = {
-			configurable: true,
-			enumerable: true,
-			get: function() {
-				return this.$mobx.values[propName].get();
-			},
-			set: function(v) {
-				setPropertyValue(this, propName, v);
-			}
-		}
-	);
+    return (
+        observablePropertyConfigs[propName] ||
+        (observablePropertyConfigs[propName] = {
+            configurable: true,
+            enumerable: true,
+            get: function() {
+                return this.$mobx.values[propName].get()
+            },
+            set: function(v) {
+                setPropertyValue(this, propName, v)
+            }
+        })
+    )
 }
 
 export function generateComputedPropConfig(propName) {
-	return computedPropertyConfigs[propName] || (
-		computedPropertyConfigs[propName] = {
-			configurable: true,
-			enumerable: false,
-			get: function() {
-				return this.$mobx.values[propName].get();
-			},
-			set: function(v) {
-				return this.$mobx.values[propName].set(v);
-			}
-		}
-	);
+    return (
+        computedPropertyConfigs[propName] ||
+        (computedPropertyConfigs[propName] = {
+            configurable: true,
+            enumerable: false,
+            get: function() {
+                return this.$mobx.values[propName].get()
+            },
+            set: function(v) {
+                return this.$mobx.values[propName].set(v)
+            }
+        })
+    )
 }
 
 export function setPropertyValue(instance, name: string, newValue) {
-	const adm = instance.$mobx;
-	const observable = adm.values[name];
+    const adm = instance.$mobx
+    const observable = adm.values[name]
 
-	// intercept
-	if (hasInterceptors(adm)) {
-		const change = interceptChange<IObjectWillChange>(adm, {
-			type: "update",
-			object: instance,
-			name, newValue
-		});
-		if (!change)
-			return;
-		newValue = change.newValue;
-	}
-	newValue = observable.prepareNewValue(newValue);
+    // intercept
+    if (hasInterceptors(adm)) {
+        const change = interceptChange<IObjectWillChange>(adm, {
+            type: "update",
+            object: instance,
+            name,
+            newValue
+        })
+        if (!change) return
+        newValue = change.newValue
+    }
+    newValue = observable.prepareNewValue(newValue)
 
-	// notify spy & observers
-	if (newValue !== UNCHANGED) {
-		const notify = hasListeners(adm);
-		const notifySpy = isSpyEnabled();
-		const change = notify || notifySpy ? {
-				type: "update",
-				object: instance,
-				oldValue: (observable as any).value,
-				name, newValue
-			} : null;
+    // notify spy & observers
+    if (newValue !== UNCHANGED) {
+        const notify = hasListeners(adm)
+        const notifySpy = isSpyEnabled()
+        const change =
+            notify || notifySpy
+                ? {
+                      type: "update",
+                      object: instance,
+                      oldValue: (observable as any).value,
+                      name,
+                      newValue
+                  }
+                : null
 
-		if (notifySpy)
-			spyReportStart(change);
-		observable.setNewValue(newValue);
-		if (notify)
-			notifyListeners(adm, change);
-		if (notifySpy)
-			spyReportEnd();
-	}
+        if (notifySpy) spyReportStart(change)
+        observable.setNewValue(newValue)
+        if (notify) notifyListeners(adm, change)
+        if (notifySpy) spyReportEnd()
+    }
 }
 
 function notifyPropertyAddition(adm, object, name: string, newValue) {
-	const notify = hasListeners(adm);
-	const notifySpy = isSpyEnabled();
-	const change = notify || notifySpy ? {
-			type: "add",
-			object, name, newValue
-		} : null;
+    const notify = hasListeners(adm)
+    const notifySpy = isSpyEnabled()
+    const change =
+        notify || notifySpy
+            ? {
+                  type: "add",
+                  object,
+                  name,
+                  newValue
+              }
+            : null
 
-	if (notifySpy)
-		spyReportStart(change);
-	if (notify)
-		notifyListeners(adm, change);
-	if (notifySpy)
-		spyReportEnd();
+    if (notifySpy) spyReportStart(change)
+    if (notify) notifyListeners(adm, change)
+    if (notifySpy) spyReportEnd()
 }
 
-const isObservableObjectAdministration = createInstanceofPredicate("ObservableObjectAdministration", ObservableObjectAdministration);
+const isObservableObjectAdministration = createInstanceofPredicate(
+    "ObservableObjectAdministration",
+    ObservableObjectAdministration
+)
 
 export function isObservableObject(thing: any): thing is IObservableObject {
-	if (isObject(thing)) {
-		// Initializers run lazily when transpiling to babel, so make sure they are run...
-		runLazyInitializers(thing);
-		return isObservableObjectAdministration((thing as any).$mobx);
-	}
-	return false;
+    if (isObject(thing)) {
+        // Initializers run lazily when transpiling to babel, so make sure they are run...
+        runLazyInitializers(thing)
+        return isObservableObjectAdministration((thing as any).$mobx)
+    }
+    return false
 }

--- a/src/types/observablevalue.ts
+++ b/src/types/observablevalue.ts
@@ -1,136 +1,159 @@
-import {BaseAtom} from "../core/atom";
-import {checkIfStateModificationsAreAllowed} from "../core/derivation";
-import {Lambda, getNextId, createInstanceofPredicate, primitiveSymbol, toPrimitive} from "../utils/utils";
-import {hasInterceptors, IInterceptable, IInterceptor, registerInterceptor, interceptChange} from "./intercept-utils";
-import {IListenable, registerListener, hasListeners, notifyListeners} from "./listen-utils";
-import {isSpyEnabled, spyReportStart, spyReportEnd, spyReport} from "../core/spy";
-import {IEnhancer} from "./modifiers";
+import { BaseAtom } from "../core/atom"
+import { checkIfStateModificationsAreAllowed } from "../core/derivation"
+import {
+    Lambda,
+    getNextId,
+    createInstanceofPredicate,
+    primitiveSymbol,
+    toPrimitive
+} from "../utils/utils"
+import {
+    hasInterceptors,
+    IInterceptable,
+    IInterceptor,
+    registerInterceptor,
+    interceptChange
+} from "./intercept-utils"
+import { IListenable, registerListener, hasListeners, notifyListeners } from "./listen-utils"
+import { isSpyEnabled, spyReportStart, spyReportEnd, spyReport } from "../core/spy"
+import { IEnhancer } from "./modifiers"
 
 export interface IValueWillChange<T> {
-	object: any;
-	type: "update";
-	newValue: T;
+    object: any
+    type: "update"
+    newValue: T
 }
 
 export interface IValueDidChange<T> extends IValueWillChange<T> {
-	oldValue: T | undefined;
+    oldValue: T | undefined
 }
 
-export type IUNCHANGED = {};
+export type IUNCHANGED = {}
 
-export const UNCHANGED: IUNCHANGED = {};
+export const UNCHANGED: IUNCHANGED = {}
 
 export interface IObservableValue<T> {
-	get(): T;
-	set(value: T): void;
-	intercept(handler: IInterceptor<IValueWillChange<T>>): Lambda;
-	observe(listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda;
+    get(): T
+    set(value: T): void
+    intercept(handler: IInterceptor<IValueWillChange<T>>): Lambda
+    observe(listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda
 }
 
-declare var Symbol;
+declare var Symbol
 
-export class ObservableValue<T> extends BaseAtom implements IObservableValue<T>, IInterceptable<IValueWillChange<T>>, IListenable {
-	hasUnreportedChange = false;
-	interceptors;
-	changeListeners;
-	protected value;
-	dehancer: any = undefined;
+export class ObservableValue<T> extends BaseAtom
+    implements IObservableValue<T>, IInterceptable<IValueWillChange<T>>, IListenable {
+    hasUnreportedChange = false
+    interceptors
+    changeListeners
+    protected value
+    dehancer: any = undefined
 
-	constructor(value: T, protected enhancer: IEnhancer<T>, name = "ObservableValue@" + getNextId(), notifySpy = true) {
-		super(name);
-		this.value = enhancer(value, undefined, name);
-		if (notifySpy && isSpyEnabled()) {
-			// only notify spy if this is a stand-alone observable
-			spyReport({ type: "create", object: this, newValue: this.value });
-		}
-	}
+    constructor(
+        value: T,
+        protected enhancer: IEnhancer<T>,
+        name = "ObservableValue@" + getNextId(),
+        notifySpy = true
+    ) {
+        super(name)
+        this.value = enhancer(value, undefined, name)
+        if (notifySpy && isSpyEnabled()) {
+            // only notify spy if this is a stand-alone observable
+            spyReport({ type: "create", object: this, newValue: this.value })
+        }
+    }
 
-	private dehanceValue(value: T): T {
-		if (this.dehancer !== undefined)
-			return this.dehancer(value);
-		return value;
-	}
+    private dehanceValue(value: T): T {
+        if (this.dehancer !== undefined) return this.dehancer(value)
+        return value
+    }
 
-	public set(newValue: T) {
-		const oldValue = this.value;
-		newValue = this.prepareNewValue(newValue) as any;
-		if (newValue !== UNCHANGED) {
-			const notifySpy = isSpyEnabled();
-			if (notifySpy) {
-				spyReportStart({
-					type: "update",
-					object: this,
-					newValue, oldValue
-				});
-			}
-			this.setNewValue(newValue);
-			if (notifySpy)
-				spyReportEnd();
-		}
-	}
+    public set(newValue: T) {
+        const oldValue = this.value
+        newValue = this.prepareNewValue(newValue) as any
+        if (newValue !== UNCHANGED) {
+            const notifySpy = isSpyEnabled()
+            if (notifySpy) {
+                spyReportStart({
+                    type: "update",
+                    object: this,
+                    newValue,
+                    oldValue
+                })
+            }
+            this.setNewValue(newValue)
+            if (notifySpy) spyReportEnd()
+        }
+    }
 
-	private prepareNewValue(newValue): T | IUNCHANGED {
-		checkIfStateModificationsAreAllowed(this);
-		if (hasInterceptors(this)) {
-			const change = interceptChange<IValueWillChange<T>>(this, { object: this, type: "update", newValue });
-			if (!change)
-				return UNCHANGED;
-			newValue = change.newValue;
-		}
-		// apply modifier
-		newValue = this.enhancer(newValue, this.value, this.name);
-		return this.value !== newValue
-			? newValue
-			: UNCHANGED
-		;
-	}
+    private prepareNewValue(newValue): T | IUNCHANGED {
+        checkIfStateModificationsAreAllowed(this)
+        if (hasInterceptors(this)) {
+            const change = interceptChange<IValueWillChange<T>>(this, {
+                object: this,
+                type: "update",
+                newValue
+            })
+            if (!change) return UNCHANGED
+            newValue = change.newValue
+        }
+        // apply modifier
+        newValue = this.enhancer(newValue, this.value, this.name)
+        return this.value !== newValue ? newValue : UNCHANGED
+    }
 
-	setNewValue(newValue: T) {
-		const oldValue = this.value;
-		this.value = newValue;
-		this.reportChanged();
-		if (hasListeners(this)) {
-			notifyListeners(this, {
-				type: "update",
-				object: this,
-				newValue, oldValue
-			});
-		}
-	}
+    setNewValue(newValue: T) {
+        const oldValue = this.value
+        this.value = newValue
+        this.reportChanged()
+        if (hasListeners(this)) {
+            notifyListeners(this, {
+                type: "update",
+                object: this,
+                newValue,
+                oldValue
+            })
+        }
+    }
 
-	public get(): T {
-		this.reportObserved();
-		return this.dehanceValue(this.value);
-	}
+    public get(): T {
+        this.reportObserved()
+        return this.dehanceValue(this.value)
+    }
 
-	public intercept(handler: IInterceptor<IValueWillChange<T>>): Lambda {
-		return registerInterceptor(this, handler);
-	}
+    public intercept(handler: IInterceptor<IValueWillChange<T>>): Lambda {
+        return registerInterceptor(this, handler)
+    }
 
-	public observe(listener: (change: IValueDidChange<T>) => void, fireImmediately?: boolean): Lambda {
-		if (fireImmediately)
-			listener({
-				object: this,
-				type: "update",
-				newValue: this.value,
-				oldValue: undefined
-			});
-		return registerListener(this, listener);
-	}
+    public observe(
+        listener: (change: IValueDidChange<T>) => void,
+        fireImmediately?: boolean
+    ): Lambda {
+        if (fireImmediately)
+            listener({
+                object: this,
+                type: "update",
+                newValue: this.value,
+                oldValue: undefined
+            })
+        return registerListener(this, listener)
+    }
 
-	toJSON() {
-		return this.get();
-	}
+    toJSON() {
+        return this.get()
+    }
 
-	toString() {
-		return `${this.name}[${this.value}]`;
-	}
+    toString() {
+        return `${this.name}[${this.value}]`
+    }
 
-	valueOf(): T {
-		return toPrimitive(this.get());
-	}
+    valueOf(): T {
+        return toPrimitive(this.get())
+    }
 }
 
-ObservableValue.prototype[primitiveSymbol()] = ObservableValue.prototype.valueOf;
+ObservableValue.prototype[primitiveSymbol()] = ObservableValue.prototype.valueOf
 
-export var isObservableValue = createInstanceofPredicate("ObservableValue", ObservableValue) as (x: any) => x is IObservableValue<any>;
+export var isObservableValue = createInstanceofPredicate("ObservableValue", ObservableValue) as (
+    x: any
+) => x is IObservableValue<any>

--- a/src/types/type-utils.ts
+++ b/src/types/type-utils.ts
@@ -1,74 +1,73 @@
-import {IDepTreeNode} from "../core/observable";
-import {invariant, fail} from "../utils/utils";
-import {runLazyInitializers} from "../utils/decorators";
-import {isAtom} from "../core/atom";
-import {isComputedValue} from "../core/computedvalue";
-import {isReaction} from "../core/reaction";
-import {isObservableArray} from "./observablearray";
-import {isObservableMap} from "./observablemap";
-import {isObservableObject} from "./observableobject";
-import {getMessage} from "../utils/messages";
-
+import { IDepTreeNode } from "../core/observable"
+import { invariant, fail } from "../utils/utils"
+import { runLazyInitializers } from "../utils/decorators"
+import { isAtom } from "../core/atom"
+import { isComputedValue } from "../core/computedvalue"
+import { isReaction } from "../core/reaction"
+import { isObservableArray } from "./observablearray"
+import { isObservableMap } from "./observablemap"
+import { isObservableObject } from "./observableobject"
+import { getMessage } from "../utils/messages"
 
 export function getAtom(thing: any, property?: string): IDepTreeNode {
-	if (typeof thing === "object" && thing !== null) {
-		if (isObservableArray(thing)) {
-			invariant(property === undefined, getMessage("m036"));
-			return (thing as any).$mobx.atom;
-		}
-		if (isObservableMap(thing)) {
-			const anyThing = thing as any;
-			if (property === undefined)
-				return getAtom(anyThing._keys);
-			const observable = anyThing._data[property] || anyThing._hasMap[property];
-			invariant(!!observable, `the entry '${property}' does not exist in the observable map '${getDebugName(thing)}'`);
-			return observable;
-		}
-		// Initializers run lazily when transpiling to babel, so make sure they are run...
-		runLazyInitializers(thing);
-		if (property && !thing.$mobx)
-			thing[property]; // See #1072 // TODO: remove in 4.0
-		if (isObservableObject(thing)) {
-			if (!property)
-				return fail(`please specify a property`);
-			const observable = (thing as any).$mobx.values[property];
-			invariant(!!observable, `no observable property '${property}' found on the observable object '${getDebugName(thing)}'`);
-			return observable;
-		}
-		if (isAtom(thing) || isComputedValue(thing) || isReaction(thing)) {
-			return thing;
-		}
-	} else if (typeof thing === "function") {
-		if (isReaction(thing.$mobx)) {
-			// disposer function
-			return thing.$mobx;
-		}
-	}
-	return fail("Cannot obtain atom from " + thing);
+    if (typeof thing === "object" && thing !== null) {
+        if (isObservableArray(thing)) {
+            invariant(property === undefined, getMessage("m036"))
+            return (thing as any).$mobx.atom
+        }
+        if (isObservableMap(thing)) {
+            const anyThing = thing as any
+            if (property === undefined) return getAtom(anyThing._keys)
+            const observable = anyThing._data[property] || anyThing._hasMap[property]
+            invariant(
+                !!observable,
+                `the entry '${property}' does not exist in the observable map '${getDebugName(
+                    thing
+                )}'`
+            )
+            return observable
+        }
+        // Initializers run lazily when transpiling to babel, so make sure they are run...
+        runLazyInitializers(thing)
+        if (property && !thing.$mobx) thing[property] // See #1072 // TODO: remove in 4.0
+        if (isObservableObject(thing)) {
+            if (!property) return fail(`please specify a property`)
+            const observable = (thing as any).$mobx.values[property]
+            invariant(
+                !!observable,
+                `no observable property '${property}' found on the observable object '${getDebugName(
+                    thing
+                )}'`
+            )
+            return observable
+        }
+        if (isAtom(thing) || isComputedValue(thing) || isReaction(thing)) {
+            return thing
+        }
+    } else if (typeof thing === "function") {
+        if (isReaction(thing.$mobx)) {
+            // disposer function
+            return thing.$mobx
+        }
+    }
+    return fail("Cannot obtain atom from " + thing)
 }
 
 export function getAdministration(thing: any, property?: string) {
-	invariant(thing, "Expecting some object");
-	if (property !== undefined)
-		return getAdministration(getAtom(thing, property));
-	if (isAtom(thing) || isComputedValue(thing) || isReaction(thing))
-		return thing;
-	if (isObservableMap(thing))
-		return thing;
-	// Initializers run lazily when transpiling to babel, so make sure they are run...
-	runLazyInitializers(thing);
-	if (thing.$mobx)
-		return thing.$mobx;
-	invariant(false, "Cannot obtain administration from " + thing);
+    invariant(thing, "Expecting some object")
+    if (property !== undefined) return getAdministration(getAtom(thing, property))
+    if (isAtom(thing) || isComputedValue(thing) || isReaction(thing)) return thing
+    if (isObservableMap(thing)) return thing
+    // Initializers run lazily when transpiling to babel, so make sure they are run...
+    runLazyInitializers(thing)
+    if (thing.$mobx) return thing.$mobx
+    invariant(false, "Cannot obtain administration from " + thing)
 }
 
 export function getDebugName(thing: any, property?: string): string {
-	let named;
-	if (property !== undefined)
-		named = getAtom(thing, property);
-	else if (isObservableObject(thing) || isObservableMap(thing))
-		named = getAdministration(thing);
-	else
-		named = getAtom(thing); // valid for arrays as well
-	return named.name;
+    let named
+    if (property !== undefined) named = getAtom(thing, property)
+    else if (isObservableObject(thing) || isObservableMap(thing)) named = getAdministration(thing)
+    else named = getAtom(thing) // valid for arrays as well
+    return named.name
 }

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -1,4 +1,4 @@
-import {invariant, addHiddenProp, hasOwnProperty} from "./utils";
+import { invariant, addHiddenProp, hasOwnProperty } from "./utils"
 
 /**
  * Constructs a decorator, that normalizes the differences between
@@ -12,115 +12,146 @@ import {invariant, addHiddenProp, hasOwnProperty} from "./utils";
  * This means that these properties despite being enumerable might not show up in Object.keys() (but they will show up in for...in loops).
  */
 export function createClassPropertyDecorator(
-	/**
+    /**
 	 * This function is invoked once, when the property is added to a new instance.
 	 * When this happens is not strictly determined due to differences in TS and Babel:
 	 * Typescript: Usually when constructing the new instance
 	 * Babel, sometimes Typescript: during the first get / set
 	 * Both: when calling `runLazyInitializers(instance)`
 	 */
-	onInitialize: (target, property, initialValue, customArgs?: IArguments, originalDescriptor?) => void,
-	get: (name) => any,
-	set: (name, newValue) => void,
-	enumerable: boolean,
-	/**
+    onInitialize: (
+        target,
+        property,
+        initialValue,
+        customArgs?: IArguments,
+        originalDescriptor?
+    ) => void,
+    get: (name) => any,
+    set: (name, newValue) => void,
+    enumerable: boolean,
+    /**
 	 * Can this decorator invoked with arguments? e.g. @decorator(args)
 	 */
-	allowCustomArguments: boolean
+    allowCustomArguments: boolean
 ): any {
-	function classPropertyDecorator(target: any, key: string, descriptor, customArgs?: IArguments, argLen: number = 0) {
-		invariant(allowCustomArguments || quacksLikeADecorator(arguments), "This function is a decorator, but it wasn't invoked like a decorator");
-		if (!descriptor) {
-			// typescript (except for getter / setters)
-			const newDescriptor = {
-				enumerable,
-				configurable: true,
-				get: function() {
-					if (!this.__mobxInitializedProps || this.__mobxInitializedProps[key] !== true)
-						typescriptInitializeProperty(this, key, undefined, onInitialize, customArgs, descriptor);
-					return get.call(this, key);
-				},
-				set: function(v) {
-					if (!this.__mobxInitializedProps || this.__mobxInitializedProps[key] !== true) {
-						typescriptInitializeProperty(this, key, v, onInitialize, customArgs, descriptor);
-					} else {
-						set.call(this, key, v);
-					}
-				}
-			};
-			if (arguments.length < 3 || arguments.length === 5 && argLen < 3) {
-				// Typescript target is ES3, so it won't define property for us
-				// or using Reflect.decorate polyfill, which will return no descriptor
-				// (see https://github.com/mobxjs/mobx/issues/333)
-				Object.defineProperty(target, key, newDescriptor);
-			}
-			return newDescriptor;
-		} else {
-			// babel and typescript getter / setter props
-			if (!hasOwnProperty(target, "__mobxLazyInitializers")) {
-				addHiddenProp(target, "__mobxLazyInitializers",
-					(target.__mobxLazyInitializers && target.__mobxLazyInitializers.slice()) || [] // support inheritance
-				);
-			}
+    function classPropertyDecorator(
+        target: any,
+        key: string,
+        descriptor,
+        customArgs?: IArguments,
+        argLen: number = 0
+    ) {
+        invariant(
+            allowCustomArguments || quacksLikeADecorator(arguments),
+            "This function is a decorator, but it wasn't invoked like a decorator"
+        )
+        if (!descriptor) {
+            // typescript (except for getter / setters)
+            const newDescriptor = {
+                enumerable,
+                configurable: true,
+                get: function() {
+                    if (!this.__mobxInitializedProps || this.__mobxInitializedProps[key] !== true)
+                        typescriptInitializeProperty(
+                            this,
+                            key,
+                            undefined,
+                            onInitialize,
+                            customArgs,
+                            descriptor
+                        )
+                    return get.call(this, key)
+                },
+                set: function(v) {
+                    if (!this.__mobxInitializedProps || this.__mobxInitializedProps[key] !== true) {
+                        typescriptInitializeProperty(
+                            this,
+                            key,
+                            v,
+                            onInitialize,
+                            customArgs,
+                            descriptor
+                        )
+                    } else {
+                        set.call(this, key, v)
+                    }
+                }
+            }
+            if (arguments.length < 3 || (arguments.length === 5 && argLen < 3)) {
+                // Typescript target is ES3, so it won't define property for us
+                // or using Reflect.decorate polyfill, which will return no descriptor
+                // (see https://github.com/mobxjs/mobx/issues/333)
+                Object.defineProperty(target, key, newDescriptor)
+            }
+            return newDescriptor
+        } else {
+            // babel and typescript getter / setter props
+            if (!hasOwnProperty(target, "__mobxLazyInitializers")) {
+                addHiddenProp(
+                    target,
+                    "__mobxLazyInitializers",
+                    (target.__mobxLazyInitializers && target.__mobxLazyInitializers.slice()) || [] // support inheritance
+                )
+            }
 
-			const {value, initializer} = descriptor;
-			target.__mobxLazyInitializers.push(instance => {
-				onInitialize(
-					instance,
-					key,
-					(initializer ? initializer.call(instance) : value),
-					customArgs,
-					descriptor
-				);
-			});
+            const { value, initializer } = descriptor
+            target.__mobxLazyInitializers.push(instance => {
+                onInitialize(
+                    instance,
+                    key,
+                    initializer ? initializer.call(instance) : value,
+                    customArgs,
+                    descriptor
+                )
+            })
 
-			return {
-				enumerable, configurable: true,
-				get : function() {
-					if (this.__mobxDidRunLazyInitializers !== true)
-						runLazyInitializers(this);
-					return get.call(this, key);
-				},
-				set : function(v) {
-					if (this.__mobxDidRunLazyInitializers !== true)
-						runLazyInitializers(this);
-					set.call(this, key, v);
-				}
-			};
-		}
-	}
+            return {
+                enumerable,
+                configurable: true,
+                get: function() {
+                    if (this.__mobxDidRunLazyInitializers !== true) runLazyInitializers(this)
+                    return get.call(this, key)
+                },
+                set: function(v) {
+                    if (this.__mobxDidRunLazyInitializers !== true) runLazyInitializers(this)
+                    set.call(this, key, v)
+                }
+            }
+        }
+    }
 
-	if (allowCustomArguments) {
-		/** If custom arguments are allowed, we should return a function that returns a decorator */
-		return function() {
-			/** Direct invocation: @decorator bla */
-			if (quacksLikeADecorator(arguments))
-				return classPropertyDecorator.apply(null, arguments);
-			/** Indirect invocation: @decorator(args) bla */
-			const outerArgs = arguments;
-			const argLen = arguments.length;
-			return (target, key, descriptor) => classPropertyDecorator(target, key, descriptor, outerArgs, argLen);
-		};
-	}
-	return classPropertyDecorator;
+    if (allowCustomArguments) {
+        /** If custom arguments are allowed, we should return a function that returns a decorator */
+        return function() {
+            /** Direct invocation: @decorator bla */
+            if (quacksLikeADecorator(arguments))
+                return classPropertyDecorator.apply(null, arguments)
+            /** Indirect invocation: @decorator(args) bla */
+            const outerArgs = arguments
+            const argLen = arguments.length
+            return (target, key, descriptor) =>
+                classPropertyDecorator(target, key, descriptor, outerArgs, argLen)
+        }
+    }
+    return classPropertyDecorator
 }
 
 function typescriptInitializeProperty(instance, key, v, onInitialize, customArgs, baseDescriptor) {
-	if (!hasOwnProperty(instance, "__mobxInitializedProps"))
-		addHiddenProp(instance, "__mobxInitializedProps", {});
-	instance.__mobxInitializedProps[key] = true;
-	onInitialize(instance, key, v, customArgs, baseDescriptor);
+    if (!hasOwnProperty(instance, "__mobxInitializedProps"))
+        addHiddenProp(instance, "__mobxInitializedProps", {})
+    instance.__mobxInitializedProps[key] = true
+    onInitialize(instance, key, v, customArgs, baseDescriptor)
 }
 
 export function runLazyInitializers(instance) {
-	if (instance.__mobxDidRunLazyInitializers === true)
-		return;
-	if (instance.__mobxLazyInitializers) {
-		addHiddenProp(instance, "__mobxDidRunLazyInitializers", true);
-		instance.__mobxDidRunLazyInitializers && instance.__mobxLazyInitializers.forEach(initializer => initializer(instance));
-	}
+    if (instance.__mobxDidRunLazyInitializers === true) return
+    if (instance.__mobxLazyInitializers) {
+        addHiddenProp(instance, "__mobxDidRunLazyInitializers", true)
+        instance.__mobxDidRunLazyInitializers &&
+            instance.__mobxLazyInitializers.forEach(initializer => initializer(instance))
+    }
 }
 
 function quacksLikeADecorator(args: IArguments): boolean {
-	return (args.length === 2 || args.length === 3) && typeof args[1] === "string";
+    return (args.length === 2 || args.length === 3) && typeof args[1] === "string"
 }

--- a/src/utils/iterable.ts
+++ b/src/utils/iterable.ts
@@ -1,40 +1,43 @@
-import {invariant, addHiddenFinalProp} from "./utils";
+import { invariant, addHiddenFinalProp } from "./utils"
 
 // inspired by https://github.com/leebyron/iterall/
 
-declare var Symbol;
+declare var Symbol
 
 function iteratorSymbol() {
-	return (typeof Symbol === "function" && Symbol.iterator) || "@@iterator";
+    return (typeof Symbol === "function" && Symbol.iterator) || "@@iterator"
 }
 
-export const IS_ITERATING_MARKER = "__$$iterating";
+export const IS_ITERATING_MARKER = "__$$iterating"
 
 export interface Iterator<T> {
-	next(): {
-		done: boolean;
-		value?: T;
-	};
+    next(): {
+        done: boolean
+        value?: T
+    }
 }
 
 export function arrayAsIterator<T>(array: T[]): T[] & Iterator<T> {
-	// returning an array for entries(), values() etc for maps was a mis-interpretation of the specs..,
-	// yet it is quite convenient to be able to use the response both as array directly and as iterator
-	// it is suboptimal, but alas...
-	invariant(array[IS_ITERATING_MARKER] !== true, "Illegal state: cannot recycle array as iterator");
-	addHiddenFinalProp(array, IS_ITERATING_MARKER, true);
+    // returning an array for entries(), values() etc for maps was a mis-interpretation of the specs..,
+    // yet it is quite convenient to be able to use the response both as array directly and as iterator
+    // it is suboptimal, but alas...
+    invariant(
+        array[IS_ITERATING_MARKER] !== true,
+        "Illegal state: cannot recycle array as iterator"
+    )
+    addHiddenFinalProp(array, IS_ITERATING_MARKER, true)
 
-	let idx = -1;
-	addHiddenFinalProp(array, "next", function next() {
-		idx++;
-		return {
-			done: idx >= this.length,
-			value: idx < this.length ? this[idx] : undefined
-		};
-	});
-	return array as any;
+    let idx = -1
+    addHiddenFinalProp(array, "next", function next() {
+        idx++
+        return {
+            done: idx >= this.length,
+            value: idx < this.length ? this[idx] : undefined
+        }
+    })
+    return array as any
 }
 
 export function declareIterator<T>(prototType, iteratorFactory: () => Iterator<T>) {
-	addHiddenFinalProp(prototType, iteratorSymbol(), iteratorFactory);
+    addHiddenFinalProp(prototType, iteratorSymbol(), iteratorFactory)
 }

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,42 +1,55 @@
 const messages = {
-"m001" : "It is not allowed to assign new values to @action fields" ,
-"m002" : "`runInAction` expects a function" ,
-"m003" : "`runInAction` expects a function without arguments" ,
-"m004" : "autorun expects a function" ,
-"m005" : "Warning: attempted to pass an action to autorun. Actions are untracked and will not trigger on state changes. Use `reaction` or wrap only your state modification code in an action." ,
-"m006" : "Warning: attempted to pass an action to autorunAsync. Actions are untracked and will not trigger on state changes. Use `reaction` or wrap only your state modification code in an action." ,
-"m007" : "reaction only accepts 2 or 3 arguments. If migrating from MobX 2, please provide an options object" ,
-"m008" : "wrapping reaction expression in `asReference` is no longer supported, use options object instead" ,
-"m009" : "@computed can only be used on getter functions, like: '@computed get myProps() { return ...; }'. It looks like it was used on a property." ,
-"m010" : "@computed can only be used on getter functions, like: '@computed get myProps() { return ...; }'" ,
-"m011" : "First argument to `computed` should be an expression. If using computed as decorator, don't pass it arguments" ,
-"m012" : "computed takes one or two arguments if used as function" ,
-"m013" : "[mobx.expr] 'expr' should only be used inside other reactive functions." ,
-"m014" : "extendObservable expected 2 or more arguments" ,
-"m015" : "extendObservable expects an object as first argument" ,
-"m016" : "extendObservable should not be used on maps, use map.merge instead" ,
-"m017" : "all arguments of extendObservable should be objects" ,
-"m018" : "extending an object with another observable (object) is not supported. Please construct an explicit propertymap, using `toJS` if need. See issue #540" ,
-"m019" : "[mobx.isObservable] isObservable(object, propertyName) is not supported for arrays and maps. Use map.has or array.length instead." ,
-"m020" : "modifiers can only be used for individual object properties" ,
-"m021" : "observable expects zero or one arguments" ,
-"m022" : "@observable can not be used on getters, use @computed instead" ,
-"m023" : "Using `transaction` is deprecated, use `runInAction` or `(@)action` instead." ,
-"m024" : "whyRun() can only be used if a derivation is active, or by passing an computed value / reaction explicitly. If you invoked whyRun from inside a computation; the computation is currently suspended but re-evaluating because somebody requested its value." ,
-"m025" : "whyRun can only be used on reactions and computed values" ,
-"m026" : "`action` can only be invoked on functions" ,
-"m028" : "It is not allowed to set `useStrict` when a derivation is running" ,
-"m029" : "INTERNAL ERROR only onBecomeUnobserved shouldn't be called twice in a row" ,
-"m030a" : "Since strict-mode is enabled, changing observed observable values outside actions is not allowed. Please wrap the code in an `action` if this change is intended. Tried to modify: " ,
-"m030b" : "Side effects like changing state are not allowed at this point. Are you trying to modify state from, for example, the render function of a React component? Tried to modify: " ,
-"m031" : "Computed values are not allowed to cause side effects by changing observables that are already being observed. Tried to modify: ",
-"m032" : "* This computation is suspended (not in use by any reaction) and won't run automatically.\n	Didn't expect this computation to be suspended at this point?\n	  1. Make sure this computation is used by a reaction (reaction, autorun, observer).\n	  2. Check whether you are using this computation synchronously (in the same stack as they reaction that needs it).",
-"m033" : "`observe` doesn't support the fire immediately property for observable maps." ,
-"m034" : "`mobx.map` is deprecated, use `new ObservableMap` or `mobx.observable.map` instead" ,
-"m035" : "Cannot make the designated object observable; it is not extensible" ,
-"m036" : "It is not possible to get index atoms from arrays" ,
-"m037" :
-`Hi there! I'm sorry you have just run into an exception.
+    m001: "It is not allowed to assign new values to @action fields",
+    m002: "`runInAction` expects a function",
+    m003: "`runInAction` expects a function without arguments",
+    m004: "autorun expects a function",
+    m005:
+        "Warning: attempted to pass an action to autorun. Actions are untracked and will not trigger on state changes. Use `reaction` or wrap only your state modification code in an action.",
+    m006:
+        "Warning: attempted to pass an action to autorunAsync. Actions are untracked and will not trigger on state changes. Use `reaction` or wrap only your state modification code in an action.",
+    m007:
+        "reaction only accepts 2 or 3 arguments. If migrating from MobX 2, please provide an options object",
+    m008:
+        "wrapping reaction expression in `asReference` is no longer supported, use options object instead",
+    m009:
+        "@computed can only be used on getter functions, like: '@computed get myProps() { return ...; }'. It looks like it was used on a property.",
+    m010:
+        "@computed can only be used on getter functions, like: '@computed get myProps() { return ...; }'",
+    m011:
+        "First argument to `computed` should be an expression. If using computed as decorator, don't pass it arguments",
+    m012: "computed takes one or two arguments if used as function",
+    m013: "[mobx.expr] 'expr' should only be used inside other reactive functions.",
+    m014: "extendObservable expected 2 or more arguments",
+    m015: "extendObservable expects an object as first argument",
+    m016: "extendObservable should not be used on maps, use map.merge instead",
+    m017: "all arguments of extendObservable should be objects",
+    m018:
+        "extending an object with another observable (object) is not supported. Please construct an explicit propertymap, using `toJS` if need. See issue #540",
+    m019:
+        "[mobx.isObservable] isObservable(object, propertyName) is not supported for arrays and maps. Use map.has or array.length instead.",
+    m020: "modifiers can only be used for individual object properties",
+    m021: "observable expects zero or one arguments",
+    m022: "@observable can not be used on getters, use @computed instead",
+    m023: "Using `transaction` is deprecated, use `runInAction` or `(@)action` instead.",
+    m024:
+        "whyRun() can only be used if a derivation is active, or by passing an computed value / reaction explicitly. If you invoked whyRun from inside a computation; the computation is currently suspended but re-evaluating because somebody requested its value.",
+    m025: "whyRun can only be used on reactions and computed values",
+    m026: "`action` can only be invoked on functions",
+    m028: "It is not allowed to set `useStrict` when a derivation is running",
+    m029: "INTERNAL ERROR only onBecomeUnobserved shouldn't be called twice in a row",
+    m030a:
+        "Since strict-mode is enabled, changing observed observable values outside actions is not allowed. Please wrap the code in an `action` if this change is intended. Tried to modify: ",
+    m030b:
+        "Side effects like changing state are not allowed at this point. Are you trying to modify state from, for example, the render function of a React component? Tried to modify: ",
+    m031:
+        "Computed values are not allowed to cause side effects by changing observables that are already being observed. Tried to modify: ",
+    m032:
+        "* This computation is suspended (not in use by any reaction) and won't run automatically.\n	Didn't expect this computation to be suspended at this point?\n	  1. Make sure this computation is used by a reaction (reaction, autorun, observer).\n	  2. Check whether you are using this computation synchronously (in the same stack as they reaction that needs it).",
+    m033: "`observe` doesn't support the fire immediately property for observable maps.",
+    m034: "`mobx.map` is deprecated, use `new ObservableMap` or `mobx.observable.map` instead",
+    m035: "Cannot make the designated object observable; it is not extensible",
+    m036: "It is not possible to get index atoms from arrays",
+    m037: `Hi there! I'm sorry you have just run into an exception.
 If your debugger ends up here, know that some reaction (like the render() of an observer component, autorun or reaction)
 threw an exception and that mobx caught it, to avoid that it brings the rest of your application down.
 The original cause of the exception (the code that caused this reaction to run (again)), is still in the stack.
@@ -54,13 +67,12 @@ You can also make sure the debugger pauses the next time this very same exceptio
 
 If that all doesn't help you out, feel free to open an issue https://github.com/mobxjs/mobx/issues!
 `,
-"m038" :
-`Missing items in this list?
+    m038: `Missing items in this list?
     1. Check whether all used values are properly marked as observable (use isObservable to verify)
     2. Make sure you didn't dereference values too early. MobX observes props, not primitives. E.g: use 'person.name' instead of 'name' in your computation.
 `
-};
+}
 
 export function getMessage(id: string): string {
-	return messages[id];
+    return messages[id]
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,145 +1,141 @@
-export const EMPTY_ARRAY = [];
-Object.freeze(EMPTY_ARRAY);
+export const EMPTY_ARRAY = []
+Object.freeze(EMPTY_ARRAY)
 
-declare var global;
+declare var global
 export function getGlobal() {
-	return typeof window !== 'undefined' ? window : global;
+    return typeof window !== "undefined" ? window : global
 }
 
 export interface Lambda {
-	(): void;
-	name?: string;
+    (): void
+    name?: string
 }
 
 export function getNextId() {
-	return ++globalState.mobxGuid;
+    return ++globalState.mobxGuid
 }
 
 export function fail(message: string, thing?): never {
-	invariant(false, message, thing);
-	throw "X"; // unreachable
+    invariant(false, message, thing)
+    throw "X" // unreachable
 }
 
 export function invariant(check: boolean, message: string, thing?) {
-	if (!check)
-		throw new Error("[mobx] Invariant failed: " + message + (thing ? ` in '${thing}'` : ""));
+    if (!check)
+        throw new Error("[mobx] Invariant failed: " + message + (thing ? ` in '${thing}'` : ""))
 }
-
 
 /**
  * Prints a deprecation message, but only one time.
  * Returns false if the deprecated message was already printed before
  */
-const deprecatedMessages: string[] = [];
+const deprecatedMessages: string[] = []
 
 export function deprecated(msg: string): boolean {
-	if (deprecatedMessages.indexOf(msg) !== -1)
-		return false;
-	deprecatedMessages.push(msg);
-	console.error("[mobx] Deprecated: " + msg);
-	return true;
+    if (deprecatedMessages.indexOf(msg) !== -1) return false
+    deprecatedMessages.push(msg)
+    console.error("[mobx] Deprecated: " + msg)
+    return true
 }
 
 /**
  * Makes sure that the provided function is invoked at most once.
  */
 export function once(func: Lambda): Lambda {
-	let invoked = false;
-	return function() {
-		if (invoked)
-			return;
-		invoked = true;
-		return (func as any).apply(this, arguments);
-	};
+    let invoked = false
+    return function() {
+        if (invoked) return
+        invoked = true
+        return (func as any).apply(this, arguments)
+    }
 }
 
-export const noop = () => {};
+export const noop = () => {}
 
 export function unique<T>(list: T[]): T[] {
-	const res: T[] = [];
-	list.forEach(item => {
-		if (res.indexOf(item) === -1)
-			res.push(item);
-	});
-	return res;
+    const res: T[] = []
+    list.forEach(item => {
+        if (res.indexOf(item) === -1) res.push(item)
+    })
+    return res
 }
 
 export function joinStrings(things: string[], limit: number = 100, separator = " - "): string {
-	if (!things)
-		return "";
-	const sliced = things.slice(0, limit);
-	return `${sliced.join(separator)}${things.length > limit ? " (... and " + (things.length - limit) + "more)" : ""}`;
+    if (!things) return ""
+    const sliced = things.slice(0, limit)
+    return `${sliced.join(separator)}${things.length > limit
+        ? " (... and " + (things.length - limit) + "more)"
+        : ""}`
 }
 
 export function isObject(value: any): boolean {
-	return value !== null && typeof value === "object";
+    return value !== null && typeof value === "object"
 }
 
 export function isPlainObject(value) {
-	if (value === null || typeof value !== "object")
-		return false;
-	const proto = Object.getPrototypeOf(value);
-	return proto === Object.prototype || proto === null;
+    if (value === null || typeof value !== "object") return false
+    const proto = Object.getPrototypeOf(value)
+    return proto === Object.prototype || proto === null
 }
 
-export function objectAssign(...objs: Object[]): Object;
+export function objectAssign(...objs: Object[]): Object
 export function objectAssign() {
-	const res = arguments[0];
-	for (let i = 1, l = arguments.length; i < l; i++) {
-		const source = arguments[i];
-		for (let key in source) if (hasOwnProperty(source, key)) {
-			res[key] = source[key];
-		}
-	}
-	return res;
+    const res = arguments[0]
+    for (let i = 1, l = arguments.length; i < l; i++) {
+        const source = arguments[i]
+        for (let key in source)
+            if (hasOwnProperty(source, key)) {
+                res[key] = source[key]
+            }
+    }
+    return res
 }
 
-const prototypeHasOwnProperty = Object.prototype.hasOwnProperty;
+const prototypeHasOwnProperty = Object.prototype.hasOwnProperty
 export function hasOwnProperty(object: Object, propName: string) {
-	return prototypeHasOwnProperty.call(object, propName);
+    return prototypeHasOwnProperty.call(object, propName)
 }
 
 export function makeNonEnumerable(object: any, propNames: string[]) {
-	for (let i = 0; i < propNames.length; i++) {
-		addHiddenProp(object, propNames[i], object[propNames[i]]);
-	}
+    for (let i = 0; i < propNames.length; i++) {
+        addHiddenProp(object, propNames[i], object[propNames[i]])
+    }
 }
 
 export function addHiddenProp(object: any, propName: string, value: any) {
-	Object.defineProperty(object, propName, {
-		enumerable: false,
-		writable: true,
-		configurable: true,
-		value
-	});
+    Object.defineProperty(object, propName, {
+        enumerable: false,
+        writable: true,
+        configurable: true,
+        value
+    })
 }
 
 export function addHiddenFinalProp(object: any, propName: string, value: any) {
-	Object.defineProperty(object, propName, {
-		enumerable: false,
-		writable: false,
-		configurable: true,
-		value
-	});
+    Object.defineProperty(object, propName, {
+        enumerable: false,
+        writable: false,
+        configurable: true,
+        value
+    })
 }
 
 export function isPropertyConfigurable(object: any, prop: string): boolean {
-	const descriptor = Object.getOwnPropertyDescriptor(object, prop);
-	return !descriptor || (descriptor.configurable !== false && descriptor.writable !== false);
+    const descriptor = Object.getOwnPropertyDescriptor(object, prop)
+    return !descriptor || (descriptor.configurable !== false && descriptor.writable !== false)
 }
 
 export function assertPropertyConfigurable(object: any, prop: string) {
-	invariant(
-		isPropertyConfigurable(object, prop),
-		`Cannot make property '${prop}' observable, it is not configurable and writable in the target object`
-	);
+    invariant(
+        isPropertyConfigurable(object, prop),
+        `Cannot make property '${prop}' observable, it is not configurable and writable in the target object`
+    )
 }
 
 export function getEnumerableKeys(obj) {
-	const res: string[] = [];
-	for (let key in obj)
-		res.push(key);
-	return res;
+    const res: string[] = []
+    for (let key in obj) res.push(key)
+    return res
 }
 
 /**
@@ -147,91 +143,81 @@ export function getEnumerableKeys(obj) {
  * If you have such a case, you probably should use this function but something fancier :).
  */
 export function deepEqual(a, b) {
-	if (a === null && b === null)
-		return true;
-	if (a === undefined && b === undefined)
-		return true;
-	if (typeof a !== "object")
-		return a === b;
-	const aIsArray = isArrayLike(a);
-	const aIsMap = isMapLike(a);
-	if (aIsArray !== isArrayLike(b)) {
-		return false;
-	} else if (aIsMap !== isMapLike(b)) {
-		return false;
-	} else if (aIsArray) {
-		if (a.length !== b.length)
-			return false;
-		for (let i = a.length -1; i >= 0; i--)
-			if (!deepEqual(a[i], b[i]))
-				return false;
-		return true;
-	} else if (aIsMap) {
-		if (a.size !== b.size)
-			return false;
-		let equals = true;
-		a.forEach((value, key) => {
-			equals = equals && deepEqual(b.get(key), value);
-		});
-		return equals;
-	} else if  (typeof a === "object" && typeof b === "object") {
-		if (a === null || b === null)
-			return false;
-		if (isMapLike(a) && isMapLike(b)) {
-			if (a.size !== b.size)
-				return false;
-			// Freaking inefficient.... Create PR if you run into this :) Much appreciated!
-			return deepEqual(observable.shallowMap(a).entries(), observable.shallowMap(b).entries());
-		}
-		if (getEnumerableKeys(a).length !== getEnumerableKeys(b).length)
-			return false;
-		for (let prop in a) {
-			if (!(prop in b))
-				return false;
-			if (!deepEqual(a[prop], b[prop]))
-				return false;
-		}
-		return true;
-	}
-	return false;
+    if (a === null && b === null) return true
+    if (a === undefined && b === undefined) return true
+    if (typeof a !== "object") return a === b
+    const aIsArray = isArrayLike(a)
+    const aIsMap = isMapLike(a)
+    if (aIsArray !== isArrayLike(b)) {
+        return false
+    } else if (aIsMap !== isMapLike(b)) {
+        return false
+    } else if (aIsArray) {
+        if (a.length !== b.length) return false
+        for (let i = a.length - 1; i >= 0; i--) if (!deepEqual(a[i], b[i])) return false
+        return true
+    } else if (aIsMap) {
+        if (a.size !== b.size) return false
+        let equals = true
+        a.forEach((value, key) => {
+            equals = equals && deepEqual(b.get(key), value)
+        })
+        return equals
+    } else if (typeof a === "object" && typeof b === "object") {
+        if (a === null || b === null) return false
+        if (isMapLike(a) && isMapLike(b)) {
+            if (a.size !== b.size) return false
+            // Freaking inefficient.... Create PR if you run into this :) Much appreciated!
+            return deepEqual(observable.shallowMap(a).entries(), observable.shallowMap(b).entries())
+        }
+        if (getEnumerableKeys(a).length !== getEnumerableKeys(b).length) return false
+        for (let prop in a) {
+            if (!(prop in b)) return false
+            if (!deepEqual(a[prop], b[prop])) return false
+        }
+        return true
+    }
+    return false
 }
 
-export function createInstanceofPredicate<T>(name: string, clazz: new (...args: any[]) => T): (x: any) => x is T {
-	const propName = "isMobX" + name;
-	clazz.prototype[propName] = true;
-	return function (x) {
-		return isObject(x) && x[propName] === true;
-	} as any;
+export function createInstanceofPredicate<T>(
+    name: string,
+    clazz: new (...args: any[]) => T
+): (x: any) => x is T {
+    const propName = "isMobX" + name
+    clazz.prototype[propName] = true
+    return function(x) {
+        return isObject(x) && x[propName] === true
+    } as any
 }
 
 /**
  * Returns whether the argument is an array, disregarding observability.
  */
 export function isArrayLike(x: any): x is Array<any> | IObservableArray<any> {
-	return Array.isArray(x) || isObservableArray(x);
+    return Array.isArray(x) || isObservableArray(x)
 }
 
 export function isMapLike(x: any): boolean {
-	return isES6Map(x) || isObservableMap(x)
+    return isES6Map(x) || isObservableMap(x)
 }
 
 export function isES6Map(thing): boolean {
-	if (getGlobal().Map !== undefined && thing instanceof getGlobal().Map)
-		return true;
-	return false;
+    if (getGlobal().Map !== undefined && thing instanceof getGlobal().Map) return true
+    return false
 }
 
-declare var Symbol;
+declare var Symbol
 
 export function primitiveSymbol() {
-	return (typeof Symbol === "function" && Symbol.toPrimitive) || "@@toPrimitive";
+    return (typeof Symbol === "function" && Symbol.toPrimitive) || "@@toPrimitive"
 }
 
 export function toPrimitive(value) {
-	return value === null ? null : typeof value === "object" ? ("" + value) : value;
+    return value === null ? null : typeof value === "object" ? "" + value : value
 }
 
-import {globalState} from "../core/globalstate";
-import {IObservableArray, isObservableArray} from "../types/observablearray";
-import {isObservableMap} from "../types/observablemap";
-import {observable} from "../api/observable";
+import { globalState } from "../core/globalstate"
+import { IObservableArray, isObservableArray } from "../types/observablearray"
+import { isObservableMap } from "../types/observablemap"
+import { observable } from "../api/observable"

--- a/test/action.js
+++ b/test/action.js
@@ -1,437 +1,428 @@
 "use strict"
 
-var test = require('tape');
-var mobx = require('../');
-var utils = require('./utils/test-utils');
+var test = require("tape")
+var mobx = require("../")
+var utils = require("./utils/test-utils")
 
-test('action should wrap in transaction', t => {
-	var values = [];
+test("action should wrap in transaction", t => {
+    var values = []
 
-	var observable = mobx.observable(0);
-	var d = mobx.autorun(() => values.push(observable.get()));
+    var observable = mobx.observable(0)
+    var d = mobx.autorun(() => values.push(observable.get()))
 
-	var increment = mobx.action("increment", (amount) => {
-		observable.set(observable.get() + amount * 2);
-		observable.set(observable.get() - amount); // oops
-	});
+    var increment = mobx.action("increment", amount => {
+        observable.set(observable.get() + amount * 2)
+        observable.set(observable.get() - amount) // oops
+    })
 
-	t.equal(mobx.isAction(increment), true);
-	t.equal(mobx.isAction(function () {}), false);
+    t.equal(mobx.isAction(increment), true)
+    t.equal(mobx.isAction(function() {}), false)
 
-	increment(7);
+    increment(7)
 
-	t.deepEqual(values, [0, 7]);
+    t.deepEqual(values, [0, 7])
 
-	t.end();
-});
-
-
-test('action modifications should be picked up 1', t => {
-	var a = mobx.observable(1);
-	var i = 3;
-	var b = 0;
-
-	mobx.autorun(() => {
-		b = a.get() * 2;
-	});
-
-	t.equal(b, 2);
-
-	var action = mobx.action(() => {
-		a.set(++i);
-	});
-
-	action();
-	t.equal(b, 8);
-
-	action();
-	t.equal(b, 10);
-
-	t.end();
-});
-
-test('action modifications should be picked up 1', t => {
-	var a = mobx.observable(1);
-	var b = 0;
-
-	mobx.autorun(() => {
-		b = a.get() * 2;
-	});
-
-	t.equal(b, 2);
-
-	var action = mobx.action(() => {
-		a.set(a.get() + 1); // ha, no loop!
-	});
-
-	action();
-	t.equal(b, 4);
-
-	action();
-	t.equal(b, 6);
-
-	t.end();
-});
-
-test('action modifications should be picked up 3', t => {
-	var a = mobx.observable(1);
-	var b = 0;
-
-	var doubler = mobx.computed(() => a.get() * 2);
-
-	doubler.observe(() => {
-		b = doubler.get();
-	}, true);
-
-	t.equal(b, 2);
-
-	var action = mobx.action(() => {
-		a.set(a.get() + 1); // ha, no loop!
-	});
-
-	action();
-	t.equal(b, 4);
-
-	action();
-	t.equal(b, 6);
-
-	t.end();
-});
-
-
-test('test action should be untracked', t => {
-	var a = mobx.observable(3);
-	var b = mobx.observable(4);
-	var latest = 0;
-	var runs = 0;
-
-	var action = mobx.action((baseValue) => {
-		b.set(baseValue * 2);
-		latest = b.get(); // without action this would trigger loop
-	});
-
-	var d = mobx.autorun(() => {
-		runs++;
-		var current = a.get();
-		action(current);
-	});
-
-	t.equal(b.get(), 6);
-	t.equal(latest, 6);
-
-	a.set(7);
-	t.equal(b.get(), 14);
-	t.equal(latest, 14);
-
-	a.set(8);
-	t.equal(b.get(), 16);
-	t.equal(latest, 16);
-
-	b.set(7); // should have no effect
-	t.equal(a.get(), 8)
-	t.equal(b.get(), 7);
-	t.equal(latest, 16); // effect not triggered
-
-	a.set(3);
-	t.equal(b.get(), 6);
-	t.equal(latest, 6);
-
-	t.equal(runs, 4);
-
-	d();
-	t.end();
-});
-
-test('should be possible to create autorun in ation', t => {
-	var a = mobx.observable(1);
-	var values = [];
-
-	var adder = mobx.action(inc => {
-		return mobx.autorun(() => {
-			values.push(a.get() + inc);
-		})
-	});
-
-	var d1 = adder(2);
-	a.set(3);
-	var d2 = adder(17);
-	a.set(24);
-	d1();
-	a.set(11);
-	d2();
-	a.set(100);
-
-	t.deepEqual(values, [
-		3,
-		5,
-		20,
-		41,
-		26,
-		28
-	]);
-	t.end();
+    t.end()
 })
 
-test('should be possible to change unobserved state in an action called from computed', t => {
-	var a = mobx.observable(2);
+test("action modifications should be picked up 1", t => {
+    var a = mobx.observable(1)
+    var i = 3
+    var b = 0
 
-	var testAction = mobx.action(() => {
-		a.set(3)
-	});
-
-	var c = mobx.computed(() => {
-		testAction();
-	});
-
-	t.plan(1)
-	mobx.autorun(() => {
-		t.doesNotThrow(() => {
-			c.get()
-		})
-	});
-
-	mobx.extras.resetGlobalState();
-	t.end();
-});
-
-test('should not be possible to change observed state in an action called from computed', t => {
-	var a = mobx.observable(2);
-	var d = mobx.autorun(() => {
-		a.get()
-	})
-
-	var testAction = mobx.action(() => {
-		a.set(3)
-	});
-
-	var c = mobx.computed(() => {
-		testAction();
-		return a.get()
-	});
-
-	t.throws(() => {
-		c.get()
-	}, /Computed values are not allowed to cause side effects by changing observables that are already being observed/)
-
-	mobx.extras.resetGlobalState();
-	d();
-	t.end();
-});
-
-test('action in autorun should be untracked', t => {
-	var a = mobx.observable(2);
-	var b = mobx.observable(3);
-
-	var data = [];
-	var multiplier = mobx.action(val => val * b.get());
-
-	var d = mobx.autorun(() => {
-		data.push(multiplier(a.get()));
-	});
-
-	a.set(3);
-	b.set(4);
-	a.set(5);
-
-	d();
-
-	a.set(6);
-
-	t.deepEqual(data, [
-		6, 9, 20
-	]);
-
-	t.end();
-})
-
-test('action should not be converted to computed when using (extend)observable', t => {
-	var a = mobx.observable({
-		a: 1,
-		b: mobx.action(function() {
-			this.a++;
-		})
-	})
-
-	t.equal(mobx.isAction(a.b), true);
-	a.b();
-	t.equal(a.a, 2);
-
-	mobx.extendObservable(a, {
-		c: mobx.action(function() {
-			this.a *= 3;
-		})
-	});
-
-	t.equal(mobx.isAction(a.c), true);
-	a.c();
-	t.equal(a.a, 6);
-
-	t.end();
-})
-
-test('#286 exceptions in actions should not affect global state', t => {
-	var autorunTimes = 0;
-    function Todos() {
-		mobx.extendObservable(this, {
-			count: 0,
-			add: mobx.action(function() {
-				this.count++;
-				if (this.count === 2) {
-					throw new Error('An Action Error!');
-				}
-			})
-		})
-    }
-    const todo = new Todos;
     mobx.autorun(() => {
-		autorunTimes++;
-		return todo.count;
-    });
-    try {
-		todo.add();
-		t.equal(autorunTimes, 2);
-		todo.add();
-    } catch (e) {
-		t.equal(autorunTimes, 3);
-		todo.add();
-		t.equal(autorunTimes, 4);
+        b = a.get() * 2
+    })
+
+    t.equal(b, 2)
+
+    var action = mobx.action(() => {
+        a.set(++i)
+    })
+
+    action()
+    t.equal(b, 8)
+
+    action()
+    t.equal(b, 10)
+
+    t.end()
+})
+
+test("action modifications should be picked up 1", t => {
+    var a = mobx.observable(1)
+    var b = 0
+
+    mobx.autorun(() => {
+        b = a.get() * 2
+    })
+
+    t.equal(b, 2)
+
+    var action = mobx.action(() => {
+        a.set(a.get() + 1) // ha, no loop!
+    })
+
+    action()
+    t.equal(b, 4)
+
+    action()
+    t.equal(b, 6)
+
+    t.end()
+})
+
+test("action modifications should be picked up 3", t => {
+    var a = mobx.observable(1)
+    var b = 0
+
+    var doubler = mobx.computed(() => a.get() * 2)
+
+    doubler.observe(() => {
+        b = doubler.get()
+    }, true)
+
+    t.equal(b, 2)
+
+    var action = mobx.action(() => {
+        a.set(a.get() + 1) // ha, no loop!
+    })
+
+    action()
+    t.equal(b, 4)
+
+    action()
+    t.equal(b, 6)
+
+    t.end()
+})
+
+test("test action should be untracked", t => {
+    var a = mobx.observable(3)
+    var b = mobx.observable(4)
+    var latest = 0
+    var runs = 0
+
+    var action = mobx.action(baseValue => {
+        b.set(baseValue * 2)
+        latest = b.get() // without action this would trigger loop
+    })
+
+    var d = mobx.autorun(() => {
+        runs++
+        var current = a.get()
+        action(current)
+    })
+
+    t.equal(b.get(), 6)
+    t.equal(latest, 6)
+
+    a.set(7)
+    t.equal(b.get(), 14)
+    t.equal(latest, 14)
+
+    a.set(8)
+    t.equal(b.get(), 16)
+    t.equal(latest, 16)
+
+    b.set(7) // should have no effect
+    t.equal(a.get(), 8)
+    t.equal(b.get(), 7)
+    t.equal(latest, 16) // effect not triggered
+
+    a.set(3)
+    t.equal(b.get(), 6)
+    t.equal(latest, 6)
+
+    t.equal(runs, 4)
+
+    d()
+    t.end()
+})
+
+test("should be possible to create autorun in ation", t => {
+    var a = mobx.observable(1)
+    var values = []
+
+    var adder = mobx.action(inc => {
+        return mobx.autorun(() => {
+            values.push(a.get() + inc)
+        })
+    })
+
+    var d1 = adder(2)
+    a.set(3)
+    var d2 = adder(17)
+    a.set(24)
+    d1()
+    a.set(11)
+    d2()
+    a.set(100)
+
+    t.deepEqual(values, [3, 5, 20, 41, 26, 28])
+    t.end()
+})
+
+test("should be possible to change unobserved state in an action called from computed", t => {
+    var a = mobx.observable(2)
+
+    var testAction = mobx.action(() => {
+        a.set(3)
+    })
+
+    var c = mobx.computed(() => {
+        testAction()
+    })
+
+    t.plan(1)
+    mobx.autorun(() => {
+        t.doesNotThrow(() => {
+            c.get()
+        })
+    })
+
+    mobx.extras.resetGlobalState()
+    t.end()
+})
+
+test("should not be possible to change observed state in an action called from computed", t => {
+    var a = mobx.observable(2)
+    var d = mobx.autorun(() => {
+        a.get()
+    })
+
+    var testAction = mobx.action(() => {
+        a.set(3)
+    })
+
+    var c = mobx.computed(() => {
+        testAction()
+        return a.get()
+    })
+
+    t.throws(() => {
+        c.get()
+    }, /Computed values are not allowed to cause side effects by changing observables that are already being observed/)
+
+    mobx.extras.resetGlobalState()
+    d()
+    t.end()
+})
+
+test("action in autorun should be untracked", t => {
+    var a = mobx.observable(2)
+    var b = mobx.observable(3)
+
+    var data = []
+    var multiplier = mobx.action(val => val * b.get())
+
+    var d = mobx.autorun(() => {
+        data.push(multiplier(a.get()))
+    })
+
+    a.set(3)
+    b.set(4)
+    a.set(5)
+
+    d()
+
+    a.set(6)
+
+    t.deepEqual(data, [6, 9, 20])
+
+    t.end()
+})
+
+test("action should not be converted to computed when using (extend)observable", t => {
+    var a = mobx.observable({
+        a: 1,
+        b: mobx.action(function() {
+            this.a++
+        })
+    })
+
+    t.equal(mobx.isAction(a.b), true)
+    a.b()
+    t.equal(a.a, 2)
+
+    mobx.extendObservable(a, {
+        c: mobx.action(function() {
+            this.a *= 3
+        })
+    })
+
+    t.equal(mobx.isAction(a.c), true)
+    a.c()
+    t.equal(a.a, 6)
+
+    t.end()
+})
+
+test("#286 exceptions in actions should not affect global state", t => {
+    var autorunTimes = 0
+    function Todos() {
+        mobx.extendObservable(this, {
+            count: 0,
+            add: mobx.action(function() {
+                this.count++
+                if (this.count === 2) {
+                    throw new Error("An Action Error!")
+                }
+            })
+        })
     }
-	t.end();
+    const todo = new Todos()
+    mobx.autorun(() => {
+        autorunTimes++
+        return todo.count
+    })
+    try {
+        todo.add()
+        t.equal(autorunTimes, 2)
+        todo.add()
+    } catch (e) {
+        t.equal(autorunTimes, 3)
+        todo.add()
+        t.equal(autorunTimes, 4)
+    }
+    t.end()
 })
 
-test('runInAction', t => {
-	mobx.useStrict(true);
-	var values = [];
-	var events = [];
-	var spyDisposer = mobx.spy(ev => {
-		if (ev.type === 'action') events.push({
-			name: ev.name,
-			arguments: ev.arguments
-		})
-	});
+test("runInAction", t => {
+    mobx.useStrict(true)
+    var values = []
+    var events = []
+    var spyDisposer = mobx.spy(ev => {
+        if (ev.type === "action")
+            events.push({
+                name: ev.name,
+                arguments: ev.arguments
+            })
+    })
 
-	var observable = mobx.observable(0);
-	var d = mobx.autorun(() => values.push(observable.get()));
+    var observable = mobx.observable(0)
+    var d = mobx.autorun(() => values.push(observable.get()))
 
-	var res = mobx.runInAction("increment", () => {
-		observable.set(observable.get() + 6 * 2);
-		observable.set(observable.get() - 3); // oops
-		return 2;
-	});
+    var res = mobx.runInAction("increment", () => {
+        observable.set(observable.get() + 6 * 2)
+        observable.set(observable.get() - 3) // oops
+        return 2
+    })
 
-	t.equal(res, 2);
-	t.deepEqual(values, [0, 9]);
+    t.equal(res, 2)
+    t.deepEqual(values, [0, 9])
 
-	res = mobx.runInAction(() => {
-		observable.set(observable.get() + 5 * 2);
-		observable.set(observable.get() - 4); // oops
-		return 3;
-	});
+    res = mobx.runInAction(() => {
+        observable.set(observable.get() + 5 * 2)
+        observable.set(observable.get() - 4) // oops
+        return 3
+    })
 
-	t.equal(res, 3);
-	t.deepEqual(values, [0, 9, 15]);
-	t.deepEqual(events, [
-		{ arguments: [], name: 'increment' },
-		{ arguments: [], name: '<unnamed action>' }
-	]);
+    t.equal(res, 3)
+    t.deepEqual(values, [0, 9, 15])
+    t.deepEqual(events, [
+        { arguments: [], name: "increment" },
+        { arguments: [], name: "<unnamed action>" }
+    ])
 
-	mobx.useStrict(false);
-	spyDisposer();
+    mobx.useStrict(false)
+    spyDisposer()
 
-	d();
-	t.end();
+    d()
+    t.end()
 })
 
-test('action in autorun does not keep / make computed values alive', t => {
-	let calls = 0
-	const myComputed = mobx.computed(() => calls++)
-	const callComputedTwice = () => {
-		myComputed.get()
-		myComputed.get()
-	}
+test("action in autorun does not keep / make computed values alive", t => {
+    let calls = 0
+    const myComputed = mobx.computed(() => calls++)
+    const callComputedTwice = () => {
+        myComputed.get()
+        myComputed.get()
+    }
 
-	const runWithMemoizing = fun => { mobx.autorun(fun)() }
+    const runWithMemoizing = fun => {
+        mobx.autorun(fun)()
+    }
 
-	callComputedTwice()
-	t.equal(calls, 2)
+    callComputedTwice()
+    t.equal(calls, 2)
 
-	runWithMemoizing(callComputedTwice)
-	t.equal(calls, 3)
+    runWithMemoizing(callComputedTwice)
+    t.equal(calls, 3)
 
-	callComputedTwice()
-	t.equal(calls, 5)
+    callComputedTwice()
+    t.equal(calls, 5)
 
-	runWithMemoizing(function() {
-		mobx.runInAction(callComputedTwice)
-	})
-	t.equal(calls, 6)
+    runWithMemoizing(function() {
+        mobx.runInAction(callComputedTwice)
+    })
+    t.equal(calls, 6)
 
-	callComputedTwice()
-	t.equal(calls, 8)
+    callComputedTwice()
+    t.equal(calls, 8)
 
-	t.end()
+    t.end()
 })
 
-test('computed values and actions', t => {
-	let calls = 0
+test("computed values and actions", t => {
+    let calls = 0
 
-	const number = mobx.observable(1)
-	const squared = mobx.computed(() => {
-		calls++
-		return number.get() * number.get()
-	})
-	const changeNumber10Times = mobx.action(() => {
-		squared.get()
-		squared.get()
-		for (let i = 0; i < 10; i++)
-			number.set(number.get() + 1)
-	})
+    const number = mobx.observable(1)
+    const squared = mobx.computed(() => {
+        calls++
+        return number.get() * number.get()
+    })
+    const changeNumber10Times = mobx.action(() => {
+        squared.get()
+        squared.get()
+        for (let i = 0; i < 10; i++) number.set(number.get() + 1)
+    })
 
-	changeNumber10Times()
-	t.equal(calls, 1)
+    changeNumber10Times()
+    t.equal(calls, 1)
 
-	mobx.autorun(() => {
-		changeNumber10Times()
-		t.equal(calls, 2)
-	})()
-	t.equal(calls, 2)
+    mobx.autorun(() => {
+        changeNumber10Times()
+        t.equal(calls, 2)
+    })()
+    t.equal(calls, 2)
 
-	changeNumber10Times()
-	t.equal(calls, 3)
+    changeNumber10Times()
+    t.equal(calls, 3)
 
-	t.end()
+    t.end()
 })
 
-test('bound actions bind', t => {
-	var called = 0;
-	var x = mobx.observable({
-		y: 0,
-		z: mobx.action.bound(function(v) {
-			this.y += v;
-			this.y += v;
-		}),
+test("bound actions bind", t => {
+    var called = 0
+    var x = mobx.observable({
+        y: 0,
+        z: mobx.action.bound(function(v) {
+            this.y += v
+            this.y += v
+        }),
 
-		get yValue() {
-			called++;
-			return this.y;
-		}
-	})
+        get yValue() {
+            called++
+            return this.y
+        }
+    })
 
-	var d = mobx.autorun(() => {
-		x.yValue;
-	})
-	var events = [];
-	var d2 = mobx.spy(e => events.push(e));
+    var d = mobx.autorun(() => {
+        x.yValue
+    })
+    var events = []
+    var d2 = mobx.spy(e => events.push(e))
 
-	var runner = x.z;
-	runner(3);
-	t.equal(x.yValue, 6);
-	t.equal(called, 2);
+    var runner = x.z
+    runner(3)
+    t.equal(x.yValue, 6)
+    t.equal(called, 2)
 
-	t.deepEqual(events.filter(e => e.type === "action").map(e => e.name), ["z"])
-	t.deepEqual(Object.keys(x), ["y"]);
+    t.deepEqual(events.filter(e => e.type === "action").map(e => e.name), ["z"])
+    t.deepEqual(Object.keys(x), ["y"])
 
-	d();
-	d2();
-	t.end();
+    d()
+    d2()
+    t.end()
 })

--- a/test/api.js
+++ b/test/api.js
@@ -1,82 +1,94 @@
-var mobx = require('../');
-var test = require('tape');
+var mobx = require("../")
+var test = require("tape")
 
-test('correct api should be exposed', function(t) {
-	t.deepEquals(Object.keys(mobx).sort(), [
-		'Atom',
-		'BaseAtom', // TODO: remove somehow
-		'IDerivationState',
-		'IObservableFactories',
-		'ObservableMap',
-		'Reaction',
-		'action',
-		'asFlat',
-		'asMap',
-		'asReference',
-		'asStructure',
-		'autorun',
-		'autorunAsync',
-		'computed',
-		'comparer',
-		'createTransformer',
-		'default',
-		'expr',
-		'extendObservable',
-		'extendShallowObservable',
-		'extras',
-		'intercept',
-		'isAction',
-		'isArrayLike',
-		'isBoxedObservable',
-		'isComputed',
-		'isModifierDescriptor',
-		'isObservable',
-		'isObservableArray',
-		'isObservableMap',
-		'isObservableObject',
-		'isStrictModeEnabled',
-		'map',
-		'observable',
-		'observe',
-		'reaction',
-		'runInAction',
-		'spy',
-		'toJS',
-		'transaction',
-		'untracked',
-		'useStrict',
-		'when',
-		'whyRun'
-	].sort());
-	t.equals(Object.keys(mobx).filter(function(key) {
-		return mobx[key] == undefined;
-	}).length, 0);
+test("correct api should be exposed", function(t) {
+    t.deepEquals(
+        Object.keys(mobx).sort(),
+        [
+            "Atom",
+            "BaseAtom", // TODO: remove somehow
+            "IDerivationState",
+            "IObservableFactories",
+            "ObservableMap",
+            "Reaction",
+            "action",
+            "asFlat",
+            "asMap",
+            "asReference",
+            "asStructure",
+            "autorun",
+            "autorunAsync",
+            "computed",
+            "comparer",
+            "createTransformer",
+            "default",
+            "expr",
+            "extendObservable",
+            "extendShallowObservable",
+            "extras",
+            "intercept",
+            "isAction",
+            "isArrayLike",
+            "isBoxedObservable",
+            "isComputed",
+            "isModifierDescriptor",
+            "isObservable",
+            "isObservableArray",
+            "isObservableMap",
+            "isObservableObject",
+            "isStrictModeEnabled",
+            "map",
+            "observable",
+            "observe",
+            "reaction",
+            "runInAction",
+            "spy",
+            "toJS",
+            "transaction",
+            "untracked",
+            "useStrict",
+            "when",
+            "whyRun"
+        ].sort()
+    )
+    t.equals(
+        Object.keys(mobx).filter(function(key) {
+            return mobx[key] == undefined
+        }).length,
+        0
+    )
 
-	t.deepEquals(Object.keys(mobx.extras).sort(), [
-			'allowStateChanges',
-			'deepEqual',
-			'getAdministration',
-			'getAtom',
-			'getDebugName',
-			'getDependencyTree',
-			'getGlobalState',
-			'getObserverTree',
-			'interceptReads',
-			'isComputingDerivation',
-			'isSpyEnabled',
-			'isolateGlobalState',
-			'onReactionError',
-			'reserveArrayBuffer',
-			'resetGlobalState',
-			'setReactionScheduler',
-			'shareGlobalState',
-			'spyReport',
-			'spyReportEnd',
-			'spyReportStart'
-	].sort());
-	t.equals(Object.keys(mobx.extras).filter(function(key) {
-		return mobx.extras[key] == undefined;
-	}).length, 0);
+    t.deepEquals(
+        Object.keys(mobx.extras).sort(),
+        [
+            "allowStateChanges",
+            "deepEqual",
+            "getAdministration",
+            "getAtom",
+            "getDebugName",
+            "getDependencyTree",
+            "getGlobalState",
+            "getObserverTree",
+            "interceptReads",
+            "isComputingDerivation",
+            "isSpyEnabled",
+            "isolateGlobalState",
+            "onReactionError",
+            "reserveArrayBuffer",
+            "resetGlobalState",
+            "setReactionScheduler",
+            "shareGlobalState",
+            "spyReport",
+            "spyReportEnd",
+            "spyReportStart"
+        ].sort()
+    )
+    t.equals(
+        Object.keys(mobx.extras).filter(function(key) {
+            return mobx.extras[key] == undefined
+        }).length,
+        0
+    )
 
-	t.end();
-});
+    t.end()
+})

--- a/test/array.js
+++ b/test/array.js
@@ -1,479 +1,512 @@
 "use strict"
-var test = require('tape');
-var mobx = require('..');
-var observable = mobx.observable;
-var iterall = require('iterall');
+var test = require("tape")
+var mobx = require("..")
+var observable = mobx.observable
+var iterall = require("iterall")
 
 function buffer() {
-    var b = [];
+    var b = []
     var res = function(newValue) {
-        b.push(newValue);
-    };
-    res.toArray = function() {
-        return b;
+        b.push(newValue)
     }
-    return res;
+    res.toArray = function() {
+        return b
+    }
+    return res
 }
 
-test('test1', function(t) {
-    var a = observable([]);
-    t.equal(a.length, 0);
-    t.deepEqual(Object.keys(a), []);
-    t.deepEqual(a.slice(), []);
+test("test1", function(t) {
+    var a = observable([])
+    t.equal(a.length, 0)
+    t.deepEqual(Object.keys(a), [])
+    t.deepEqual(a.slice(), [])
 
-    a.push(1);
-    t.equal(a.length, 1);
-    t.deepEqual(a.slice(), [1]);
+    a.push(1)
+    t.equal(a.length, 1)
+    t.deepEqual(a.slice(), [1])
 
-    a[1] = 2;
-    t.equal(a.length, 2);
-    t.deepEqual(a.slice(), [1,2]);
+    a[1] = 2
+    t.equal(a.length, 2)
+    t.deepEqual(a.slice(), [1, 2])
 
     var sum = mobx.computed(function() {
-        return -1 + a.reduce(function(a,b) {
-            return a + b;
-        }, 1);
-    });
+        return (
+            -1 +
+            a.reduce(function(a, b) {
+                return a + b
+            }, 1)
+        )
+    })
 
-    t.equal(sum.get(), 3);
+    t.equal(sum.get(), 3)
 
-    a[1] = 3;
-    t.equal(a.length, 2);
-    t.deepEqual(a.slice(), [1,3]);
-    t.equal(sum.get(), 4);
+    a[1] = 3
+    t.equal(a.length, 2)
+    t.deepEqual(a.slice(), [1, 3])
+    t.equal(sum.get(), 4)
 
-    a.splice(1,1,4,5);
-    t.equal(a.length, 3);
-    t.deepEqual(a.slice(), [1,4,5]);
-    t.equal(sum.get(), 10);
+    a.splice(1, 1, 4, 5)
+    t.equal(a.length, 3)
+    t.deepEqual(a.slice(), [1, 4, 5])
+    t.equal(sum.get(), 10)
 
-    a.replace([2,4]);
-    t.equal(sum.get(), 6);
+    a.replace([2, 4])
+    t.equal(sum.get(), 6)
 
-    a.splice(1,1);
-    t.equal(sum.get(), 2);
+    a.splice(1, 1)
+    t.equal(sum.get(), 2)
     t.deepEqual(a.slice(), [2])
 
-	a.spliceWithArray(0,0, [4,3]);
-    t.equal(sum.get(), 9);
-    t.deepEqual(a.slice(), [4,3,2]);
+    a.spliceWithArray(0, 0, [4, 3])
+    t.equal(sum.get(), 9)
+    t.deepEqual(a.slice(), [4, 3, 2])
 
-    a.clear();
-    t.equal(sum.get(), 0);
-    t.deepEqual(a.slice(), []);
+    a.clear()
+    t.equal(sum.get(), 0)
+    t.deepEqual(a.slice(), [])
 
-    a.length = 4;
-    t.equal(isNaN(sum.get()), true);
-    t.deepEqual(a.length, 4);
+    a.length = 4
+    t.equal(isNaN(sum.get()), true)
+    t.deepEqual(a.length, 4)
 
-    t.deepEqual(a.slice(), [undefined, undefined, undefined, undefined]);
+    t.deepEqual(a.slice(), [undefined, undefined, undefined, undefined])
 
-    a.replace([1,2, 2,4]);
-    t.equal(sum.get(), 9);
-    a.length = 4;
-    t.equal(sum.get(), 9);
+    a.replace([1, 2, 2, 4])
+    t.equal(sum.get(), 9)
+    a.length = 4
+    t.equal(sum.get(), 9)
 
+    a.length = 2
+    t.equal(sum.get(), 3)
+    t.deepEqual(a.slice(), [1, 2])
 
-    a.length = 2;
-    t.equal(sum.get(), 3);
-    t.deepEqual(a.slice(), [1,2]);
+    t.deepEqual(a.reverse(), [2, 1])
+    t.deepEqual(a.slice(), [1, 2])
 
-    t.deepEqual(a.reverse(), [2,1]);
-    t.deepEqual(a.slice(), [1,2]);
+    a.unshift(3)
+    t.deepEqual(a.sort(), [1, 2, 3])
+    t.deepEqual(a.slice(), [3, 1, 2])
 
-    a.unshift(3);
-    t.deepEqual(a.sort(), [1,2,3]);
-    t.deepEqual(a.slice(), [3,1,2]);
+    t.equal(JSON.stringify(a), "[3,1,2]")
 
-	t.equal(JSON.stringify(a), "[3,1,2]");
+    t.equal(a.get(1), 1)
+    a.set(2, 4)
+    t.equal(a.get(2), 4)
 
-	t.equal(a.get(1), 1);
-	a.set(2, 4);
-	t.equal(a.get(2), 4);
+    //	t.deepEqual(Object.keys(a), ['0', '1', '2']); // ideally....
+    t.deepEqual(Object.keys(a), [])
 
-//	t.deepEqual(Object.keys(a), ['0', '1', '2']); // ideally....
-	t.deepEqual(Object.keys(a), []);
-
-    t.end();
+    t.end()
 })
 
-test('array should support iterall / iterable ', t => {
-	var a = observable([1,2,3])
+test("array should support iterall / iterable ", t => {
+    var a = observable([1, 2, 3])
 
-	t.equal(iterall.isIterable(a), true);
-	t.equal(iterall.isArrayLike(a), true);
+    t.equal(iterall.isIterable(a), true)
+    t.equal(iterall.isArrayLike(a), true)
 
-	var values = [];
-	iterall.forEach(a, v => values.push(v))
+    var values = []
+    iterall.forEach(a, v => values.push(v))
 
-	t.deepEqual(values, [1,2,3])
+    t.deepEqual(values, [1, 2, 3])
 
-	var iter = iterall.getIterator(a)
-	t.deepEqual(iter.next(), { value: 1, done: false })
-	t.deepEqual(iter.next(), { value: 2, done: false })
-	t.deepEqual(iter.next(), { value: 3, done: false })
-	t.deepEqual(iter.next(), { value: undefined, done: true })
+    var iter = iterall.getIterator(a)
+    t.deepEqual(iter.next(), { value: 1, done: false })
+    t.deepEqual(iter.next(), { value: 2, done: false })
+    t.deepEqual(iter.next(), { value: 3, done: false })
+    t.deepEqual(iter.next(), { value: undefined, done: true })
 
-	a.replace([])
-	iter = iterall.getIterator(a)
-	t.deepEqual(iter.next(), { value: undefined, done: true })
+    a.replace([])
+    iter = iterall.getIterator(a)
+    t.deepEqual(iter.next(), { value: undefined, done: true })
 
-	t.end()
+    t.end()
 })
 
-test('find(findIndex) and remove', function(t) {
-    var a = mobx.observable([10,20,20]);
-    var idx = -1;
+test("find(findIndex) and remove", function(t) {
+    var a = mobx.observable([10, 20, 20])
+    var idx = -1
     function predicate(item, index) {
         if (item === 20) {
-            idx = index;
-            return true;
+            idx = index
+            return true
         }
-        return false;
+        return false
     }
 
-    t.equal(a.find(predicate), 20);
-    t.equal(idx, 1);
-    t.equal(a.findIndex(predicate), 1);
-    t.equal(a.find(predicate, null, 1), 20);
-    t.equal(idx, 1);
-    t.equal(a.findIndex(predicate, null, 1), 1);
-    t.equal(a.find(predicate, null, 2), 20);
-    t.equal(idx, 2);
-    t.equal(a.findIndex(predicate, null, 2), 2);
-    idx = -1;
-    t.equal(a.find(predicate, null, 3), undefined);
-    t.equal(idx, -1);
-    t.equal(a.findIndex(predicate, null, 3), -1);
+    t.equal(a.find(predicate), 20)
+    t.equal(idx, 1)
+    t.equal(a.findIndex(predicate), 1)
+    t.equal(a.find(predicate, null, 1), 20)
+    t.equal(idx, 1)
+    t.equal(a.findIndex(predicate, null, 1), 1)
+    t.equal(a.find(predicate, null, 2), 20)
+    t.equal(idx, 2)
+    t.equal(a.findIndex(predicate, null, 2), 2)
+    idx = -1
+    t.equal(a.find(predicate, null, 3), undefined)
+    t.equal(idx, -1)
+    t.equal(a.findIndex(predicate, null, 3), -1)
 
-    t.equal(a.remove(20), true);
-    t.equal(a.find(predicate), 20);
-    t.equal(idx, 1);
-    t.equal(a.findIndex(predicate), 1);
-    idx = -1;
-    t.equal(a.remove(20), true);
-    t.equal(a.find(predicate), undefined);
-    t.equal(idx, -1);
-    t.equal(a.findIndex(predicate), -1);
+    t.equal(a.remove(20), true)
+    t.equal(a.find(predicate), 20)
+    t.equal(idx, 1)
+    t.equal(a.findIndex(predicate), 1)
+    idx = -1
+    t.equal(a.remove(20), true)
+    t.equal(a.find(predicate), undefined)
+    t.equal(idx, -1)
+    t.equal(a.findIndex(predicate), -1)
 
-    t.equal(a.remove(20), false);
+    t.equal(a.remove(20), false)
 
-    t.end();
+    t.end()
 })
 
-test('concat should automatically slice observable arrays, #260', t => {
-	var a1 = mobx.observable([1,2])
-	var a2 = mobx.observable([3,4])
-	t.deepEqual(a1.concat(a2), [1,2,3,4])
-	t.end()
+test("concat should automatically slice observable arrays, #260", t => {
+    var a1 = mobx.observable([1, 2])
+    var a2 = mobx.observable([3, 4])
+    t.deepEqual(a1.concat(a2), [1, 2, 3, 4])
+    t.end()
 })
 
-test('observe', function(t) {
-    var ar = mobx.observable([1,4]);
-    var buf = [];
+test("observe", function(t) {
+    var ar = mobx.observable([1, 4])
+    var buf = []
     var disposer = ar.observe(function(changes) {
-        buf.push(changes);
-    }, true);
+        buf.push(changes)
+    }, true)
 
-    ar[1] = 3; // 1,3
-    ar[2] = 0; // 1, 3, 0
-    ar.shift(); // 3, 0
-    ar.push(1,2); // 3, 0, 1, 2
-    ar.splice(1,2,3,4); // 3, 3, 4, 2
-    t.deepEqual(ar.slice(), [3,3,4,2]);
-    ar.splice(6);
-    ar.splice(6,2);
-    ar.replace(['a']);
-    ar.pop();
-    ar.pop(); // does not fire anything
+    ar[1] = 3 // 1,3
+    ar[2] = 0 // 1, 3, 0
+    ar.shift() // 3, 0
+    ar.push(1, 2) // 3, 0, 1, 2
+    ar.splice(1, 2, 3, 4) // 3, 3, 4, 2
+    t.deepEqual(ar.slice(), [3, 3, 4, 2])
+    ar.splice(6)
+    ar.splice(6, 2)
+    ar.replace(["a"])
+    ar.pop()
+    ar.pop() // does not fire anything
 
     // check the object param
     buf.forEach(function(change) {
-        t.equal(change.object, ar);
-        delete change.object;
-    });
+        t.equal(change.object, ar)
+        delete change.object
+    })
 
     var result = [
         { type: "splice", index: 0, addedCount: 2, removed: [], added: [1, 4], removedCount: 0 },
         { type: "update", index: 1, oldValue: 4, newValue: 3 },
         { type: "splice", index: 2, addedCount: 1, removed: [], added: [0], removedCount: 0 },
         { type: "splice", index: 0, addedCount: 0, removed: [1], added: [], removedCount: 1 },
-        { type: "splice", index: 2, addedCount: 2, removed: [], added: [1,2], removedCount: 0 },
-        { type: "splice", index: 1, addedCount: 2, removed: [0,1], added: [3, 4], removedCount: 2 },
-        { type: "splice", index: 0, addedCount: 1, removed: [3,3,4,2], added:['a'], removedCount: 4 },
-        { type: "splice", index: 0, addedCount: 0, removed: ['a'], added: [], removedCount: 1 },
+        { type: "splice", index: 2, addedCount: 2, removed: [], added: [1, 2], removedCount: 0 },
+        {
+            type: "splice",
+            index: 1,
+            addedCount: 2,
+            removed: [0, 1],
+            added: [3, 4],
+            removedCount: 2
+        },
+        {
+            type: "splice",
+            index: 0,
+            addedCount: 1,
+            removed: [3, 3, 4, 2],
+            added: ["a"],
+            removedCount: 4
+        },
+        { type: "splice", index: 0, addedCount: 0, removed: ["a"], added: [], removedCount: 1 }
     ]
 
-    t.deepEqual(buf, result);
+    t.deepEqual(buf, result)
 
-    disposer();
-    ar[0] = 5;
-    t.deepEqual(buf, result);
+    disposer()
+    ar[0] = 5
+    t.deepEqual(buf, result)
 
-    t.end();
+    t.end()
 })
 
-test('array modification1', function(t) {
-    var a = mobx.observable([1,2,3]);
-    var r = a.splice(-10, 5, 4,5,6);
-    t.deepEqual(a.slice(), [4,5,6]);
-    t.deepEqual(r, [1,2,3]);
-    t.end();
+test("array modification1", function(t) {
+    var a = mobx.observable([1, 2, 3])
+    var r = a.splice(-10, 5, 4, 5, 6)
+    t.deepEqual(a.slice(), [4, 5, 6])
+    t.deepEqual(r, [1, 2, 3])
+    t.end()
 })
 
-test('serialize', function(t) {
-    var a = [1,2,3];
-    var m = mobx.observable(a);
+test("serialize", function(t) {
+    var a = [1, 2, 3]
+    var m = mobx.observable(a)
 
-    t.deepEqual(JSON.stringify(m), JSON.stringify(a));
-    t.deepEqual(a, m.peek());
+    t.deepEqual(JSON.stringify(m), JSON.stringify(a))
+    t.deepEqual(a, m.peek())
 
-    a = [4];
-    m.replace(a);
-    t.deepEqual(JSON.stringify(m), JSON.stringify(a));
-    t.deepEqual(a, m.toJSON());
+    a = [4]
+    m.replace(a)
+    t.deepEqual(JSON.stringify(m), JSON.stringify(a))
+    t.deepEqual(a, m.toJSON())
 
-    t.end();
+    t.end()
 })
 
-test('array modification functions', function(t) {
-    var ars = [[], [1,2,3]];
-    var funcs = ["push","pop","shift","unshift"];
+test("array modification functions", function(t) {
+    var ars = [[], [1, 2, 3]]
+    var funcs = ["push", "pop", "shift", "unshift"]
     funcs.forEach(function(f) {
-        ars.forEach(function (ar) {
-            var a = ar.slice();
-            var b = mobx.observable(a);
-            var res1 = a[f](4);
-            var res2 = b[f](4);
-            t.deepEqual(res1, res2);
-            t.deepEqual(a, b.slice());
-        });
-    });
-    t.end();
+        ars.forEach(function(ar) {
+            var a = ar.slice()
+            var b = mobx.observable(a)
+            var res1 = a[f](4)
+            var res2 = b[f](4)
+            t.deepEqual(res1, res2)
+            t.deepEqual(a, b.slice())
+        })
+    })
+    t.end()
 })
 
-test('array modifications', function(t) {
-
-    var a2 = mobx.observable([]);
-    var inputs = [undefined, -10, -4, -3, -1, 0, 1, 3, 4, 10];
-    var arrays = [[], [1], [1,2,3,4], [1,2,3,4,5,6,7,8,9,10,11],[1,undefined],[undefined]]
+test("array modifications", function(t) {
+    var a2 = mobx.observable([])
+    var inputs = [undefined, -10, -4, -3, -1, 0, 1, 3, 4, 10]
+    var arrays = [
+        [],
+        [1],
+        [1, 2, 3, 4],
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        [1, undefined],
+        [undefined]
+    ]
     for (var i = 0; i < inputs.length; i++)
-    for (var j = 0; j< inputs.length; j++)
-    for (var k = 0; k < arrays.length; k++)
-    for (var l = 0; l < arrays.length; l++) {
-        var msg = ["array mod: [", arrays[k].toString(),"] i: ",inputs[i]," d: ", inputs[j]," [", arrays[l].toString(),"]"].join(' ');
-        var a1 = arrays[k].slice();
-        a2.replace(a1);
-        var res1 = a1.splice.apply(a1, [inputs[i], inputs[j]].concat(arrays[l]));
-        var res2 = a2.splice.apply(a2, [inputs[i], inputs[j]].concat(arrays[l]));
-        t.deepEqual(a1.slice(), a2.slice(), "values wrong: " + msg);
-        t.deepEqual(res1, res2, "results wrong: " + msg);
-        t.equal(a1.length, a2.length, "length wrong: " + msg);
-    }
+        for (var j = 0; j < inputs.length; j++)
+            for (var k = 0; k < arrays.length; k++)
+                for (var l = 0; l < arrays.length; l++) {
+                    var msg = [
+                        "array mod: [",
+                        arrays[k].toString(),
+                        "] i: ",
+                        inputs[i],
+                        " d: ",
+                        inputs[j],
+                        " [",
+                        arrays[l].toString(),
+                        "]"
+                    ].join(" ")
+                    var a1 = arrays[k].slice()
+                    a2.replace(a1)
+                    var res1 = a1.splice.apply(a1, [inputs[i], inputs[j]].concat(arrays[l]))
+                    var res2 = a2.splice.apply(a2, [inputs[i], inputs[j]].concat(arrays[l]))
+                    t.deepEqual(a1.slice(), a2.slice(), "values wrong: " + msg)
+                    t.deepEqual(res1, res2, "results wrong: " + msg)
+                    t.equal(a1.length, a2.length, "length wrong: " + msg)
+                }
 
-    t.end();
+    t.end()
 })
 
-test('is array', function(t) {
-    var x = mobx.observable([]);
-    t.equal(x instanceof Array, true);
+test("is array", function(t) {
+    var x = mobx.observable([])
+    t.equal(x instanceof Array, true)
 
     // would be cool if this would return true...
-    t.equal(Array.isArray(x), false);
-    t.end();
+    t.equal(Array.isArray(x), false)
+    t.end()
 })
 
-test('stringifies same as ecma array', function(t) {
-    const x = mobx.observable([]);
-    t.equal(x instanceof Array, true);
+test("stringifies same as ecma array", function(t) {
+    const x = mobx.observable([])
+    t.equal(x instanceof Array, true)
 
     // would be cool if these two would return true...
-	t.equal(x.toString(), "");
-	t.equal(x.toLocaleString(), "");
-	x.push(1, 2)
-	t.equal(x.toString(), "1,2");
-	t.equal(x.toLocaleString(), "1,2");
-    t.end();
+    t.equal(x.toString(), "")
+    t.equal(x.toLocaleString(), "")
+    x.push(1, 2)
+    t.equal(x.toString(), "1,2")
+    t.equal(x.toLocaleString(), "1,2")
+    t.end()
 })
 
-test("observes when stringified", function (t) {
-	const x = mobx.observable([]);
-	let c = 0;
-	mobx.autorun(function() {
-        x.toString();
-		c++;
-    });
-	x.push(1);
-	t.equal(c, 2);
-	t.end();
+test("observes when stringified", function(t) {
+    const x = mobx.observable([])
+    let c = 0
+    mobx.autorun(function() {
+        x.toString()
+        c++
+    })
+    x.push(1)
+    t.equal(c, 2)
+    t.end()
 })
 
-test("observes when stringified to locale", function (t) {
-	const x = mobx.observable([]);
-	let c = 0;
-	mobx.autorun(function() {
-        x.toLocaleString();
-		c++;
-    });
-	x.push(1);
-	t.equal(c, 2);
-	t.end();
+test("observes when stringified to locale", function(t) {
+    const x = mobx.observable([])
+    let c = 0
+    mobx.autorun(function() {
+        x.toLocaleString()
+        c++
+    })
+    x.push(1)
+    t.equal(c, 2)
+    t.end()
 })
 
-test('peek', function(t) {
-    var x = mobx.observable([1, 2, 3]);
-    t.deepEqual(x.peek(), [1, 2, 3]);
-    t.equal(x.$mobx.values, x.peek());
+test("peek", function(t) {
+    var x = mobx.observable([1, 2, 3])
+    t.deepEqual(x.peek(), [1, 2, 3])
+    t.equal(x.$mobx.values, x.peek())
 
-    x.peek().push(4); //noooo!
+    x.peek().push(4) //noooo!
     t.throws(function() {
-        x.push(5); // detect alien change
-    }, "modification exception");
-    t.end();
+        x.push(5) // detect alien change
+    }, "modification exception")
+    t.end()
 })
 
-test('react to sort changes', function(t) {
-    var x = mobx.observable([4, 2, 3]);
+test("react to sort changes", function(t) {
+    var x = mobx.observable([4, 2, 3])
     var sortedX = mobx.computed(function() {
-        return x.sort();
-    });
-    var sorted;
+        return x.sort()
+    })
+    var sorted
 
     mobx.autorun(function() {
-        sorted = sortedX.get();
-    });
+        sorted = sortedX.get()
+    })
 
-    t.deepEqual(x.slice(), [4,2,3]);
-    t.deepEqual(sorted, [2,3,4]);
-    x.push(1);
-    t.deepEqual(x.slice(), [4,2,3,1]);
-    t.deepEqual(sorted, [1,2,3,4]);
-    x.shift();
-    t.deepEqual(x.slice(), [2,3,1]);
-    t.deepEqual(sorted, [1,2,3]);
-    t.end();
+    t.deepEqual(x.slice(), [4, 2, 3])
+    t.deepEqual(sorted, [2, 3, 4])
+    x.push(1)
+    t.deepEqual(x.slice(), [4, 2, 3, 1])
+    t.deepEqual(sorted, [1, 2, 3, 4])
+    x.shift()
+    t.deepEqual(x.slice(), [2, 3, 1])
+    t.deepEqual(sorted, [1, 2, 3])
+    t.end()
 })
 
-test('autoextend buffer length', function(t) {
-	var ar = observable(new Array(1000));
-	var changesCount = 0;
-	ar.observe(changes => ++changesCount);
+test("autoextend buffer length", function(t) {
+    var ar = observable(new Array(1000))
+    var changesCount = 0
+    ar.observe(changes => ++changesCount)
 
-	ar[ar.length] = 0;
-	ar.push(0);
+    ar[ar.length] = 0
+    ar.push(0)
 
-	t.equal(changesCount, 2);
+    t.equal(changesCount, 2)
 
-	t.end();
+    t.end()
 })
 
-test('array exposes correct keys', t => {
-	var keys = []
-	var ar = observable([1,2])
-	for (var key in ar)
-		keys.push(key)
+test("array exposes correct keys", t => {
+    var keys = []
+    var ar = observable([1, 2])
+    for (var key in ar) keys.push(key)
 
-	t.deepEqual(keys, [])
-	t.end()
+    t.deepEqual(keys, [])
+    t.end()
 })
 
-test('isArrayLike', t => {
-	var arr = [0, 1, 2];
-	var observableArr = observable(arr);
+test("isArrayLike", t => {
+    var arr = [0, 1, 2]
+    var observableArr = observable(arr)
 
-	var isArrayLike = mobx.isArrayLike;
-	t.equal(typeof isArrayLike, "function");
+    var isArrayLike = mobx.isArrayLike
+    t.equal(typeof isArrayLike, "function")
 
-	t.equal(isArrayLike(observableArr), true);
-	t.equal(isArrayLike(arr), true);
-	t.equal(isArrayLike(42), false);
-	t.equal(isArrayLike({}), false);
+    t.equal(isArrayLike(observableArr), true)
+    t.equal(isArrayLike(arr), true)
+    t.equal(isArrayLike(42), false)
+    t.equal(isArrayLike({}), false)
 
-	t.end();
-});
+    t.end()
+})
 
-test('.move throws on invalid indices', t => {
-	const arr = [0, 1, 2];
-	const observableArr = observable(arr);
+test(".move throws on invalid indices", t => {
+    const arr = [0, 1, 2]
+    const observableArr = observable(arr)
 
-	t.throws(() => observableArr.move(-1, 0), /Index out of bounds: -1 is negative/);
-	t.throws(() => observableArr.move(3, 0), /Index out of bounds: 3 is not smaller than 3/);
-	t.throws(() => observableArr.move(0, -1), /Index out of bounds: -1 is negative/);
-	t.throws(() => observableArr.move(0, 3), /Index out of bounds: 3 is not smaller than 3/);
+    t.throws(() => observableArr.move(-1, 0), /Index out of bounds: -1 is negative/)
+    t.throws(() => observableArr.move(3, 0), /Index out of bounds: 3 is not smaller than 3/)
+    t.throws(() => observableArr.move(0, -1), /Index out of bounds: -1 is negative/)
+    t.throws(() => observableArr.move(0, 3), /Index out of bounds: 3 is not smaller than 3/)
 
-	t.end();
-});
+    t.end()
+})
 
-test('.move(i, i) does nothing', t => {
-	const arr = [0, 1, 2];
-	const observableArr = observable(arr);
-	var changesCount = 0;
-	observableArr.observe(changes => ++changesCount);
+test(".move(i, i) does nothing", t => {
+    const arr = [0, 1, 2]
+    const observableArr = observable(arr)
+    var changesCount = 0
+    observableArr.observe(changes => ++changesCount)
 
-	observableArr.move(0, 0);
+    observableArr.move(0, 0)
 
-	t.equal(0, changesCount);
+    t.equal(0, changesCount)
 
-	t.end();
-});
+    t.end()
+})
 
-test('.move works correctly', t => {
-	const arr = [0, 1, 2, 3];
+test(".move works correctly", t => {
+    const arr = [0, 1, 2, 3]
 
-	function checkMove(fromIndex, toIndex, expected) {
-		const oa = observable(arr);
-		var changesCount = 0;
-		oa.observe(changes => ++changesCount);
-		oa.move(fromIndex, toIndex);
-		t.deepEqual(oa.slice(), expected, ".move(" + fromIndex + ", " + toIndex + ")");
-		t.equal(changesCount, 1);
-	}
+    function checkMove(fromIndex, toIndex, expected) {
+        const oa = observable(arr)
+        var changesCount = 0
+        oa.observe(changes => ++changesCount)
+        oa.move(fromIndex, toIndex)
+        t.deepEqual(oa.slice(), expected, ".move(" + fromIndex + ", " + toIndex + ")")
+        t.equal(changesCount, 1)
+    }
 
-	checkMove(0, 1, [1, 0, 2, 3]);
-	checkMove(0, 2, [1, 2, 0, 3]);
-	checkMove(1, 2, [0, 2, 1, 3]);
-	checkMove(2, 3, [0, 1, 3, 2]);
-	checkMove(0, 3, [1, 2, 3, 0]);
+    checkMove(0, 1, [1, 0, 2, 3])
+    checkMove(0, 2, [1, 2, 0, 3])
+    checkMove(1, 2, [0, 2, 1, 3])
+    checkMove(2, 3, [0, 1, 3, 2])
+    checkMove(0, 3, [1, 2, 3, 0])
 
-	checkMove(1, 0, [1, 0, 2, 3]);
-	checkMove(2, 0, [2, 0, 1, 3]);
-	checkMove(2, 1, [0, 2, 1, 3]);
-	checkMove(3, 1, [0, 3, 1, 2]);
-	checkMove(3, 0, [3, 0, 1, 2]);
+    checkMove(1, 0, [1, 0, 2, 3])
+    checkMove(2, 0, [2, 0, 1, 3])
+    checkMove(2, 1, [0, 2, 1, 3])
+    checkMove(3, 1, [0, 3, 1, 2])
+    checkMove(3, 0, [3, 0, 1, 2])
 
-	t.end();
-});
+    t.end()
+})
 
 test("accessing out of bound values throws", t => {
-	const a = mobx.observable([]);
+    const a = mobx.observable([])
 
-	var warns = 0;
-	const baseWarn = console.warn;
-	console.warn = () => { warns++ }
+    var warns = 0
+    const baseWarn = console.warn
+    console.warn = () => {
+        warns++
+    }
 
-	a[0]; // out of bounds
-	a[1]; // out of bounds
+    a[0] // out of bounds
+    a[1] // out of bounds
 
-	t.equal(warns, 2);
+    t.equal(warns, 2)
 
-	t.doesNotThrow(() => a[0] = 3);
-	t.throws(() => a[2] = 4);
+    t.doesNotThrow(() => (a[0] = 3))
+    t.throws(() => (a[2] = 4))
 
-	console.warn = baseWarn;
-	t.end();
+    console.warn = baseWarn
+    t.end()
 })
 
 test("replace can handle large arrays", t => {
-	const a = mobx.observable([])
-	const b = []
-	b.length = 1000*1000
-	t.doesNotThrow(() => {
-		a.replace(b)
-	})
+    const a = mobx.observable([])
+    const b = []
+    b.length = 1000 * 1000
+    t.doesNotThrow(() => {
+        a.replace(b)
+    })
 
-	t.doesNotThrow(() => {
-		a.spliceWithArray(0, 0, b)
-	})
+    t.doesNotThrow(() => {
+        a.spliceWithArray(0, 0, b)
+    })
 
-	t.end()
+    t.end()
 })

--- a/test/autorun.js
+++ b/test/autorun.js
@@ -1,104 +1,103 @@
-var test = require('tape');
-var m = require('..');
+var test = require("tape")
+var m = require("..")
 
-test('autorun passes Reaction as an argument to view function', function(t) {
-	var a = m.observable(1);
-	var values = [];
+test("autorun passes Reaction as an argument to view function", function(t) {
+    var a = m.observable(1)
+    var values = []
 
-	m.autorun(r => {
-		t.equal(typeof r.dispose, 'function');
-		if (a.get() === 'pleaseDispose') r.dispose();
-		values.push(a.get());
-	});
+    m.autorun(r => {
+        t.equal(typeof r.dispose, "function")
+        if (a.get() === "pleaseDispose") r.dispose()
+        values.push(a.get())
+    })
 
-	a.set(2);
-	a.set(2);
-	a.set('pleaseDispose');
-	a.set(3);
-	a.set(4);
+    a.set(2)
+    a.set(2)
+    a.set("pleaseDispose")
+    a.set(3)
+    a.set(4)
 
-	t.deepEqual(values, [1, 2, 'pleaseDispose']);
+    t.deepEqual(values, [1, 2, "pleaseDispose"])
 
-	t.end()
-});
-
-test('autorun can be disposed on first run', function(t) {
-	var a = m.observable(1);
-	var values = [];
-
-	m.autorun(r => {
-		r.dispose();
-		values.push(a.get());
-	});
-
-	a.set(2);
-
-	t.deepEqual(values, [1]);
-
-	t.end()
-});
-
-test('autorun warns when passed an action', function(t) {
-	var action = m.action(() => {});
-	t.plan(1);
-	t.throws(() => m.autorun(action), /attempted to pass an action to autorun/);
-	t.end();
-});
-
-test('autorun batches automatically', function(t) {
-	var runs = 0;
-	var a1runs = 0;
-	var a2runs = 0;
-
-	var x = m.observable({
-		a: 1,
-		b: 1,
-		c: 1,
-		get d() {
-			runs++
-			return this.c + this.b
-		}
-	})
-
-	var d1 = m.autorun(() => {
-		a1runs++
-		x.d; // read
-	})
-
-	var d2 = m.autorun(() => {
-		a2runs++
-		x.b = x.a
-		x.c = x.a
-	})
-
-	t.equal(a1runs, 1)
-	t.equal(a2runs, 1)
-	t.equal(runs, 1)
-
-	x.a = 17
-
-	t.equal(a1runs, 2)
-	t.equal(a2runs, 2)
-	t.equal(runs, 2)
-
-	d1()
-	d2()
-	t.end();
+    t.end()
 })
 
+test("autorun can be disposed on first run", function(t) {
+    var a = m.observable(1)
+    var values = []
 
-test('autorun tracks invalidation of unbound dependencies', function(t) {
-	var a = m.observable(0);
-	var b = m.observable(0);
-	var c = m.computed(() => a.get() + b.get());
-	var values = [];
+    m.autorun(r => {
+        r.dispose()
+        values.push(a.get())
+    })
 
-	m.autorun(() => {
-		values.push(c.get());
-		b.set(100);
-	});
+    a.set(2)
 
-	a.set(1);
-	t.deepEqual(values, [0, 100, 101]);
-	t.end();
+    t.deepEqual(values, [1])
+
+    t.end()
+})
+
+test("autorun warns when passed an action", function(t) {
+    var action = m.action(() => {})
+    t.plan(1)
+    t.throws(() => m.autorun(action), /attempted to pass an action to autorun/)
+    t.end()
+})
+
+test("autorun batches automatically", function(t) {
+    var runs = 0
+    var a1runs = 0
+    var a2runs = 0
+
+    var x = m.observable({
+        a: 1,
+        b: 1,
+        c: 1,
+        get d() {
+            runs++
+            return this.c + this.b
+        }
+    })
+
+    var d1 = m.autorun(() => {
+        a1runs++
+        x.d // read
+    })
+
+    var d2 = m.autorun(() => {
+        a2runs++
+        x.b = x.a
+        x.c = x.a
+    })
+
+    t.equal(a1runs, 1)
+    t.equal(a2runs, 1)
+    t.equal(runs, 1)
+
+    x.a = 17
+
+    t.equal(a1runs, 2)
+    t.equal(a2runs, 2)
+    t.equal(runs, 2)
+
+    d1()
+    d2()
+    t.end()
+})
+
+test("autorun tracks invalidation of unbound dependencies", function(t) {
+    var a = m.observable(0)
+    var b = m.observable(0)
+    var c = m.computed(() => a.get() + b.get())
+    var values = []
+
+    m.autorun(() => {
+        values.push(c.get())
+        b.set(100)
+    })
+
+    a.set(1)
+    t.deepEqual(values, [0, 100, 101])
+    t.end()
 })

--- a/test/autorunAsync.js
+++ b/test/autorunAsync.js
@@ -1,134 +1,137 @@
-var test = require('tape');
-var m = require('..');
+var test = require("tape")
+var m = require("..")
 
-test('autorun 1', function(t) {
-	var _fired = 0;
-	var _result = null;
-	var _cCalcs = 0;
-	var to = setTimeout;
+test("autorun 1", function(t) {
+    var _fired = 0
+    var _result = null
+    var _cCalcs = 0
+    var to = setTimeout
 
-	function expect(fired, cCalcs, result) {
-		t.equal(_fired, fired, "autorun fired");
-		t.equal(_cCalcs, cCalcs, "'c' fired");
-		if (fired)
-			t.equal(_result, result, "result");
-		_fired = 0;
-		_cCalcs = 0;
-	}
+    function expect(fired, cCalcs, result) {
+        t.equal(_fired, fired, "autorun fired")
+        t.equal(_cCalcs, cCalcs, "'c' fired")
+        if (fired) t.equal(_result, result, "result")
+        _fired = 0
+        _cCalcs = 0
+    }
 
-	var a = m.observable(2);
-	var b = m.observable(3);
-	var c = m.computed(function() {
-		_cCalcs++;
-		return a.get() * b.get();
-	});
-	var d = m.observable(1);
-	var autorun = function() {
-		_fired++;
-		_result = d.get() > 0 ? a.get() * c.get() : d.get();
-	};
-	var disp = m.autorunAsync(autorun, 20);
+    var a = m.observable(2)
+    var b = m.observable(3)
+    var c = m.computed(function() {
+        _cCalcs++
+        return a.get() * b.get()
+    })
+    var d = m.observable(1)
+    var autorun = function() {
+        _fired++
+        _result = d.get() > 0 ? a.get() * c.get() : d.get()
+    }
+    var disp = m.autorunAsync(autorun, 20)
 
-	expect(0, 0, null);
-	disp();
-	to(function() {
-		expect(0, 0, null);
-		disp = m.autorunAsync(autorun, 20);
+    expect(0, 0, null)
+    disp()
+    to(function() {
+        expect(0, 0, null)
+        disp = m.autorunAsync(autorun, 20)
 
-		to(function() {
-			expect(1, 1, 12);
-			a.set(4);
-			b.set(5);
-			a.set(6);
-			expect(0, 0, null); // a change triggered async rerun, compute will trigger after 20ms of async timeout
-			to(function() {
-				expect(1, 1, 180);
-				d.set(2);
+        to(function() {
+            expect(1, 1, 12)
+            a.set(4)
+            b.set(5)
+            a.set(6)
+            expect(0, 0, null) // a change triggered async rerun, compute will trigger after 20ms of async timeout
+            to(function() {
+                expect(1, 1, 180)
+                d.set(2)
 
-				to(function() {
-					expect(1, 0, 180);
+                to(function() {
+                    expect(1, 0, 180)
 
-					d.set(-2);
-					to(function() {
-						expect(1, 0, -2);
+                    d.set(-2)
+                    to(function() {
+                        expect(1, 0, -2)
 
-						a.set(7);
-						to(function() {
-							expect(0, 0, 0); // change a has no effect
+                        a.set(7)
+                        to(function() {
+                            expect(0, 0, 0) // change a has no effect
 
-							a.set(4);
-							b.set(2);
-							d.set(2)
+                            a.set(4)
+                            b.set(2)
+                            d.set(2)
 
-							to(function() {
-								expect(1, 1, 32);
+                            to(function() {
+                                expect(1, 1, 32)
 
-								disp();
-								a.set(1);
-								b.set(2);
-								d.set(4);
-								to(function() {
-									expect(0, 0, 0);
-									t.end();
-								},30)
-							}, 30);
-						}, 30);
-					}, 30);
-				}, 30);
-			}, 30);
-		}, 30);
-	}, 30);
-});
+                                disp()
+                                a.set(1)
+                                b.set(2)
+                                d.set(4)
+                                to(function() {
+                                    expect(0, 0, 0)
+                                    t.end()
+                                }, 30)
+                            }, 30)
+                        }, 30)
+                    }, 30)
+                }, 30)
+            }, 30)
+        }, 30)
+    }, 30)
+})
 
-test('autorun should not result in loop', function(t) {
-	var i = 0;
-	var a = m.observable({
-		x: i
-	});
+test("autorun should not result in loop", function(t) {
+    var i = 0
+    var a = m.observable({
+        x: i
+    })
 
-	var autoRunsCalled = 0;
-	var d = m.autorunAsync("named async", function() {
-		autoRunsCalled++;
-		a.x = ++i;
-		setTimeout(function() {
-			a.x = ++i;
-		}, 10);
-	}, 10);
+    var autoRunsCalled = 0
+    var d = m.autorunAsync(
+        "named async",
+        function() {
+            autoRunsCalled++
+            a.x = ++i
+            setTimeout(function() {
+                a.x = ++i
+            }, 10)
+        },
+        10
+    )
 
-	setTimeout(function() {
-		t.equal(autoRunsCalled, 1);
-		t.end();
+    setTimeout(function() {
+        t.equal(autoRunsCalled, 1)
+        t.end()
 
-		t.equal(d.$mobx.name, "named async");
-		d();
-	}, 100);
-});
+        t.equal(d.$mobx.name, "named async")
+        d()
+    }, 100)
+})
 
-test('autorunAsync passes Reaction as an argument to view function', function(t) {
-	var a = m.observable(1);
+test("autorunAsync passes Reaction as an argument to view function", function(t) {
+    var a = m.observable(1)
 
-	var autoRunsCalled = 0;
+    var autoRunsCalled = 0
 
-	m.autorunAsync(r => {
-		t.equal(typeof r.dispose, 'function');
-		autoRunsCalled++;
-		if (a.get() === 'pleaseDispose') r.dispose();
-	}, 10);
+    m.autorunAsync(r => {
+        t.equal(typeof r.dispose, "function")
+        autoRunsCalled++
+        if (a.get() === "pleaseDispose") r.dispose()
+    }, 10)
 
-	setTimeout(() => a.set(2), 250);
-	setTimeout(() => a.set('pleaseDispose'), 400);
-	setTimeout(() => a.set(3), 550);
-	setTimeout(() => a.set(4), 700);
+    setTimeout(() => a.set(2), 250)
+    setTimeout(() => a.set("pleaseDispose"), 400)
+    setTimeout(() => a.set(3), 550)
+    setTimeout(() => a.set(4), 700)
 
-	setTimeout(function() {
-		t.equal(autoRunsCalled, 3);
-		t.end();
-	}, 1000);
-});
+    setTimeout(function() {
+        t.equal(autoRunsCalled, 3)
+        t.end()
+    }, 1000)
+})
 
-test('autorunAsync warns when passed an action', function(t) {
-	var action = m.action(() => {});
-	t.plan(1);
-	t.throws(() => m.autorunAsync(action), /attempted to pass an action to autorunAsync/);
-	t.end();
-});
+test("autorunAsync warns when passed an action", function(t) {
+    var action = m.action(() => {})
+    t.plan(1)
+    t.throws(() => m.autorunAsync(action), /attempted to pass an action to autorunAsync/)
+    t.end()
+})

--- a/test/babel/babel-tests.js
+++ b/test/babel/babel-tests.js
@@ -1,910 +1,964 @@
 import {
-    observable, computed, transaction, autorun, extendObservable, action,
-	isObservableObject, observe, isObservable, spy, isAction, useStrict
-} from "../";
+    observable,
+    computed,
+    transaction,
+    autorun,
+    extendObservable,
+    action,
+    isObservableObject,
+    observe,
+    isObservable,
+    spy,
+    isAction,
+    useStrict
+} from "../"
 import * as mobx from "../"
 
-var test = require('tape')
+var test = require("tape")
 
 class Box {
-    @observable uninitialized;
-    @observable height = 20;
-    @observable sizes = [2];
-    @observable someFunc = function () { return 2; };
-    @computed get width() {
-        return this.height * this.sizes.length * this.someFunc() * (this.uninitialized ? 2 : 1);
+    @observable uninitialized
+    @observable height = 20
+    @observable sizes = [2]
+    @observable
+    someFunc = function() {
+        return 2
+    }
+    @computed
+    get width() {
+        return this.height * this.sizes.length * this.someFunc() * (this.uninitialized ? 2 : 1)
     }
 }
 
-var box = new Box();
+var box = new Box()
 
 var ar = []
 
 autorun(() => {
-    ar.push(box.width);
-});
-
-
-test('babel', function (t) {
-  var s = ar.slice()
-  t.deepEqual(s, [40])
-  box.height = 10
-  s = ar.slice()
-  t.deepEqual(s, [40, 20])
-  box.sizes.push(3, 4)
-  s = ar.slice()
-  t.deepEqual(s, [40, 20, 60])
-  box.someFunc = () => 7
-  s = ar.slice()
-  t.deepEqual(s, [40, 20, 60, 210])
-  box.uninitialized = true
-  s = ar.slice()
-  t.deepEqual(s, [40, 20, 60, 210, 420])
-  t.end()
+    ar.push(box.width)
 })
 
-test('babel: parameterized computed decorator', (t) => {
-	class TestClass {
-		@observable x = 3;
-		@observable y = 3;
-		@computed.struct get boxedSum() {
-			return { sum: Math.round(this.x) + Math.round(this.y) };
-		}
-	}
+test("babel", function(t) {
+    var s = ar.slice()
+    t.deepEqual(s, [40])
+    box.height = 10
+    s = ar.slice()
+    t.deepEqual(s, [40, 20])
+    box.sizes.push(3, 4)
+    s = ar.slice()
+    t.deepEqual(s, [40, 20, 60])
+    box.someFunc = () => 7
+    s = ar.slice()
+    t.deepEqual(s, [40, 20, 60, 210])
+    box.uninitialized = true
+    s = ar.slice()
+    t.deepEqual(s, [40, 20, 60, 210, 420])
+    t.end()
+})
 
-	const t1 = new TestClass();
-	const changes: { sum: number}[] = [];
-	const d = autorun(() => changes.push(t1.boxedSum));
+test("babel: parameterized computed decorator", t => {
+    class TestClass {
+        @observable x = 3
+        @observable y = 3
+        @computed.struct
+        get boxedSum() {
+            return { sum: Math.round(this.x) + Math.round(this.y) }
+        }
+    }
 
-	t1.y = 4; // change
-	t.equal(changes.length, 2);
-	t1.y = 4.2; // no change
-	t.equal(changes.length, 2);
-	transaction(() => {
-		t1.y = 3;
-		t1.x = 4;
-	}); // no change
-	t.equal(changes.length, 2);
-	t1.x = 6; // change
-	t.equal(changes.length, 3);
-	d();
+    const t1 = new TestClass()
+    const changes: { sum: number }[] = []
+    const d = autorun(() => changes.push(t1.boxedSum))
 
-	t.deepEqual(changes, [{ sum: 6 }, { sum: 7 }, { sum: 9 }]);
+    t1.y = 4 // change
+    t.equal(changes.length, 2)
+    t1.y = 4.2 // no change
+    t.equal(changes.length, 2)
+    transaction(() => {
+        t1.y = 3
+        t1.x = 4
+    }) // no change
+    t.equal(changes.length, 2)
+    t1.x = 6 // change
+    t.equal(changes.length, 3)
+    d()
 
-	t.end();
-});
+    t.deepEqual(changes, [{ sum: 6 }, { sum: 7 }, { sum: 9 }])
+
+    t.end()
+})
 
 class Order {
-    @observable price = 3;
-    @observable amount = 2;
-    @observable orders = [];
-    @observable aFunction = function(a) { };
+    @observable price = 3
+    @observable amount = 2
+    @observable orders = []
+    @observable aFunction = function(a) {}
 
-    @computed get total() {
-        return this.amount * this.price * (1 + this.orders.length);
+    @computed
+    get total() {
+        return this.amount * this.price * (1 + this.orders.length)
     }
 }
 
-test('decorators', function(t) {
-	var o = new Order();
-	t.equal(isObservableObject(o), true);
-	t.equal(isObservable(o, 'amount'), true);
-	t.equal(o.total, 6); // .... this is required to initialize the props which are made reactive lazily...
-	t.equal(isObservable(o, 'total'), true);
+test("decorators", function(t) {
+    var o = new Order()
+    t.equal(isObservableObject(o), true)
+    t.equal(isObservable(o, "amount"), true)
+    t.equal(o.total, 6) // .... this is required to initialize the props which are made reactive lazily...
+    t.equal(isObservable(o, "total"), true)
 
-	var events = [];
-	var d1 = observe(o, (ev) => events.push(ev.name, ev.oldValue));
-	var d2 = observe(o, 'price', (ev) => events.push(ev.newValue, ev.oldValue));
-	var d3 = observe(o, 'total', (ev) => events.push(ev.newValue, ev.oldValue));
+    var events = []
+    var d1 = observe(o, ev => events.push(ev.name, ev.oldValue))
+    var d2 = observe(o, "price", ev => events.push(ev.newValue, ev.oldValue))
+    var d3 = observe(o, "total", ev => events.push(ev.newValue, ev.oldValue))
 
-	o.price = 4;
+    o.price = 4
 
-	d1();
-	d2();
-	d3();
+    d1()
+    d2()
+    d3()
 
-	o.price = 5;
+    o.price = 5
 
-	t.deepEqual(events, [
-		8, // new total
-		6, // old total
-		4, // new price
-		3, // old price
-		"price", // event name
-		3, // event oldValue
-	]);
+    t.deepEqual(events, [
+        8, // new total
+        6, // old total
+        4, // new price
+        3, // old price
+        "price", // event name
+        3 // event oldValue
+    ])
 
-	t.end();
+    t.end()
 })
 
-test('issue 191 - shared initializers (babel)', function(t) {
-	class Test {
-		@observable obj = { a: 1 };
-		@observable array = [2];
-	}
+test("issue 191 - shared initializers (babel)", function(t) {
+    class Test {
+        @observable obj = { a: 1 }
+        @observable array = [2]
+    }
 
-	var t1 = new Test();
-	t1.obj.a = 2;
-	t1.array.push(3);
+    var t1 = new Test()
+    t1.obj.a = 2
+    t1.array.push(3)
 
-	var t2 = new Test();
-	t2.obj.a = 3;
-	t2.array.push(4);
+    var t2 = new Test()
+    t2.obj.a = 3
+    t2.array.push(4)
 
-	t.notEqual(t1.obj, t2.obj);
-	t.notEqual(t1.array, t2.array);
-	t.equal(t1.obj.a, 2);
-	t.equal(t2.obj.a, 3);
+    t.notEqual(t1.obj, t2.obj)
+    t.notEqual(t1.array, t2.array)
+    t.equal(t1.obj.a, 2)
+    t.equal(t2.obj.a, 3)
 
-	t.deepEqual(t1.array.slice(), [2,3]);
-	t.deepEqual(t2.array.slice(), [2,4]);
+    t.deepEqual(t1.array.slice(), [2, 3])
+    t.deepEqual(t2.array.slice(), [2, 4])
 
-	t.end();
+    t.end()
 })
 
 test("705 - setter undoing caching (babel)", t => {
-	let recomputes = 0;
-	let autoruns = 0;
+    let recomputes = 0
+    let autoruns = 0
 
-	class Person {
-		@observable name: string;
-		@observable title: string;
-		set fullName(val) {
-			// Noop
-		}
-		@computed get fullName() {
-			debugger;
-			recomputes++;
-			return this.title+" "+this.name;
-		}
-	}
+    class Person {
+        @observable name: string
+        @observable title: string
+        set fullName(val) {
+            // Noop
+        }
+        @computed
+        get fullName() {
+            debugger
+            recomputes++
+            return this.title + " " + this.name
+        }
+    }
 
-	let p1 = new Person();
-	p1.name="Tom Tank";
-	p1.title="Mr.";
+    let p1 = new Person()
+    p1.name = "Tom Tank"
+    p1.title = "Mr."
 
-	t.equal(recomputes, 0);
-	t.equal(autoruns, 0);
+    t.equal(recomputes, 0)
+    t.equal(autoruns, 0)
 
-	const d1 = autorun(()=> {
-		autoruns++;
-		p1.fullName;
-	})
+    const d1 = autorun(() => {
+        autoruns++
+        p1.fullName
+    })
 
-	const d2 = autorun(()=> {
-		autoruns++;
-		p1.fullName;
-	})
+    const d2 = autorun(() => {
+        autoruns++
+        p1.fullName
+    })
 
-	t.equal(recomputes, 1);
-	t.equal(autoruns, 2);
+    t.equal(recomputes, 1)
+    t.equal(autoruns, 2)
 
-	p1.title="Master";
-	t.equal(recomputes, 2);
-	t.equal(autoruns, 4);
+    p1.title = "Master"
+    t.equal(recomputes, 2)
+    t.equal(autoruns, 4)
 
-	d1();
-	d2();
-	t.end();
+    d1()
+    d2()
+    t.end()
 })
 
 function normalizeSpyEvents(events) {
-	events.forEach(ev => {
-		delete ev.fn;
-		delete ev.time;
-	});
-	return events;
+    events.forEach(ev => {
+        delete ev.fn
+        delete ev.time
+    })
+    return events
 }
 
 test("action decorator (babel)", function(t) {
-	class Store {
-		constructor(multiplier) {
-			this.multiplier = multiplier;
-		}
+    class Store {
+        constructor(multiplier) {
+            this.multiplier = multiplier
+        }
 
-		@action
-		add(a, b) {
-			return (a + b) * this.multiplier;
-		}
-	}
+        @action
+        add(a, b) {
+            return (a + b) * this.multiplier
+        }
+    }
 
-	const store1 =  new Store(2);
-	const store2 =  new Store(3);
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(3, 4), 21);
-	t.equal(store1.add(1, 1), 4);
+    const store1 = new Store(2)
+    const store2 = new Store(3)
+    const events: any[] = []
+    const d = spy(events.push.bind(events))
+    t.equal(store1.add(3, 4), 14)
+    t.equal(store2.add(3, 4), 21)
+    t.equal(store1.add(1, 1), 4)
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, object: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 1, 1 ], name: "add", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true }
-	]);
+    t.deepEqual(normalizeSpyEvents(events), [
+        { arguments: [3, 4], name: "add", spyReportStart: true, object: store1, type: "action" },
+        { spyReportEnd: true },
+        { arguments: [3, 4], name: "add", spyReportStart: true, object: store2, type: "action" },
+        { spyReportEnd: true },
+        { arguments: [1, 1], name: "add", spyReportStart: true, object: store1, type: "action" },
+        { spyReportEnd: true }
+    ])
 
-	d();
-	t.end();
-});
+    d()
+    t.end()
+})
 
 test("custom action decorator (babel)", function(t) {
-	class Store {
-		constructor(multiplier) {
-			this.multiplier = multiplier;
-		}
+    class Store {
+        constructor(multiplier) {
+            this.multiplier = multiplier
+        }
 
-		@action("zoem zoem")
-		add(a, b) {
-			return (a + b) * this.multiplier;
-		}
-	}
+        @action("zoem zoem")
+        add(a, b) {
+            return (a + b) * this.multiplier
+        }
+    }
 
-	const store1 =  new Store(2);
-	const store2 =  new Store(3);
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(3, 4), 21);
-	t.equal(store1.add(1, 1), 4);
+    const store1 = new Store(2)
+    const store2 = new Store(3)
+    const events: any[] = []
+    const d = spy(events.push.bind(events))
+    t.equal(store1.add(3, 4), 14)
+    t.equal(store2.add(3, 4), 21)
+    t.equal(store1.add(1, 1), 4)
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, object: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 1, 1 ], name: "zoem zoem", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true },
-	]);
+    t.deepEqual(normalizeSpyEvents(events), [
+        {
+            arguments: [3, 4],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store1,
+            type: "action"
+        },
+        { spyReportEnd: true },
+        {
+            arguments: [3, 4],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store2,
+            type: "action"
+        },
+        { spyReportEnd: true },
+        {
+            arguments: [1, 1],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store1,
+            type: "action"
+        },
+        { spyReportEnd: true }
+    ])
 
-	d();
-	t.end();
-});
-
+    d()
+    t.end()
+})
 
 test("action decorator on field (babel)", function(t) {
-	class Store {
-		constructor(multiplier) {
-			this.multiplier = multiplier;
-		}
+    class Store {
+        constructor(multiplier) {
+            this.multiplier = multiplier
+        }
 
+        @action
+        add = (a, b) => {
+            return (a + b) * this.multiplier
+        }
+    }
 
-		@action
-		add = (a, b) => {
-			return (a + b) * this.multiplier;
-		};
-	}
+    const store1 = new Store(2)
+    const store2 = new Store(7)
 
-	const store1 =  new Store(2);
-	const store2 =  new Store(7);
+    const events: any[] = []
+    const d = spy(events.push.bind(events))
+    t.equal(store1.add(3, 4), 14)
+    t.equal(store2.add(5, 4), 63)
+    t.equal(store1.add(2, 2), 8)
 
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(5, 4), 63);
-	t.equal(store1.add(2, 2), 8);
+    t.deepEqual(normalizeSpyEvents(events), [
+        { arguments: [3, 4], name: "add", spyReportStart: true, object: store1, type: "action" },
+        { spyReportEnd: true },
+        { arguments: [5, 4], name: "add", spyReportStart: true, object: store2, type: "action" },
+        { spyReportEnd: true },
+        { arguments: [2, 2], name: "add", spyReportStart: true, object: store1, type: "action" },
+        { spyReportEnd: true }
+    ])
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 5, 4 ], name: "add", spyReportStart: true, object: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 2, 2 ], name: "add", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true }
-	]);
-
-	d();
-	t.end();
-});
+    d()
+    t.end()
+})
 
 test("custom action decorator on field (babel)", function(t) {
-	class Store {
-		constructor(multiplier) {
-			this.multiplier = multiplier;
-		}
+    class Store {
+        constructor(multiplier) {
+            this.multiplier = multiplier
+        }
 
+        @action("zoem zoem")
+        add = (a, b) => {
+            return (a + b) * this.multiplier
+        }
+    }
 
-		@action("zoem zoem")
-		add = (a, b) => {
-			return (a + b) * this.multiplier;
-		};
-	}
+    const store1 = new Store(2)
+    const store2 = new Store(7)
 
-	const store1 =  new Store(2);
-	const store2 =  new Store(7);
+    const events: any[] = []
+    const d = spy(events.push.bind(events))
+    t.equal(store1.add(3, 4), 14)
+    t.equal(store2.add(5, 4), 63)
+    t.equal(store1.add(2, 2), 8)
 
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(5, 4), 63);
-	t.equal(store1.add(2, 2), 8);
+    t.deepEqual(normalizeSpyEvents(events), [
+        {
+            arguments: [3, 4],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store1,
+            type: "action"
+        },
+        { spyReportEnd: true },
+        {
+            arguments: [5, 4],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store2,
+            type: "action"
+        },
+        { spyReportEnd: true },
+        {
+            arguments: [2, 2],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store1,
+            type: "action"
+        },
+        { spyReportEnd: true }
+    ])
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 5, 4 ], name: "zoem zoem", spyReportStart: true, object: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 2, 2 ], name: "zoem zoem", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true }
-	]);
-
-	d();
-	t.end();
-});
+    d()
+    t.end()
+})
 
 test("267 (babel) should be possible to declare properties observable outside strict mode", t => {
-	useStrict(true);
+    useStrict(true)
 
-	class Store {
-		@observable timer;
-	}
+    class Store {
+        @observable timer
+    }
 
-	useStrict(false);
-	t.end();
+    useStrict(false)
+    t.end()
 })
 
 test("288 atom not detected for object property", t => {
-	class Store {
-		@mobx.observable foo = '';
-	}
+    class Store {
+        @mobx.observable foo = ""
+    }
 
-	const store = new Store();
+    const store = new Store()
 
-	mobx.observe(store, 'foo', () => {
-		console.log('Change observed');
-	}, true);
+    mobx.observe(
+        store,
+        "foo",
+        () => {
+            console.log("Change observed")
+        },
+        true
+    )
 
-	t.end()
+    t.end()
 })
 
 test("observable performance", t => {
-	const AMOUNT = 100000;
+    const AMOUNT = 100000
 
-	class A {
-		@observable a = 1;
-		@observable b = 2;
-		@observable c = 3;
-		@computed get d() {
-			return this.a + this.b + this.c;
-		}
-	}
+    class A {
+        @observable a = 1
+        @observable b = 2
+        @observable c = 3
+        @computed
+        get d() {
+            return this.a + this.b + this.c
+        }
+    }
 
-	const objs = [];
-	const start = Date.now();
+    const objs = []
+    const start = Date.now()
 
-	for (var i = 0; i < AMOUNT; i++)
-		objs.push(new A());
+    for (var i = 0; i < AMOUNT; i++) objs.push(new A())
 
-	console.log("created in ", Date.now() - start);
+    console.log("created in ", Date.now() - start)
 
-	for (var j = 0; j < 4; j++) {
-		for (var i = 0; i < AMOUNT; i++) {
-			const obj = objs[i]
-			obj.a += 3;
-			obj.b *= 4;
-			obj.c = obj.b - obj.a;
-			obj.d;
-		}
-	}
+    for (var j = 0; j < 4; j++) {
+        for (var i = 0; i < AMOUNT; i++) {
+            const obj = objs[i]
+            obj.a += 3
+            obj.b *= 4
+            obj.c = obj.b - obj.a
+            obj.d
+        }
+    }
 
-	console.log("changed in ", Date.now() - start);
+    console.log("changed in ", Date.now() - start)
 
-	t.end();
+    t.end()
 })
 
 test("unbound methods", t => {
-	class A {
-		// shared across all instances
-		@action m1() {
+    class A {
+        // shared across all instances
+        @action
+        m1() {}
 
-		}
+        // per instance
+        @action m2 = () => {}
+    }
 
-		// per instance
-		@action m2 = () => {};
-	}
+    const a1 = new A()
+    const a2 = new A()
 
-	const a1 = new A();
-	const a2 = new A();
-
-	t.equal(a1.m1, a2.m1);
-	t.notEqual(a1.m2, a2.m2);
-	t.equal(a1.hasOwnProperty("m1"), false);
-	t.equal(a1.hasOwnProperty("m2"), true);
-	t.equal(a2.hasOwnProperty("m1"), false);
-	t.equal(a2.hasOwnProperty("m2"), true);
-	t.end();
-
+    t.equal(a1.m1, a2.m1)
+    t.notEqual(a1.m2, a2.m2)
+    t.equal(a1.hasOwnProperty("m1"), false)
+    t.equal(a1.hasOwnProperty("m2"), true)
+    t.equal(a2.hasOwnProperty("m1"), false)
+    t.equal(a2.hasOwnProperty("m2"), true)
+    t.end()
 })
 
 test("inheritance", t => {
-	class A {
-		@observable a = 2;
-	}
+    class A {
+        @observable a = 2
+    }
 
-	class B extends A {
-		@observable b = 3;
-		@computed get c() {
-			return this.a + this.b;
-		}
-	}
+    class B extends A {
+        @observable b = 3
+        @computed
+        get c() {
+            return this.a + this.b
+        }
+    }
 
-	const b1 = new B();
-	const b2 = new B();
-	const values = []
-	mobx.autorun(() => values.push(b1.c + b2.c));
+    const b1 = new B()
+    const b2 = new B()
+    const values = []
+    mobx.autorun(() => values.push(b1.c + b2.c))
 
-	b1.a = 3;
-	b1.b = 4;
-	b2.b = 5;
-	b2.a = 6;
+    b1.a = 3
+    b1.b = 4
+    b2.b = 5
+    b2.a = 6
 
-	t.deepEqual(values, [
-		10,
-		11,
-		12,
-		14,
-		18
-	])
+    t.deepEqual(values, [10, 11, 12, 14, 18])
 
-	t.end();
+    t.end()
 })
 
 test("inheritance overrides observable", t => {
-	class A {
-		@observable a = 2;
-	}
+    class A {
+        @observable a = 2
+    }
 
-	class B {
-		@observable a = 5;
-		@observable b = 3;
-		@computed get c() {
-			return this.a + this.b;
-		}
-	}
+    class B {
+        @observable a = 5
+        @observable b = 3
+        @computed
+        get c() {
+            return this.a + this.b
+        }
+    }
 
-	const b1 = new B();
-	const b2 = new B();
-	const values = []
-	mobx.autorun(() => values.push(b1.c + b2.c));
+    const b1 = new B()
+    const b2 = new B()
+    const values = []
+    mobx.autorun(() => values.push(b1.c + b2.c))
 
-	b1.a = 3;
-	b1.b = 4;
-	b2.b = 5;
-	b2.a = 6;
+    b1.a = 3
+    b1.b = 4
+    b2.b = 5
+    b2.a = 6
 
-	t.deepEqual(values, [
-		16,
-		14,
-		15,
-		17,
-		18
-	])
+    t.deepEqual(values, [16, 14, 15, 17, 18])
 
-	t.end();
+    t.end()
 })
 
 test("reusing initializers", t => {
-	class A {
-		@observable a = 3;
-		@observable b = this.a + 2;
-		@computed get c() {
-			return this.a + this.b;
-		}
-		@computed get d() {
-			return this.c + 1;
-		}
-	}
+    class A {
+        @observable a = 3
+        @observable b = this.a + 2
+        @computed
+        get c() {
+            return this.a + this.b
+        }
+        @computed
+        get d() {
+            return this.c + 1
+        }
+    }
 
-	const a = new A();
-	const values = [];
-	mobx.autorun(() => values.push(a.d));
+    const a = new A()
+    const values = []
+    mobx.autorun(() => values.push(a.d))
 
-	a.a = 4;
-	t.deepEqual(values, [
-		9,
-		10
-	])
+    a.a = 4
+    t.deepEqual(values, [9, 10])
 
-	t.end();
+    t.end()
 })
 
 test("enumerability", t => {
-	class A {
-		@observable a = 1; // enumerable, on proto
-		@observable a2 = 2;
-		@computed get b () { return this.a } // non-enumerable, on proto
-		@action m() {} // non-enumerable, on proto
-		@action m2 = () => {}; // non-enumerable, on self
-	}
+    class A {
+        @observable a = 1 // enumerable, on proto
+        @observable a2 = 2
+        @computed
+        get b() {
+            return this.a
+        } // non-enumerable, on proto
+        @action
+        m() {} // non-enumerable, on proto
+        @action m2 = () => {} // non-enumerable, on self
+    }
 
-	const a = new A();
+    const a = new A()
 
-	// not initialized yet
-	let ownProps = Object.keys(a);
-	let props = [];
-	for (var key in a)
-		props.push(key);
+    // not initialized yet
+    let ownProps = Object.keys(a)
+    let props = []
+    for (var key in a) props.push(key)
 
-	t.deepEqual(ownProps, [
-		// should have a, not supported yet in babel...
-	]);
+    t.deepEqual(
+        ownProps,
+        [
+            // should have a, not supported yet in babel...
+        ]
+    )
 
-	t.deepEqual(props, [
-		"a",
-		"a2"
-	]);
+    t.deepEqual(props, ["a", "a2"])
 
-	t.equal("a" in a, true);
-	t.equal(a.hasOwnProperty("a"), false); // true would better..
-	t.equal(a.hasOwnProperty("b"), false);
-	t.equal(a.hasOwnProperty("m"), false);
-	t.equal(a.hasOwnProperty("m2"), false); // true would be ok as well
+    t.equal("a" in a, true)
+    t.equal(a.hasOwnProperty("a"), false) // true would better..
+    t.equal(a.hasOwnProperty("b"), false)
+    t.equal(a.hasOwnProperty("m"), false)
+    t.equal(a.hasOwnProperty("m2"), false) // true would be ok as well
 
-	t.equal(mobx.isAction(a.m), true);
-	t.equal(mobx.isAction(a.m2), true);
+    t.equal(mobx.isAction(a.m), true)
+    t.equal(mobx.isAction(a.m2), true)
 
-	// after initialization
-	a.a;
-	a.b;
-	a.m;
-	a.m2;
+    // after initialization
+    a.a
+    a.b
+    a.m
+    a.m2
 
-	ownProps = Object.keys(a);
-	props = [];
-	for (var key in a)
-		props.push(key);
+    ownProps = Object.keys(a)
+    props = []
+    for (var key in a) props.push(key)
 
-	t.deepEqual(ownProps, [
-		"a",
-		"a2" // a2 is now initialized as well, altough never accessed!
-	]);
+    t.deepEqual(ownProps, [
+        "a",
+        "a2" // a2 is now initialized as well, altough never accessed!
+    ])
 
-	t.deepEqual(props, [
-		"a",
-		"a2"
-	]);
+    t.deepEqual(props, ["a", "a2"])
 
-	t.equal("a" in a, true);
-	t.equal(a.hasOwnProperty("a"), true);
-	t.equal(a.hasOwnProperty("a2"), true);
-	t.equal(a.hasOwnProperty("b"), false);
-	t.equal(a.hasOwnProperty("m"), false);
-	t.equal(a.hasOwnProperty("m2"), true);
+    t.equal("a" in a, true)
+    t.equal(a.hasOwnProperty("a"), true)
+    t.equal(a.hasOwnProperty("a2"), true)
+    t.equal(a.hasOwnProperty("b"), false)
+    t.equal(a.hasOwnProperty("m"), false)
+    t.equal(a.hasOwnProperty("m2"), true)
 
-
-	t.end();
+    t.end()
 })
 
 test("enumerability - workaround", t => {
-	class A {
-		@observable a = 1; // enumerable, on proto
-		@observable a2 = 2;
-		@computed get b () { return this.a } // non-enumerable, on proto
-		@action m() {} // non-enumerable, on proto
-		@action m2 = () => {}; // non-enumerable, on self
+    class A {
+        @observable a = 1 // enumerable, on proto
+        @observable a2 = 2
+        @computed
+        get b() {
+            return this.a
+        } // non-enumerable, on proto
+        @action
+        m() {} // non-enumerable, on proto
+        @action m2 = () => {} // non-enumerable, on self
 
-		constructor() {
-			this.a = 1
-			this.a2 = 2
-		}
-	}
+        constructor() {
+            this.a = 1
+            this.a2 = 2
+        }
+    }
 
-	const a = new A();
+    const a = new A()
 
-	const ownProps = Object.keys(a);
-	const props = [];
-	for (var key in a)
-		props.push(key);
+    const ownProps = Object.keys(a)
+    const props = []
+    for (var key in a) props.push(key)
 
-	t.deepEqual(ownProps, [
-		"a",
-		"a2" // a2 is now initialized as well, altough never accessed!
-	]);
+    t.deepEqual(ownProps, [
+        "a",
+        "a2" // a2 is now initialized as well, altough never accessed!
+    ])
 
-	t.deepEqual(props, [
-		"a",
-		"a2"
-	]);
+    t.deepEqual(props, ["a", "a2"])
 
-	t.equal("a" in a, true);
-	t.equal(a.hasOwnProperty("a"), true);
-	t.equal(a.hasOwnProperty("a2"), true);
-	t.equal(a.hasOwnProperty("b"), false);
-	t.equal(a.hasOwnProperty("m"), false);
-	t.equal(a.hasOwnProperty("m2"), true);
+    t.equal("a" in a, true)
+    t.equal(a.hasOwnProperty("a"), true)
+    t.equal(a.hasOwnProperty("a2"), true)
+    t.equal(a.hasOwnProperty("b"), false)
+    t.equal(a.hasOwnProperty("m"), false)
+    t.equal(a.hasOwnProperty("m2"), true)
 
-
-	t.end();
+    t.end()
 })
 
 test("issue 285 (babel)", t => {
-	const {observable, toJS} = mobx;
+    const { observable, toJS } = mobx
 
-	class Todo {
-		id = 1;
-		@observable title;
-		@observable finished = false;
-		@observable childThings = [1,2,3];
-		constructor(title) {
-			this.title = title;
-		}
-	}
+    class Todo {
+        id = 1
+        @observable title
+        @observable finished = false
+        @observable childThings = [1, 2, 3]
+        constructor(title) {
+            this.title = title
+        }
+    }
 
-	var todo = new Todo("Something to do");
+    var todo = new Todo("Something to do")
 
-	t.deepEqual(toJS(todo), {
-		id: 1,
-		title: "Something to do",
-		finished: false,
-		childThings: [1,2,3]
-	})
+    t.deepEqual(toJS(todo), {
+        id: 1,
+        title: "Something to do",
+        finished: false,
+        childThings: [1, 2, 3]
+    })
 
-	t.end();
+    t.end()
 })
 
 test("verify object assign (babel)", t => {
-	class Todo {
-		@observable title = "test";
-		@computed get upperCase() {
-			return this.title.toUpperCase()
-		}
-	}
+    class Todo {
+        @observable title = "test"
+        @computed
+        get upperCase() {
+            return this.title.toUpperCase()
+        }
+    }
 
-	const todo = new Todo();
-	t.deepEqual(Object.assign({}, todo), {
-//		Should be:	title: "test"!
-	});
+    const todo = new Todo()
+    t.deepEqual(
+        Object.assign({}, todo),
+        {
+            //		Should be:	title: "test"!
+        }
+    )
 
-	todo.title; // lazy initialization :'(
+    todo.title // lazy initialization :'(
 
-	t.deepEqual(Object.assign({}, todo), {
-		title: "test"
-	});
+    t.deepEqual(Object.assign({}, todo), {
+        title: "test"
+    })
 
-	t.end();
+    t.end()
 })
 
-
 test("379, inheritable actions (babel)", t => {
-	class A {
-		@action method() {
-			return 42;
-		}
-	}
+    class A {
+        @action
+        method() {
+            return 42
+        }
+    }
 
-	class B extends A {
-		@action method() {
-			return super.method() * 2
-		}
-	}
+    class B extends A {
+        @action
+        method() {
+            return super.method() * 2
+        }
+    }
 
-	class C extends B {
-		@action method() {
-			return super.method() + 3
-		}
-	}
+    class C extends B {
+        @action
+        method() {
+            return super.method() + 3
+        }
+    }
 
-	const b = new B()
-	t.equal(b.method(), 84)
-	t.equal(isAction(b.method), true)
+    const b = new B()
+    t.equal(b.method(), 84)
+    t.equal(isAction(b.method), true)
 
-	const a = new A()
-	t.equal(a.method(), 42)
-	t.equal(isAction(a.method), true)
+    const a = new A()
+    t.equal(a.method(), 42)
+    t.equal(isAction(a.method), true)
 
-	const c = new C()
-	t.equal(c.method(), 87)
-	t.equal(isAction(c.method), true)
+    const c = new C()
+    t.equal(c.method(), 87)
+    t.equal(isAction(c.method), true)
 
-	t.end()
+    t.end()
 })
 
 test("379, inheritable actions - 2 (babel)", t => {
-	class A {
-		@action("a method") method() {
-			return 42;
-		}
-	}
+    class A {
+        @action("a method")
+        method() {
+            return 42
+        }
+    }
 
-	class B extends A {
-		@action("b method") method() {
-			return super.method() * 2
-		}
-	}
+    class B extends A {
+        @action("b method")
+        method() {
+            return super.method() * 2
+        }
+    }
 
-	class C extends B {
-		@action("c method") method() {
-			return super.method() + 3
-		}
-	}
+    class C extends B {
+        @action("c method")
+        method() {
+            return super.method() + 3
+        }
+    }
 
-	const b = new B()
-	t.equal(b.method(), 84)
-	t.equal(isAction(b.method), true)
+    const b = new B()
+    t.equal(b.method(), 84)
+    t.equal(isAction(b.method), true)
 
-	const a = new A()
-	t.equal(a.method(), 42)
-	t.equal(isAction(a.method), true)
+    const a = new A()
+    t.equal(a.method(), 42)
+    t.equal(isAction(a.method), true)
 
-	const c = new C()
-	t.equal(c.method(), 87)
-	t.equal(isAction(c.method), true)
+    const c = new C()
+    t.equal(c.method(), 87)
+    t.equal(isAction(c.method), true)
 
-	t.end()
+    t.end()
 })
 
 test("505, don't throw when accessing subclass fields in super constructor (babel)", t => {
-	const values = {}
-	class A {
-		@observable a = 1
-		constructor() {
-			values.b = this.b
-			values.a = this.a
-		}
-	}
+    const values = {}
+    class A {
+        @observable a = 1
+        constructor() {
+            values.b = this.b
+            values.a = this.a
+        }
+    }
 
-	class B extends A {
-		@observable b = 2
-	}
+    class B extends A {
+        @observable b = 2
+    }
 
-	new B()
-	t.deepEqual(values, { a: 1, b: 2}) // In the TS test b is undefined, which is actually the expected behavior?
-	t.end()
+    new B()
+    t.deepEqual(values, { a: 1, b: 2 }) // In the TS test b is undefined, which is actually the expected behavior?
+    t.end()
 })
 
-test('computed setter should succeed (babel)', function(t) {
-	class Bla {
-		@observable a = 3;
-		@computed get propX() {
-			return this.a * 2;
-		}
-		set propX(v) {
-			this.a = v
-		}
-	}
+test("computed setter should succeed (babel)", function(t) {
+    class Bla {
+        @observable a = 3
+        @computed
+        get propX() {
+            return this.a * 2
+        }
+        set propX(v) {
+            this.a = v
+        }
+    }
 
-	const b = new Bla();
-	t.equal(b.propX, 6);
-	b.propX = 4;
-	t.equal(b.propX, 8);
+    const b = new Bla()
+    t.equal(b.propX, 6)
+    b.propX = 4
+    t.equal(b.propX, 8)
 
-	t.end();
-});
-
-test('computed getter / setter for plan objects should succeed (babel)', function(t) {
-	const b = observable({
-		a: 3,
-		get propX() { return this.a * 2 },
-		set propX(v) { this.a = v }
-	})
-
-	const values = []
-	mobx.autorun(() => values.push(b.propX))
-	t.equal(b.propX, 6);
-	b.propX = 4;
-	t.equal(b.propX, 8);
-
-	t.deepEqual(values, [6, 8])
-
-	t.end();
-});
-
-test('issue #701', t => {
-
-	class Model {
-	@observable a = 5
-	}
-
-	const model = new Model()
-
-	t.deepEqual(mobx.toJS(model), { a: 5 })
-	t.equal(mobx.isObservable(model), true);
-	t.equal(mobx.isObservableObject(model), true);
-
-	t.end()
+    t.end()
 })
 
+test("computed getter / setter for plan objects should succeed (babel)", function(t) {
+    const b = observable({
+        a: 3,
+        get propX() {
+            return this.a * 2
+        },
+        set propX(v) {
+            this.a = v
+        }
+    })
+
+    const values = []
+    mobx.autorun(() => values.push(b.propX))
+    t.equal(b.propX, 6)
+    b.propX = 4
+    t.equal(b.propX, 8)
+
+    t.deepEqual(values, [6, 8])
+
+    t.end()
+})
+
+test("issue #701", t => {
+    class Model {
+        @observable a = 5
+    }
+
+    const model = new Model()
+
+    t.deepEqual(mobx.toJS(model), { a: 5 })
+    t.equal(mobx.isObservable(model), true)
+    t.equal(mobx.isObservableObject(model), true)
+
+    t.end()
+})
 
 test("@observable.ref (Babel)", t => {
-	class A {
-		@observable.ref ref = { a: 3}
-	}
+    class A {
+        @observable.ref ref = { a: 3 }
+    }
 
-	const a = new A();
-	t.equal(a.ref.a, 3);
-	t.equal(mobx.isObservable(a.ref), false);
-	t.equal(mobx.isObservable(a, "ref"), true);
+    const a = new A()
+    t.equal(a.ref.a, 3)
+    t.equal(mobx.isObservable(a.ref), false)
+    t.equal(mobx.isObservable(a, "ref"), true)
 
-	t.end();
+    t.end()
 })
 
 test("@observable.shallow (Babel)", t => {
-	class A {
-		@observable.shallow arr = [{ todo: 1 }]
-	}
+    class A {
+        @observable.shallow arr = [{ todo: 1 }]
+    }
 
-	const a = new A();
-	const todo2 = { todo: 2 };
-	a.arr.push(todo2)
-	t.equal(mobx.isObservable(a.arr), true);
-	t.equal(mobx.isObservable(a, "arr"), true);
-	t.equal(mobx.isObservable(a.arr[0]), false);
-	t.equal(mobx.isObservable(a.arr[1]), false);
-	t.ok(a.arr[1] === todo2)
+    const a = new A()
+    const todo2 = { todo: 2 }
+    a.arr.push(todo2)
+    t.equal(mobx.isObservable(a.arr), true)
+    t.equal(mobx.isObservable(a, "arr"), true)
+    t.equal(mobx.isObservable(a.arr[0]), false)
+    t.equal(mobx.isObservable(a.arr[1]), false)
+    t.ok(a.arr[1] === todo2)
 
-	t.end();
+    t.end()
 })
-
 
 test("@observable.deep (Babel)", t => {
-	class A {
-		@observable.deep arr = [{ todo: 1 }]
-	}
+    class A {
+        @observable.deep arr = [{ todo: 1 }]
+    }
 
-	const a = new A();
-	const todo2 = { todo: 2 };
-	a.arr.push(todo2)
+    const a = new A()
+    const todo2 = { todo: 2 }
+    a.arr.push(todo2)
 
-	t.equal(mobx.isObservable(a.arr), true);
-	t.equal(mobx.isObservable(a, "arr"), true);
-	t.equal(mobx.isObservable(a.arr[0]), true);
-	t.equal(mobx.isObservable(a.arr[1]), true);
-	t.ok(a.arr[1] !== todo2)
-	t.equal(isObservable(todo2), false);
+    t.equal(mobx.isObservable(a.arr), true)
+    t.equal(mobx.isObservable(a, "arr"), true)
+    t.equal(mobx.isObservable(a.arr[0]), true)
+    t.equal(mobx.isObservable(a.arr[1]), true)
+    t.ok(a.arr[1] !== todo2)
+    t.equal(isObservable(todo2), false)
 
-	t.end();
+    t.end()
 })
 
-test("action.bound binds (Babel)", t=> {
-	class A {
-		@observable x = 0;
-		@action.bound
-		inc(value: number) {
-			this.x += value;
-		}
-	}
+test("action.bound binds (Babel)", t => {
+    class A {
+        @observable x = 0
+        @action.bound
+        inc(value: number) {
+            this.x += value
+        }
+    }
 
-	const a = new A();
-	const runner = a.inc;
-	runner(2);
+    const a = new A()
+    const runner = a.inc
+    runner(2)
 
-	t.equal(a.x, 2);
+    t.equal(a.x, 2)
 
-	t.end();
+    t.end()
 })
 
 test("@computed.equals (Babel)", t => {
-	const sameTime = (from, to) => from.hour === to.hour && from.minute === to.minute;
-	class Time {
-		constructor(hour, minute) {
-			this.hour = hour;
-			this.minute = minute;
-		}
+    const sameTime = (from, to) => from.hour === to.hour && from.minute === to.minute
+    class Time {
+        constructor(hour, minute) {
+            this.hour = hour
+            this.minute = minute
+        }
 
-		@observable hour: number;
-		@observable minute: number;
+        @observable hour: number
+        @observable minute: number
 
-		@computed.equals(sameTime) get time() {
-			return { hour: this.hour, minute: this.minute };
-		}
-	}
-	const time = new Time(9, 0);
+        @computed.equals(sameTime)
+        get time() {
+            return { hour: this.hour, minute: this.minute }
+        }
+    }
+    const time = new Time(9, 0)
 
-	const changes = [];
-	const disposeAutorun = autorun(() => changes.push(time.time));
+    const changes = []
+    const disposeAutorun = autorun(() => changes.push(time.time))
 
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }]);
-	time.hour = 9;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }]);
-	time.minute = 0;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }]);
-	time.hour = 10;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }, { hour: 10, minute: 0 }]);
-	time.minute = 30;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }, { hour: 10, minute: 0 }, { hour: 10, minute: 30 }]);
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }])
+    time.hour = 9
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }])
+    time.minute = 0
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }])
+    time.hour = 10
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    time.minute = 30
+    t.deepEqual(changes, [
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 },
+        { hour: 10, minute: 30 }
+    ])
 
-	disposeAutorun();
+    disposeAutorun()
 
-	t.end();
-});
+    t.end()
+})

--- a/test/cycles.js
+++ b/test/cycles.js
@@ -1,189 +1,208 @@
-var m = require('../');
-var test = require('tape');
+var m = require("../")
+var test = require("tape")
 
-test('cascading active state (form 1)', function(t) {
-  var Store = function() {
-    m.extendObservable(this, {_activeItem: null});
-  }
-  Store.prototype.activeItem = function(item) {
-    var _this = this;
+test("cascading active state (form 1)", function(t) {
+    var Store = function() {
+        m.extendObservable(this, { _activeItem: null })
+    }
+    Store.prototype.activeItem = function(item) {
+        var _this = this
 
-    if (arguments.length === 0) return this._activeItem;
+        if (arguments.length === 0) return this._activeItem
 
-    m.transaction(function() {
-      if (_this._activeItem === item) return;
-      if (_this._activeItem) _this._activeItem.isActive = false;
-      _this._activeItem = item;
-      if (_this._activeItem) _this._activeItem.isActive = true;
-    });
-  }
+        m.transaction(function() {
+            if (_this._activeItem === item) return
+            if (_this._activeItem) _this._activeItem.isActive = false
+            _this._activeItem = item
+            if (_this._activeItem) _this._activeItem.isActive = true
+        })
+    }
 
-  var Item = function() {
-    m.extendObservable(this, {isActive: false});
-  }
+    var Item = function() {
+        m.extendObservable(this, { isActive: false })
+    }
 
-  var store = new Store();
-  var item1 = new Item(), item2 = new Item();
-  t.equal(store.activeItem(), null);
-  t.equal(item1.isActive, false);
-  t.equal(item2.isActive, false);
+    var store = new Store()
+    var item1 = new Item(),
+        item2 = new Item()
+    t.equal(store.activeItem(), null)
+    t.equal(item1.isActive, false)
+    t.equal(item2.isActive, false)
 
-  store.activeItem(item1);
-  t.equal(store.activeItem(), item1);
-  t.equal(item1.isActive, true);
-  t.equal(item2.isActive, false);
+    store.activeItem(item1)
+    t.equal(store.activeItem(), item1)
+    t.equal(item1.isActive, true)
+    t.equal(item2.isActive, false)
 
-  store.activeItem(item2);
-  t.equal(store.activeItem(), item2);
-  t.equal(item1.isActive, false);
-  t.equal(item2.isActive, true);
+    store.activeItem(item2)
+    t.equal(store.activeItem(), item2)
+    t.equal(item1.isActive, false)
+    t.equal(item2.isActive, true)
 
-  store.activeItem(null);
-  t.equal(store.activeItem(), null);
-  t.equal(item1.isActive, false);
-  t.equal(item2.isActive, false);
+    store.activeItem(null)
+    t.equal(store.activeItem(), null)
+    t.equal(item1.isActive, false)
+    t.equal(item2.isActive, false)
 
-  t.end();
-});
+    t.end()
+})
 
-test('cascading active state (form 2)', function(t) {
-  var Store = function() {
-    var _this = this;
-    m.extendObservable(this, {activeItem: null});
+test("cascading active state (form 2)", function(t) {
+    var Store = function() {
+        var _this = this
+        m.extendObservable(this, { activeItem: null })
 
-    m.autorun(function() {
-      if (_this._activeItem === _this.activeItem) return;
-      if (_this._activeItem) _this._activeItem.isActive = false;
-      _this._activeItem = _this.activeItem;
-      if (_this._activeItem) _this._activeItem.isActive = true;
-    });
-  }
+        m.autorun(function() {
+            if (_this._activeItem === _this.activeItem) return
+            if (_this._activeItem) _this._activeItem.isActive = false
+            _this._activeItem = _this.activeItem
+            if (_this._activeItem) _this._activeItem.isActive = true
+        })
+    }
 
-  var Item = function() {
-    m.extendObservable(this, {isActive: false});
-  }
+    var Item = function() {
+        m.extendObservable(this, { isActive: false })
+    }
 
-  var store = new Store();
-  var item1 = new Item(), item2 = new Item();
-  t.equal(store.activeItem, null);
-  t.equal(item1.isActive, false);
-  t.equal(item2.isActive, false);
+    var store = new Store()
+    var item1 = new Item(),
+        item2 = new Item()
+    t.equal(store.activeItem, null)
+    t.equal(item1.isActive, false)
+    t.equal(item2.isActive, false)
 
-  store.activeItem = item1;
-  t.equal(store.activeItem, item1);
-  t.equal(item1.isActive, true);
-  t.equal(item2.isActive, false);
+    store.activeItem = item1
+    t.equal(store.activeItem, item1)
+    t.equal(item1.isActive, true)
+    t.equal(item2.isActive, false)
 
-  store.activeItem = item2;
-  t.equal(store.activeItem, item2);
-  t.equal(item1.isActive, false);
-  t.equal(item2.isActive, true);
+    store.activeItem = item2
+    t.equal(store.activeItem, item2)
+    t.equal(item1.isActive, false)
+    t.equal(item2.isActive, true)
 
-  store.activeItem = null;
-  t.equal(store.activeItem, null);
-  t.equal(item1.isActive, false);
-  t.equal(item2.isActive, false);
+    store.activeItem = null
+    t.equal(store.activeItem, null)
+    t.equal(item1.isActive, false)
+    t.equal(item2.isActive, false)
 
-  t.end();
-});
+    t.end()
+})
 
-test('emulate rendering', function(t) {
-  var renderCount = 0;
+test("emulate rendering", function(t) {
+    var renderCount = 0
 
-  var Component = function(props) {
-    var _this = this;
-    this.props = props;
-  }
-  Component.prototype.destroy = function() {
-    if (this.handler) { this.handler(); this.handler = null; }
-  }
+    var Component = function(props) {
+        var _this = this
+        this.props = props
+    }
+    Component.prototype.destroy = function() {
+        if (this.handler) {
+            this.handler()
+            this.handler = null
+        }
+    }
 
-  Component.prototype.render = function() {
-    var _this = this;
+    Component.prototype.render = function() {
+        var _this = this
 
-    if (this.handler) { this.handler(); this.handler = null; }
-    this.handler = m.autorun(function() {
-      if (!_this.props.data.title) _this.props.data.title = 'HELLO';
-      renderCount++;
-    });
-  }
+        if (this.handler) {
+            this.handler()
+            this.handler = null
+        }
+        this.handler = m.autorun(function() {
+            if (!_this.props.data.title) _this.props.data.title = "HELLO"
+            renderCount++
+        })
+    }
 
-  var data = {};
-  m.extendObservable(data, {title: null});
-  var component = new Component({data: data});
-  t.equal(renderCount, 0);
+    var data = {}
+    m.extendObservable(data, { title: null })
+    var component = new Component({ data: data })
+    t.equal(renderCount, 0)
 
-  component.render();
-  t.equal(renderCount, 1);
+    component.render()
+    t.equal(renderCount, 1)
 
-  data.title = 'WORLD';
-  t.equal(renderCount, 2);
+    data.title = "WORLD"
+    t.equal(renderCount, 2)
 
-  data.title = null;
-  // Note that this causes two invalidations
-  // however, the real mobx-react binding optimizes this as well
-  // see mobx-react #12, so maybe this ain't the best test
-  t.equal(renderCount, 4);
+    data.title = null
+    // Note that this causes two invalidations
+    // however, the real mobx-react binding optimizes this as well
+    // see mobx-react #12, so maybe this ain't the best test
+    t.equal(renderCount, 4)
 
-  data.title = 'WORLD';
-  t.equal(renderCount, 5);
+    data.title = "WORLD"
+    t.equal(renderCount, 5)
 
-  component.destroy();
-  data.title = 'HELLO';
-  t.equal(renderCount, 5);
+    component.destroy()
+    data.title = "HELLO"
+    t.equal(renderCount, 5)
 
-  t.end();
-});
+    t.end()
+})
 
-
-test('efficient selection', function(t) {
-
+test("efficient selection", function(t) {
     function Item(value) {
         m.extendObservable(this, {
             selected: false,
             value: value
-        });
+        })
     }
 
     function Store() {
-        this.prevSelection = null;
+        this.prevSelection = null
         m.extendObservable(this, {
             selection: null,
-            items: [
-                new Item(1),
-                new Item(2),
-                new Item(3)
-            ]
-        });
+            items: [new Item(1), new Item(2), new Item(3)]
+        })
         m.autorun(function() {
-			if (this.previousSelection === this.selection)
-				return true; // converging condition
-			if (this.previousSelection)
-				this.previousSelection.selected = false;
-			if (this.selection)
-				this.selection.selected = true;
-			this.previousSelection = this.selection;
-        }, this);
+            if (this.previousSelection === this.selection) return true // converging condition
+            if (this.previousSelection) this.previousSelection.selected = false
+            if (this.selection) this.selection.selected = true
+            this.previousSelection = this.selection
+        }, this)
     }
 
-    var store = new Store();
+    var store = new Store()
 
-    t.equal(store.selection, null);
-    t.equal(store.items.filter(function (i) { return i.selected }).length, 0);
+    t.equal(store.selection, null)
+    t.equal(
+        store.items.filter(function(i) {
+            return i.selected
+        }).length,
+        0
+    )
 
-    store.selection = store.items[1];
-    t.equal(store.items.filter(function (i) { return i.selected }).length, 1);
-    t.equal(store.selection, store.items[1]);
-    t.equal(store.items[1].selected, true);
+    store.selection = store.items[1]
+    t.equal(
+        store.items.filter(function(i) {
+            return i.selected
+        }).length,
+        1
+    )
+    t.equal(store.selection, store.items[1])
+    t.equal(store.items[1].selected, true)
 
-    store.selection = store.items[2];
-    t.equal(store.items.filter(function (i) { return i.selected }).length, 1);
-    t.equal(store.selection, store.items[2]);
-    t.equal(store.items[2].selected, true);
+    store.selection = store.items[2]
+    t.equal(
+        store.items.filter(function(i) {
+            return i.selected
+        }).length,
+        1
+    )
+    t.equal(store.selection, store.items[2])
+    t.equal(store.items[2].selected, true)
 
-    store.selection = null;
-    t.equal(store.items.filter(function (i) { return i.selected }).length, 0);
-    t.equal(store.selection, null);
+    store.selection = null
+    t.equal(
+        store.items.filter(function(i) {
+            return i.selected
+        }).length,
+        0
+    )
+    t.equal(store.selection, null)
 
-    t.end();
-});
+    t.end()
+})

--- a/test/errorhandling.js
+++ b/test/errorhandling.js
@@ -1,352 +1,379 @@
-var test = require('tape');
-var mobx = require('..');
-var m = mobx;
-var utils = require('./utils/test-utils');
+var test = require("tape")
+var mobx = require("..")
+var m = mobx
+var utils = require("./utils/test-utils")
 
-var observable = mobx.observable;
-var computed = mobx.computed;
+var observable = mobx.observable
+var computed = mobx.computed
 
-var voidObserver = function(){};
+var voidObserver = function() {}
 
 function buffer() {
-    var b = [];
+    var b = []
     var res = function(newValue) {
-        b.push(newValue);
-    };
+        b.push(newValue)
+    }
     res.toArray = function() {
-        return b;
-    };
-    return res;
+        return b
+    }
+    return res
 }
 
 function checkGlobalState(t) {
-	const gs = mobx.extras.getGlobalState();
-	t.equal(gs.isRunningReactions, false)
-	t.equal(gs.trackingDerivation, null)
-	t.equal(gs.inBatch, 0)
-	t.equal(gs.allowStateChanges, !gs.strictMode)
-	t.equal(gs.pendingUnobservations.length, 0)
+    const gs = mobx.extras.getGlobalState()
+    t.equal(gs.isRunningReactions, false)
+    t.equal(gs.trackingDerivation, null)
+    t.equal(gs.inBatch, 0)
+    t.equal(gs.allowStateChanges, !gs.strictMode)
+    t.equal(gs.pendingUnobservations.length, 0)
 }
 
-test('exception1', function(t) {
+test("exception1", function(t) {
     var a = computed(function() {
-        throw "hoi";
-    });
-    t.throws(() => a(), "hoi");
-	checkGlobalState(t);
-    t.end();
+        throw "hoi"
+    })
+    t.throws(() => a(), "hoi")
+    checkGlobalState(t)
+    t.end()
 })
 
-test('exceptions in computed values can be recovered from', t => {
-	var a = observable({
-		x: 1,
-		get y() {
-			if (this.x === 2)
-				throw "Uhoh"
-			return this.x * 2
-		}
-	})
+test("exceptions in computed values can be recovered from", t => {
+    var a = observable({
+        x: 1,
+        get y() {
+            if (this.x === 2) throw "Uhoh"
+            return this.x * 2
+        }
+    })
 
-	t.equal(a.y, 2)
-	a.x = 2
+    t.equal(a.y, 2)
+    a.x = 2
 
-	t.throws(() => a.y, /Uhoh/)
+    t.throws(() => a.y, /Uhoh/)
 
-	checkGlobalState(t)
+    checkGlobalState(t)
 
-	a.x = 3
-	t.equal(a.y, 6)
-	checkGlobalState(t)
-	t.end()
+    a.x = 3
+    t.equal(a.y, 6)
+    checkGlobalState(t)
+    t.end()
 })
 
-test('exception when starting autorun can be recovered from', t => {
-	var b = undefined
-	var a = observable({
-		x: 2,
-		get y() {
-			if (this.x === 2)
-				throw "Uhoh"
-			return this.x * 2
-		}
-	})
+test("exception when starting autorun can be recovered from", t => {
+    var b = undefined
+    var a = observable({
+        x: 2,
+        get y() {
+            if (this.x === 2) throw "Uhoh"
+            return this.x * 2
+        }
+    })
 
-	utils.consoleError(t, () => {
-		mobx.autorun(() => { b = a.y })
-	}, /Uhoh/)
-	t.equal(b, undefined)
-	checkGlobalState(t)
-	a.x = 3
-	t.equal(b, 6)
-	checkGlobalState(t)
-	t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
-	t.end()
+    utils.consoleError(
+        t,
+        () => {
+            mobx.autorun(() => {
+                b = a.y
+            })
+        },
+        /Uhoh/
+    )
+    t.equal(b, undefined)
+    checkGlobalState(t)
+    a.x = 3
+    t.equal(b, 6)
+    checkGlobalState(t)
+    t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
+    t.end()
 })
 
-test('exception in autorun can be recovered from', t => {
-	var b = undefined
-	var a = observable({
-		x: 1,
-		get y() {
-			if (this.x === 2)
-				throw "Uhoh"
-			return this.x * 2
-		}
-	})
+test("exception in autorun can be recovered from", t => {
+    var b = undefined
+    var a = observable({
+        x: 1,
+        get y() {
+            if (this.x === 2) throw "Uhoh"
+            return this.x * 2
+        }
+    })
 
-	var d = mobx.autorun(() => { b = a.y })
-	t.equal(a.y, 2)
-	t.equal(b, 2)
-	t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
+    var d = mobx.autorun(() => {
+        b = a.y
+    })
+    t.equal(a.y, 2)
+    t.equal(b, 2)
+    t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
 
-	utils.consoleError(t, () => {
-		a.x = 2
-	}, /Uhoh/)
+    utils.consoleError(
+        t,
+        () => {
+            a.x = 2
+        },
+        /Uhoh/
+    )
 
-	// exception is also rethrown to each consumer
-	t.throws(() => {
-		t.equal(a.y, 2) // old cached value!
-	}, /Uhoh/)
-	t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
+    // exception is also rethrown to each consumer
+    t.throws(() => {
+        t.equal(a.y, 2) // old cached value!
+    }, /Uhoh/)
+    t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
 
-	t.equal(b, 2)
-	checkGlobalState(t)
+    t.equal(b, 2)
+    checkGlobalState(t)
 
-	a.x = 3
-	t.equal(a.y, 6)
-	t.equal(b, 6)
-	checkGlobalState(t)
-	t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
-	d()
-	t.equal(mobx.extras.getAtom(a, "y").observers.length, 0)
-	t.end()
+    a.x = 3
+    t.equal(a.y, 6)
+    t.equal(b, 6)
+    checkGlobalState(t)
+    t.equal(mobx.extras.getAtom(a, "y").observers.length, 1)
+    d()
+    t.equal(mobx.extras.getAtom(a, "y").observers.length, 0)
+    t.end()
 })
 
-test('multiple autoruns with exceptions are handled correctly', t => {
-	var a = mobx.observable(1)
-	var values = []
-	var d1 = mobx.autorun(() => values.push("a" + a.get()))
-	var d2 = mobx.autorun(() => {
-		if (a.get() === 2)
-			throw /Uhoh/
-		values.push("b" + a.get())
-	})
-	var d3 = mobx.autorun(() => values.push("c" + a.get()))
+test("multiple autoruns with exceptions are handled correctly", t => {
+    var a = mobx.observable(1)
+    var values = []
+    var d1 = mobx.autorun(() => values.push("a" + a.get()))
+    var d2 = mobx.autorun(() => {
+        if (a.get() === 2) throw /Uhoh/
+        values.push("b" + a.get())
+    })
+    var d3 = mobx.autorun(() => values.push("c" + a.get()))
 
-	t.deepEqual(values, ["a1", "b1", "c1"])
-	values.splice(0)
+    t.deepEqual(values, ["a1", "b1", "c1"])
+    values.splice(0)
 
-	utils.consoleError(t,() => a.set(2), /Uhoh/)
-	checkGlobalState(t)
+    utils.consoleError(t, () => a.set(2), /Uhoh/)
+    checkGlobalState(t)
 
-	t.deepEqual(values.sort(), ["a2", "c2"]) // order is irrelevant
-	values.splice(0)
+    t.deepEqual(values.sort(), ["a2", "c2"]) // order is irrelevant
+    values.splice(0)
 
-	a.set(3)
-	t.deepEqual(values.sort(), ["a3", "b3", "c3"]) // order is irrelevant
+    a.set(3)
+    t.deepEqual(values.sort(), ["a3", "b3", "c3"]) // order is irrelevant
 
-	checkGlobalState(t)
-	d1(); d2(); d3()
-	t.end()
+    checkGlobalState(t)
+    d1()
+    d2()
+    d3()
+    t.end()
 })
 
-test('deny state changes in views', function(t) {
-    var x = observable(3);
-    var z = observable(5);
+test("deny state changes in views", function(t) {
+    var x = observable(3)
+    var z = observable(5)
     var y = computed(function() {
-        z(6);
-        return x() * x();
-    });
-
+        z(6)
+        return x() * x()
+    })
 
     t.throws(() => {
         y()
-    }, 'It is not allowed to change the state during the computation of a reactive view');
+    }, "It is not allowed to change the state during the computation of a reactive view")
 
-	checkGlobalState(t);
-    t.end();
+    checkGlobalState(t)
+    t.end()
 })
 
-test('allow state changes in autorun', function(t) {
-    var x = observable(3);
-    var z = observable(3);
+test("allow state changes in autorun", function(t) {
+    var x = observable(3)
+    var z = observable(3)
 
     m.autorun(function() {
-        if (x.get() !== 3)
-            z.set(x.get());
-    });
+        if (x.get() !== 3) z.set(x.get())
+    })
 
-    t.equal(x.get(), 3);
-    t.equal(z.get(), 3);
+    t.equal(x.get(), 3)
+    t.equal(z.get(), 3)
 
-    x.set(5); // autorunneres are allowed to change state
+    x.set(5) // autorunneres are allowed to change state
 
-    t.equal(x.get(), 5);
-    t.equal(z.get(), 5);
+    t.equal(x.get(), 5)
+    t.equal(z.get(), 5)
 
-    t.equal(mobx.extras.isComputingDerivation(), false);
-	checkGlobalState(t);
-    t.end();
+    t.equal(mobx.extras.isComputingDerivation(), false)
+    checkGlobalState(t)
+    t.end()
 })
 
-test('deny array change in view', function(t) {
+test("deny array change in view", function(t) {
     try {
-        var x = observable(3);
-        var z = observable([]);
+        var x = observable(3)
+        var z = observable([])
         var y = computed(function() {
-            z.push(3);
-            return x() * x();
-        });
+            z.push(3)
+            return x() * x()
+        })
 
         t.throws(function() {
-            t.equal(9, y());
-        }, 'It is not allowed to change the state during the computation of a reactive derivation');
+            t.equal(9, y())
+        }, "It is not allowed to change the state during the computation of a reactive derivation")
 
-        t.deepEqual(z.slice(), []);
-        t.equal(mobx.extras.isComputingDerivation(), false);
+        t.deepEqual(z.slice(), [])
+        t.equal(mobx.extras.isComputingDerivation(), false)
 
-		checkGlobalState(t);
-        t.end();
-    }
-    catch(e) {
-        console.log(e.stack);
+        checkGlobalState(t)
+        t.end()
+    } catch (e) {
+        console.log(e.stack)
     }
 })
 
-test('allow array change in autorun', function(t) {
-    var x = observable(3);
-    var z = observable([]);
+test("allow array change in autorun", function(t) {
+    var x = observable(3)
+    var z = observable([])
     var y = m.autorun(function() {
-        if (x.get() > 4)
-            z.push(x.get());
-    });
+        if (x.get() > 4) z.push(x.get())
+    })
 
-    x.set(5);
-    x.set(6);
+    x.set(5)
+    x.set(6)
     t.deepEqual(z.slice(), [5, 6])
-    x.set(2);
+    x.set(2)
     t.deepEqual(z.slice(), [5, 6])
 
-    t.equal(mobx.extras.isComputingDerivation(), false);
-	checkGlobalState(t);
-    t.end();
+    t.equal(mobx.extras.isComputingDerivation(), false)
+    checkGlobalState(t)
+    t.end()
 })
 
-test('throw error if modification loop', function(t) {
-    var x = observable(3);
+test("throw error if modification loop", function(t) {
+    var x = observable(3)
     var dis = m.autorun(function() {
-        x.set(x.get() + 1); // is allowed to throw, but doesn't as the observables aren't bound yet during first execution
-    });
-    utils.consoleError(t, () => {
-        x.set(5);
-    }, /Reaction doesn't converge to a stable state/)
-	checkGlobalState(t);
-    t.end();
+        x.set(x.get() + 1) // is allowed to throw, but doesn't as the observables aren't bound yet during first execution
+    })
+    utils.consoleError(
+        t,
+        () => {
+            x.set(5)
+        },
+        /Reaction doesn't converge to a stable state/
+    )
+    checkGlobalState(t)
+    t.end()
 })
 
-test('cycle1', function(t) {
-	var p = computed(function() { return p.get() * 2; }); // thats a cycle!
-    utils.consoleError(t, () => {
-        p.observe(voidObserver, true);
-    }, /Cycle detected/);
-	checkGlobalState(t);
-    t.end();
+test("cycle1", function(t) {
+    var p = computed(function() {
+        return p.get() * 2
+    }) // thats a cycle!
+    utils.consoleError(
+        t,
+        () => {
+            p.observe(voidObserver, true)
+        },
+        /Cycle detected/
+    )
+    checkGlobalState(t)
+    t.end()
 })
 
-test('cycle2', function(t) {
-    var a = computed(function() { return b.get() * 2; });
-    var b = computed(function() { return a.get() * 2; });
+test("cycle2", function(t) {
+    var a = computed(function() {
+        return b.get() * 2
+    })
+    var b = computed(function() {
+        return a.get() * 2
+    })
     t.throws(() => {
         b.get()
-    }, "Found cyclic dependency");
-	checkGlobalState(t);
-    t.end();
+    }, "Found cyclic dependency")
+    checkGlobalState(t)
+    t.end()
 })
 
-test('cycle3', function(t) {
-    var p = computed(function() { return p.get() * 2; });
+test("cycle3", function(t) {
+    var p = computed(function() {
+        return p.get() * 2
+    })
     t.throws(() => {
-        p.get();
-    }, "Found cyclic dependency");
-	checkGlobalState(t);
-    t.end();
+        p.get()
+    }, "Found cyclic dependency")
+    checkGlobalState(t)
+    t.end()
 })
 
-test('cycle4', function(t) {
-    var z = observable(true);
-    var a = computed(function() { return z.get() ? 1 : b.get() * 2; });
-    var b = computed(function() { return a.get() * 2; });
+test("cycle4", function(t) {
+    var z = observable(true)
+    var a = computed(function() {
+        return z.get() ? 1 : b.get() * 2
+    })
+    var b = computed(function() {
+        return a.get() * 2
+    })
 
-    m.observe(b, voidObserver);
-    t.equal(1, a.get());
+    m.observe(b, voidObserver)
+    t.equal(1, a.get())
 
-    utils.consoleError(t, () => {
-        z.set(false); // introduces a cycle!
-    }, /Cycle detected/);
-	checkGlobalState(t);
-    t.end();
-});
+    utils.consoleError(
+        t,
+        () => {
+            z.set(false) // introduces a cycle!
+        },
+        /Cycle detected/
+    )
+    checkGlobalState(t)
+    t.end()
+})
 
 test("throws when the max iterations over reactions are done", t => {
-	var foo = mobx.observable({
-		a: 1,
-	});
+    var foo = mobx.observable({
+        a: 1
+    })
 
-	mobx.autorun("bar", () => {
-		var x = foo.a;
-		foo.a = Math.random();
-	});
+    mobx.autorun("bar", () => {
+        var x = foo.a
+        foo.a = Math.random()
+    })
 
-	utils.consoleError(t,
-		() => foo.a++,
-		/Reaction doesn't converge to a stable state after 100 iterations/
-	);
-	mobx.extras.resetGlobalState();
-	t.end();
+    utils.consoleError(
+        t,
+        () => foo.a++,
+        /Reaction doesn't converge to a stable state after 100 iterations/
+    )
+    mobx.extras.resetGlobalState()
+    t.end()
 })
 
-test('issue 86, converging cycles', function(t) {
+test("issue 86, converging cycles", function(t) {
     function findIndex(arr, predicate) {
-        for (var i = 0, l = arr.length; i < l; i++)
-            if (predicate(arr[i]) === true)
-                return i;
-        return -1;
+        for (var i = 0, l = arr.length; i < l; i++) if (predicate(arr[i]) === true) return i
+        return -1
     }
 
-    const deleteThisId = mobx.observable(1);
-    const state = mobx.observable({ someArray: [] });
-    var calcs = 0;
+    const deleteThisId = mobx.observable(1)
+    const state = mobx.observable({ someArray: [] })
+    var calcs = 0
 
-    state.someArray.push({ id: 1, text: 'I am 1' });
-    state.someArray.push({ id: 2, text: 'I am 2' });
+    state.someArray.push({ id: 1, text: "I am 1" })
+    state.someArray.push({ id: 2, text: "I am 2" })
 
     // should delete item 1 in first run, which works fine
     mobx.autorun(() => {
-        calcs++;
-        const i = findIndex(state.someArray, item => item.id === deleteThisId.get());
-        state.someArray.remove(state.someArray[i]);
-    });
+        calcs++
+        const i = findIndex(state.someArray, item => item.id === deleteThisId.get())
+        state.someArray.remove(state.someArray[i])
+    })
 
-    t.equal(state.someArray.length, 1); // should be 1, which prints fine
-    t.equal(calcs, 1);
-    deleteThisId.set(2); // should delete item 2, but it errors on cycle
+    t.equal(state.someArray.length, 1) // should be 1, which prints fine
+    t.equal(calcs, 1)
+    deleteThisId.set(2) // should delete item 2, but it errors on cycle
 
-    t.equal(console.log(state.someArray.length, 0)); // should be 0, which never prints
-    t.equal(calcs, 3);
+    t.equal(console.log(state.someArray.length, 0)) // should be 0, which never prints
+    t.equal(calcs, 3)
 
-	checkGlobalState(t);
-    t.end();
-});
+    checkGlobalState(t)
+    t.end()
+})
 
-test('slow converging cycle', function(t) {
-    var x = mobx.observable(1);
-    var res = -1;
+test("slow converging cycle", function(t) {
+    var x = mobx.observable(1)
+    var res = -1
     mobx.autorun(() => {
-        if (x.get() === 100)
-            res = x.get();
-        else
-            x.set(x.get() + 1);
-    });
+        if (x.get() === 100) res = x.get()
+        else x.set(x.get() + 1)
+    })
 
     // ideally the outcome should be 100 / 100.
     // autorun is only an observer of x *after* the first run, hence the initial outcome is not as expected..
@@ -354,365 +381,366 @@ test('slow converging cycle', function(t) {
     // maybe we need to immediately register observers on the observable? but that would be slow....
     // or detect cycles and re-run the autorun in that case once?
     t.equal(x.get(), 2)
-    t.equal(res, -1);
+    t.equal(res, -1)
 
-    x.set(7);
+    x.set(7)
     t.equal(x.get(), 100)
-    t.equal(res, 100);
+    t.equal(res, 100)
 
-	checkGlobalState(t);
-    t.end();
-});
+    checkGlobalState(t)
+    t.end()
+})
 
-test('error handling assistence ', function(t) {
-    var baseError = console.error;
-	var baseWarn = console.warn;
-    var errors = []; // logged errors
-    var warns = [];  // logged warns
-	var values = []; // produced errors
-    var thrown = []; // list of actually thrown exceptons
+test("error handling assistence ", function(t) {
+    var baseError = console.error
+    var baseWarn = console.warn
+    var errors = [] // logged errors
+    var warns = [] // logged warns
+    var values = [] // produced errors
+    var thrown = [] // list of actually thrown exceptons
 
     console.error = function(msg) {
-        baseError.apply(console, arguments);
-        errors.push(msg);
+        baseError.apply(console, arguments)
+        errors.push(msg)
     }
     console.warn = function(msg) {
-        baseWarn.apply(console, arguments);
-        warns.push(msg);
+        baseWarn.apply(console, arguments)
+        warns.push(msg)
     }
 
-    var a = observable(3);
+    var a = observable(3)
     var b = computed(function() {
-        if (a.get() === 42)
-            throw 'should not be 42';
-        return a.get() * 2;
-    });
+        if (a.get() === 42) throw "should not be 42"
+        return a.get() * 2
+    })
 
     var c = m.autorun(function() {
-        values.push(b.get());
-    });
+        values.push(b.get())
+    })
 
-    a.set(2);
-    try{
-        a.set(42);
+    a.set(2)
+    try {
+        a.set(42)
     } catch (e) {
-        thrown.push(e);
+        thrown.push(e)
     }
-    a.set(7);
+    a.set(7)
 
     // Test recovery
     setTimeout(function() {
-        a.set(4);
+        a.set(4)
         try {
-            a.set(42);
+            a.set(42)
         } catch (e) {
-            thrown.push(e);
+            thrown.push(e)
         }
 
-        t.deepEqual(values, [6, 4, 14, 8]);
-        t.equal(errors.length, 2);
-		t.equal(warns.length, 0);
-        t.equal(thrown.length, 0); // Mobx doesn't propagate throws from reactions
+        t.deepEqual(values, [6, 4, 14, 8])
+        t.equal(errors.length, 2)
+        t.equal(warns.length, 0)
+        t.equal(thrown.length, 0) // Mobx doesn't propagate throws from reactions
 
-        console.error = baseError;
-		console.warn = baseWarn;
+        console.error = baseError
+        console.warn = baseWarn
 
-		checkGlobalState(t);
-        t.end();
-    }, 10);
+        checkGlobalState(t)
+        t.end()
+    }, 10)
 })
 
-test('236 - cycles', t => {
-	var Parent = function() {
-		m.extendObservable(this, {
-			children: [],
-			get total0() {
-				// Sum "value" of children of kind "0"
-				return this.children.filter(c => c.kind === 0).map(c => c.value).reduce((a, b) => a+b, 0);
-			},
-			get total1() {
-				// Sum "value" of children of kind "1"
-				return this.children.filter(c => c.kind === 1).map(c => c.value).reduce((a, b) => a+b, 0);
-			}
-		});
-	};
+test("236 - cycles", t => {
+    var Parent = function() {
+        m.extendObservable(this, {
+            children: [],
+            get total0() {
+                // Sum "value" of children of kind "0"
+                return this.children
+                    .filter(c => c.kind === 0)
+                    .map(c => c.value)
+                    .reduce((a, b) => a + b, 0)
+            },
+            get total1() {
+                // Sum "value" of children of kind "1"
+                return this.children
+                    .filter(c => c.kind === 1)
+                    .map(c => c.value)
+                    .reduce((a, b) => a + b, 0)
+            }
+        })
+    }
 
-	var Child = function(parent, kind) {
-		this.parent = parent;
-		m.extendObservable(this, {
-			kind: kind,
-			get value() {
-				if (this.kind === 0) {
-					return 3;
-				} else {
-					// Value of child of kind "1" depends on the total value for all children of kind "0"
-					return this.parent.total0 * 2;
-				}
-			}
-		});
-	};
+    var Child = function(parent, kind) {
+        this.parent = parent
+        m.extendObservable(this, {
+            kind: kind,
+            get value() {
+                if (this.kind === 0) {
+                    return 3
+                } else {
+                    // Value of child of kind "1" depends on the total value for all children of kind "0"
+                    return this.parent.total0 * 2
+                }
+            }
+        })
+    }
 
-	const parent = new Parent();
-	parent.children.push(new Child(parent, 0));
-	parent.children.push(new Child(parent, 0));
-	parent.children.push(new Child(parent, 0));
+    const parent = new Parent()
+    parent.children.push(new Child(parent, 0))
+    parent.children.push(new Child(parent, 0))
+    parent.children.push(new Child(parent, 0))
 
-	var msg = [];
-	var d = m.autorun(() => {
-		msg.push('total0:', parent.total0, 'total1:', parent.total1);
-	});
-	// So far, so good: total0: 9 total1: 0
-	t.deepEqual(msg, ["total0:", 9, "total1:", 0])
-	parent.children[0].kind = 1;
-	t.deepEqual(msg, [
-		"total0:", 9, "total1:", 0,
-		"total0:", 6, "total1:", 12
-	])
+    var msg = []
+    var d = m.autorun(() => {
+        msg.push("total0:", parent.total0, "total1:", parent.total1)
+    })
+    // So far, so good: total0: 9 total1: 0
+    t.deepEqual(msg, ["total0:", 9, "total1:", 0])
+    parent.children[0].kind = 1
+    t.deepEqual(msg, ["total0:", 9, "total1:", 0, "total0:", 6, "total1:", 12])
 
-	checkGlobalState(t);
-	t.end();
+    checkGlobalState(t)
+    t.end()
 })
 
-test('peeking inside erroring computed value doesn\'t bork (global) state', t => {
-	const a = mobx.observable(1)
-	const b = mobx.computed(() => {
-		a.get()
-		throw "chocolademelk"
-	})
+test("peeking inside erroring computed value doesn't bork (global) state", t => {
+    const a = mobx.observable(1)
+    const b = mobx.computed(() => {
+        a.get()
+        throw "chocolademelk"
+    })
 
-	t.throws(() => {
-		b.get()
-	}, /chocolademelk/)
+    t.throws(() => {
+        b.get()
+    }, /chocolademelk/)
 
-	t.equal(a.isPendingUnobservation, true) // true is a default for optimization
-	t.equal(a.observers.length, 0)
-	t.equal(a.diffValue, 0)
-	t.equal(a.lowestObserverState, -1)
-	t.equal(a.hasUnreportedChange, false)
-	t.equal(a.value, 1)
+    t.equal(a.isPendingUnobservation, true) // true is a default for optimization
+    t.equal(a.observers.length, 0)
+    t.equal(a.diffValue, 0)
+    t.equal(a.lowestObserverState, -1)
+    t.equal(a.hasUnreportedChange, false)
+    t.equal(a.value, 1)
 
-	// t.equal(b.dependenciesState, 0) // TODO: re-enable
-	t.equal(b.observing.length, 0)
-	t.equal(b.newObserving, null)
-	t.equal(b.isPendingUnobservation, false)
-	t.equal(b.observers.length, 0)
-	t.equal(b.diffValue, 0)
-	t.equal(b.lowestObserverState, 0)
-	t.equal(b.unboundDepsCount, 0)
-	t.throws(() => {
-		b.get();
-	}, /chocolademelk/)
-	t.equal(b.isComputing, false)
+    // t.equal(b.dependenciesState, 0) // TODO: re-enable
+    t.equal(b.observing.length, 0)
+    t.equal(b.newObserving, null)
+    t.equal(b.isPendingUnobservation, false)
+    t.equal(b.observers.length, 0)
+    t.equal(b.diffValue, 0)
+    t.equal(b.lowestObserverState, 0)
+    t.equal(b.unboundDepsCount, 0)
+    t.throws(() => {
+        b.get()
+    }, /chocolademelk/)
+    t.equal(b.isComputing, false)
 
-	checkGlobalState(t)
+    checkGlobalState(t)
 
-	t.end()
+    t.end()
 })
 
+test("peeking inside autorun doesn't bork (global) state", t => {
+    var r = -1
+    const a = mobx.observable(1)
+    const b = mobx.computed(() => {
+        const res = (r = a.get())
+        if (res === 2) throw "chocolademelk"
+        return res
+    })
+    const d = mobx.autorun(() => b.get())
+    const c = d.$mobx
 
-test('peeking inside autorun doesn\'t bork (global) state', t => {
-	var r = -1
-	const a = mobx.observable(1)
-	const b = mobx.computed(() => {
-		const res = r = a.get()
-		if (res === 2)
-			throw "chocolademelk"
-		return res
-	})
-	const d = mobx.autorun(() => b.get())
-	const c = d.$mobx;
+    t.equal(b.get(), 1)
+    t.equal(r, 1)
 
-	t.equal(b.get(), 1)
-	t.equal(r, 1)
+    test("it should update correctly initially", t => {
+        t.equal(a.isPendingUnobservation, true) // true is a default for optimization
+        t.equal(a.observers.length, 1)
+        t.equal(a.diffValue, 0)
+        t.equal(a.lowestObserverState, -1)
+        t.equal(a.hasUnreportedChange, false)
+        t.equal(a.value, 1)
 
-	test("it should update correctly initially", t => {
-		t.equal(a.isPendingUnobservation, true) // true is a default for optimization
-		t.equal(a.observers.length, 1)
-		t.equal(a.diffValue, 0)
-		t.equal(a.lowestObserverState, -1)
-		t.equal(a.hasUnreportedChange, false)
-		t.equal(a.value, 1)
+        t.equal(b.dependenciesState, 0)
+        t.equal(b.observing.length, 1)
+        t.equal(b.newObserving, null)
+        t.equal(b.isPendingUnobservation, false)
+        t.equal(b.observers.length, 1)
+        t.equal(b.diffValue, 0)
+        t.equal(b.lowestObserverState, 0)
+        t.equal(b.unboundDepsCount, 1) // value is always the last bound amount of observers
+        t.equal(b.value, 1, "value should be 1")
+        t.equal(b.isComputing, false)
 
-		t.equal(b.dependenciesState, 0)
-		t.equal(b.observing.length, 1)
-		t.equal(b.newObserving, null)
-		t.equal(b.isPendingUnobservation, false)
-		t.equal(b.observers.length, 1)
-		t.equal(b.diffValue, 0)
-		t.equal(b.lowestObserverState, 0)
-		t.equal(b.unboundDepsCount, 1) // value is always the last bound amount of observers
-		t.equal(b.value, 1, "value should be 1")
-		t.equal(b.isComputing, false)
+        t.equal(c.dependenciesState, 0)
+        t.equal(c.observing.length, 1)
+        t.equal(c.newObserving, null)
+        t.equal(c.diffValue, 0)
+        t.equal(c.unboundDepsCount, 1)
+        t.equal(c.isDisposed, false)
+        t.equal(c._isScheduled, false)
+        t.equal(c._isTrackPending, false)
+        t.equal(c._isRunning, false)
+        checkGlobalState(t)
+        t.end()
+    })
 
-		t.equal(c.dependenciesState, 0)
-		t.equal(c.observing.length, 1)
-		t.equal(c.newObserving, null)
-		t.equal(c.diffValue, 0)
-		t.equal(c.unboundDepsCount, 1)
-		t.equal(c.isDisposed, false)
-		t.equal(c._isScheduled, false)
-		t.equal(c._isTrackPending, false)
-		t.equal(c._isRunning, false)
-		checkGlobalState(t)
-		t.end()
-	})
+    test("it should not break internal consistency when exception occurred", t => {
+        // Trigger exception
+        utils.consoleError(
+            t,
+            () => {
+                a.set(2)
+            },
+            /chocolademelk/
+        )
+        t.equal(r, 2)
 
-	test("it should not break internal consistency when exception occurred", t => {
-		// Trigger exception
-		utils.consoleError(t, () => {
-			a.set(2)
-		}, /chocolademelk/)
-		t.equal(r, 2)
+        t.equal(a.isPendingUnobservation, true) // true is a default for optimization
+        t.equal(a.observers.length, 1)
+        t.equal(a.diffValue, 0)
+        t.equal(a.lowestObserverState, 0)
+        t.equal(a.hasUnreportedChange, false)
+        t.equal(a.value, 2)
 
-		t.equal(a.isPendingUnobservation, true) // true is a default for optimization
-		t.equal(a.observers.length, 1)
-		t.equal(a.diffValue, 0)
-		t.equal(a.lowestObserverState, 0)
-		t.equal(a.hasUnreportedChange, false)
-		t.equal(a.value, 2)
+        t.equal(b.dependenciesState, 0) // up to date (for what it's worth)
+        t.equal(b.observing.length, 1)
+        t.equal(b.newObserving, null)
+        t.equal(b.isPendingUnobservation, false)
+        t.equal(b.observers.length, 1)
+        t.equal(b.diffValue, 0)
+        t.equal(b.lowestObserverState, 0)
+        t.equal(b.unboundDepsCount, 1)
+        t.equal(b.isComputing, false)
+        t.throws(() => b.get(), /chocolademelk/)
 
-		t.equal(b.dependenciesState, 0) // up to date (for what it's worth)
-		t.equal(b.observing.length, 1)
-		t.equal(b.newObserving, null)
-		t.equal(b.isPendingUnobservation, false)
-		t.equal(b.observers.length, 1)
-		t.equal(b.diffValue, 0)
-		t.equal(b.lowestObserverState, 0)
-		t.equal(b.unboundDepsCount, 1)
-		t.equal(b.isComputing, false)
-		t.throws(() => b.get(), /chocolademelk/)
+        t.equal(c.dependenciesState, 0)
+        t.equal(c.observing.length, 1)
+        t.equal(c.newObserving, null)
+        t.equal(c.diffValue, 0)
+        t.equal(c.unboundDepsCount, 1)
+        t.equal(c.isDisposed, false)
+        t.equal(c._isScheduled, false)
+        t.equal(c._isTrackPending, false)
+        t.equal(c._isRunning, false)
+        checkGlobalState(t)
+        t.end()
+    })
 
-		t.equal(c.dependenciesState, 0)
-		t.equal(c.observing.length, 1)
-		t.equal(c.newObserving, null)
-		t.equal(c.diffValue, 0)
-		t.equal(c.unboundDepsCount, 1)
-		t.equal(c.isDisposed, false)
-		t.equal(c._isScheduled, false)
-		t.equal(c._isTrackPending, false)
-		t.equal(c._isRunning, false)
-		checkGlobalState(t)
-		t.end()
-	})
+    // Trigger a new change, will this recover?
+    // is this actually a supported case or should we just give up?
+    test("it should recover from errors", t => {
+        a.set(3)
+        t.equal(r, 3, "recovered from error")
 
-	// Trigger a new change, will this recover?
-	// is this actually a supported case or should we just give up?
-	test("it should recover from errors", t => {
-		a.set(3)
-		t.equal(r, 3, "recovered from error")
+        t.equal(a.isPendingUnobservation, true) // true is a default for optimization
+        t.equal(a.observers.length, 1)
+        t.equal(a.diffValue, 0)
+        t.equal(a.lowestObserverState, 0)
+        t.equal(a.hasUnreportedChange, false)
+        t.equal(a.value, 3)
 
-		t.equal(a.isPendingUnobservation, true) // true is a default for optimization
-		t.equal(a.observers.length, 1)
-		t.equal(a.diffValue, 0)
-		t.equal(a.lowestObserverState, 0)
-		t.equal(a.hasUnreportedChange, false)
-		t.equal(a.value, 3)
+        t.equal(b.dependenciesState, 0) // up to date
+        t.equal(b.observing.length, 1)
+        t.equal(b.newObserving, null)
+        t.equal(b.isPendingUnobservation, false)
+        t.equal(b.observers.length, 1)
+        t.equal(b.diffValue, 0)
+        t.equal(b.lowestObserverState, 0)
+        t.equal(b.unboundDepsCount, 1)
+        t.equal(b.value, 3, "value should be 3")
+        t.equal(b.isComputing, false)
 
-		t.equal(b.dependenciesState, 0) // up to date
-		t.equal(b.observing.length, 1)
-		t.equal(b.newObserving, null)
-		t.equal(b.isPendingUnobservation, false)
-		t.equal(b.observers.length, 1)
-		t.equal(b.diffValue, 0)
-		t.equal(b.lowestObserverState, 0)
-		t.equal(b.unboundDepsCount, 1)
-		t.equal(b.value, 3, "value should be 3")
-		t.equal(b.isComputing, false)
+        t.equal(c.dependenciesState, 0)
+        t.equal(c.observing.length, 1)
+        t.equal(c.newObserving, null)
+        t.equal(c.diffValue, 0)
+        t.equal(c.unboundDepsCount, 1)
+        t.equal(c.isDisposed, false)
+        t.equal(c._isScheduled, false)
+        t.equal(c._isTrackPending, false)
+        t.equal(c._isRunning, false)
 
-		t.equal(c.dependenciesState, 0)
-		t.equal(c.observing.length, 1)
-		t.equal(c.newObserving, null)
-		t.equal(c.diffValue, 0)
-		t.equal(c.unboundDepsCount, 1)
-		t.equal(c.isDisposed, false)
-		t.equal(c._isScheduled, false)
-		t.equal(c._isTrackPending, false)
-		t.equal(c._isRunning, false)
+        checkGlobalState(t)
+        t.end()
+    })
 
-		checkGlobalState(t)
-		t.end()
-	})
+    test("it should clean up correctly", t => {
+        d()
 
-	test("it should clean up correctly", t => {
-		d()
+        t.equal(a.isPendingUnobservation, true) // true is a default for optimization
+        t.equal(a.observers.length, 0)
+        t.equal(a.diffValue, 0)
+        t.equal(a.lowestObserverState, 0)
+        t.equal(a.hasUnreportedChange, false)
+        t.equal(a.value, 3)
 
-		t.equal(a.isPendingUnobservation, true) // true is a default for optimization
-		t.equal(a.observers.length, 0)
-		t.equal(a.diffValue, 0)
-		t.equal(a.lowestObserverState, 0)
-		t.equal(a.hasUnreportedChange, false)
-		t.equal(a.value, 3)
+        t.equal(b.dependenciesState, -1) // not tracking
+        t.equal(b.observing.length, 0)
+        t.equal(b.newObserving, null)
+        t.equal(b.isPendingUnobservation, false)
+        t.equal(b.observers.length, 0)
+        t.equal(b.diffValue, 0)
+        t.equal(b.lowestObserverState, 0)
+        t.equal(b.unboundDepsCount, 1)
+        t.equal(b.value, undefined)
+        t.equal(b.isComputing, false)
 
-		t.equal(b.dependenciesState, -1) // not tracking
-		t.equal(b.observing.length, 0)
-		t.equal(b.newObserving, null)
-		t.equal(b.isPendingUnobservation, false)
-		t.equal(b.observers.length, 0)
-		t.equal(b.diffValue, 0)
-		t.equal(b.lowestObserverState, 0)
-		t.equal(b.unboundDepsCount, 1)
-		t.equal(b.value, undefined)
-		t.equal(b.isComputing, false)
+        t.equal(c.dependenciesState, -1)
+        t.equal(c.observing.length, 0)
+        t.equal(c.newObserving, null)
+        t.equal(c.diffValue, 0)
+        t.equal(c.unboundDepsCount, 1)
+        t.equal(c.isDisposed, true)
+        t.equal(c._isScheduled, false)
+        t.equal(c._isTrackPending, false)
+        t.equal(c._isRunning, false)
 
-		t.equal(c.dependenciesState, -1)
-		t.equal(c.observing.length, 0)
-		t.equal(c.newObserving, null)
-		t.equal(c.diffValue, 0)
-		t.equal(c.unboundDepsCount, 1)
-		t.equal(c.isDisposed, true)
-		t.equal(c._isScheduled, false)
-		t.equal(c._isTrackPending, false)
-		t.equal(c._isRunning, false)
+        t.equal(b.get(), 3)
 
-		t.equal(b.get(), 3)
+        checkGlobalState(t)
+        t.end()
+    })
 
-		checkGlobalState(t)
-		t.end()
-	})
+    test("it should be possible to handle exceptions in reaction", t => {
+        const a = mobx.observable(1)
+        const d = mobx.autorun(function() {
+            throw a.get()
+        })
 
-	test("it should be possible to handle exceptions in reaction", t => {
+        const errors = []
+        d.onError(e => errors.push(e))
 
-		const a = mobx.observable(1)
-		const d = mobx.autorun(function() {
-			throw a.get()
-		})
+        a.set(2)
+        a.set(3)
 
-		const errors = []
-		d.onError(e => errors.push(e))
+        t.deepEqual(errors, [2, 3])
+        d()
 
-		a.set(2)
-		a.set(3)
+        checkGlobalState(t)
+        t.end()
+    })
 
-		t.deepEqual(errors, [2, 3])
-		d()
+    test("it should be possible to handle global errors in reactions", t => {
+        const a = mobx.observable(1)
+        const errors = []
+        const d2 = mobx.extras.onReactionError(e => errors.push(e))
 
-		checkGlobalState(t)
-		t.end()
-	})
+        const d = mobx.autorun(function() {
+            throw a.get()
+        })
 
+        a.set(2)
+        a.set(3)
 
-	test("it should be possible to handle global errors in reactions", t => {
+        d2()
+        a.set(4)
 
-		const a = mobx.observable(1)
-		const errors = []
-		const d2 = mobx.extras.onReactionError(e => errors.push(e))
+        t.deepEqual(errors, [1, 2, 3])
+        d()
 
-		const d = mobx.autorun(function() {
-			throw a.get()
-		})
+        checkGlobalState(t)
+        t.end()
+    })
 
-		a.set(2)
-		a.set(3)
-
-		d2()
-		a.set(4)
-
-		t.deepEqual(errors, [1, 2, 3])
-		d()
-
-		checkGlobalState(t)
-		t.end()
-	})
-
-	t.end()
+    t.end()
 })

--- a/test/extras.js
+++ b/test/extras.js
@@ -1,308 +1,352 @@
-var test = require('tape');
-var mobx = require('..');
-var m = mobx;
+var test = require("tape")
+var mobx = require("..")
+var m = mobx
 
-test('treeD', function(t) {
-    m.extras.resetGlobalState();
-    mobx.extras.getGlobalState().mobxGuid = 0;
-    var a = m.observable(3);
-    var aName = 'ObservableValue@1';
+test("treeD", function(t) {
+    m.extras.resetGlobalState()
+    mobx.extras.getGlobalState().mobxGuid = 0
+    var a = m.observable(3)
+    var aName = "ObservableValue@1"
 
-    var dtree = m.extras.getDependencyTree;
+    var dtree = m.extras.getDependencyTree
     t.deepEqual(dtree(a), {
-       name: aName
-    });
+        name: aName
+    })
 
-
-    var b = m.computed(() => a.get() * a.get());
-    var bName = 'ComputedValue@3';
+    var b = m.computed(() => a.get() * a.get())
+    var bName = "ComputedValue@3"
     t.deepEqual(dtree(b), {
         name: bName
         // no dependencies yet, since it isn't observed yet
-    });
+    })
 
-    var c = m.autorun(() => b.get());
-    var cName = 'Autorun@4';
+    var c = m.autorun(() => b.get())
+    var cName = "Autorun@4"
     t.deepEqual(dtree(c.$mobx), {
         name: cName,
-        dependencies: [{
-            name: bName,
-            dependencies: [{
-                name: aName,
-            }]
-        }]
-    });
+        dependencies: [
+            {
+                name: bName,
+                dependencies: [
+                    {
+                        name: aName
+                    }
+                ]
+            }
+        ]
+    })
 
-    t.ok(aName !== bName);
-    t.ok(bName !== cName);
+    t.ok(aName !== bName)
+    t.ok(bName !== cName)
 
     t.deepEqual(m.extras.getObserverTree(a), {
         name: aName,
-        observers: [{
-            name: bName,
-            observers: [{
-                name: cName,
-            }]
-        }]
-    });
+        observers: [
+            {
+                name: bName,
+                observers: [
+                    {
+                        name: cName
+                    }
+                ]
+            }
+        ]
+    })
 
-    var x = mobx.map({ temperature: 0 });
+    var x = mobx.map({ temperature: 0 })
     var d = mobx.autorun(function() {
-        x.keys();
-        if (x.has('temperature'))
-            x.get('temperature');
-        x.has('absent');
-    });
+        x.keys()
+        if (x.has("temperature")) x.get("temperature")
+        x.has("absent")
+    })
 
     t.deepEqual(m.extras.getDependencyTree(d.$mobx), {
-        name: 'Autorun@7',
-        dependencies: [{
-            name: 'ObservableMap@6.keys()'
-        }, {
-            name: 'ObservableMap@6.temperature?'
-        }, {
-            name: 'ObservableMap@6.temperature'
-        }, {
-            name: 'ObservableMap@6.absent?'
-        }]
-    });
+        name: "Autorun@7",
+        dependencies: [
+            {
+                name: "ObservableMap@6.keys()"
+            },
+            {
+                name: "ObservableMap@6.temperature?"
+            },
+            {
+                name: "ObservableMap@6.temperature"
+            },
+            {
+                name: "ObservableMap@6.absent?"
+            }
+        ]
+    })
 
-    t.end();
+    t.end()
 })
 
-test('names', function(t) {
-    m.extras.resetGlobalState();
-    mobx.extras.getGlobalState().mobxGuid = 0;
+test("names", function(t) {
+    m.extras.resetGlobalState()
+    mobx.extras.getGlobalState().mobxGuid = 0
 
     var struct = {
-        x: 'ObservableValue@1',
+        x: "ObservableValue@1",
         y: {
             z: 7
         },
-        ar : [
+        ar: [
             4,
             {
                 w: 5
             }
         ]
-    };
+    }
 
-    var rstruct = m.observable(struct);
-    m.extendObservable(rstruct.y, { a:  { b : 2}});
-    rstruct.ar.push({ b : 2});
-    rstruct.ar.push([]);
-    t.equal(rstruct.$mobx.values.x.name, "ObservableObject@1.x");
-    t.equal(rstruct.$mobx.values.y.name, "ObservableObject@1.y");
-    t.equal(rstruct.y.$mobx.values.z.name, "ObservableObject@1.y.z");
-    t.equal(rstruct.$mobx.values.ar.name, "ObservableObject@1.ar");
-    t.equal(rstruct.ar.$mobx.atom.name, "ObservableObject@1.ar");
-    t.equal(rstruct.ar[1].$mobx.values.w.name, "ObservableObject@1.ar[..].w");
-    t.equal(rstruct.y.a.$mobx.values.b.name, "ObservableObject@1.y.a.b");
-    t.equal(rstruct.ar[2].$mobx.values.b.name, "ObservableObject@1.ar[..].b");
+    var rstruct = m.observable(struct)
+    m.extendObservable(rstruct.y, { a: { b: 2 } })
+    rstruct.ar.push({ b: 2 })
+    rstruct.ar.push([])
+    t.equal(rstruct.$mobx.values.x.name, "ObservableObject@1.x")
+    t.equal(rstruct.$mobx.values.y.name, "ObservableObject@1.y")
+    t.equal(rstruct.y.$mobx.values.z.name, "ObservableObject@1.y.z")
+    t.equal(rstruct.$mobx.values.ar.name, "ObservableObject@1.ar")
+    t.equal(rstruct.ar.$mobx.atom.name, "ObservableObject@1.ar")
+    t.equal(rstruct.ar[1].$mobx.values.w.name, "ObservableObject@1.ar[..].w")
+    t.equal(rstruct.y.a.$mobx.values.b.name, "ObservableObject@1.y.a.b")
+    t.equal(rstruct.ar[2].$mobx.values.b.name, "ObservableObject@1.ar[..].b")
 
-    var d = m.autorun(function() {
-    });
-    t.ok(d.$mobx.name);
+    var d = m.autorun(function() {})
+    t.ok(d.$mobx.name)
 
-    t.equal(m.autorun(function namedFunction() {
-    }).$mobx.name, "namedFunction");
+    t.equal(m.autorun(function namedFunction() {}).$mobx.name, "namedFunction")
 
-    t.ok(m.computed(function() {}));
+    t.ok(m.computed(function() {}))
 
-    t.equal(m.computed(function namedFunction() {}).name, "namedFunction");
+    t.equal(m.computed(function namedFunction() {}).name, "namedFunction")
 
-	function Task() {
-		m.extendObservable(this, {
-			title: "test"
-		});
-	}
+    function Task() {
+        m.extendObservable(this, {
+            title: "test"
+        })
+    }
 
-	var task = new Task();
-	t.equal(task.$mobx.name, "Task@8");
-	t.equal(task.$mobx.values.title.name, "Task@8.title");
+    var task = new Task()
+    t.equal(task.$mobx.name, "Task@8")
+    t.equal(task.$mobx.values.title.name, "Task@8.title")
 
-    t.end();
+    t.end()
 })
 
 function stripTrackerOutput(output) {
-    return output.map(function (i) {
-        if (Array.isArray(i))
-            return stripTrackerOutput(i);
-        delete i.object;
-		delete i.time;
-		delete i.fn;
-        return i;
-    });
+    return output.map(function(i) {
+        if (Array.isArray(i)) return stripTrackerOutput(i)
+        delete i.object
+        delete i.time
+        delete i.fn
+        return i
+    })
 }
 
-test('spy 1', function(t) {
-    m.extras.resetGlobalState();
-    var lines = [];
+test("spy 1", function(t) {
+    m.extras.resetGlobalState()
+    var lines = []
 
-    var a = m.observable(3);
-    var b = m.computed(function() { return a.get() * 2 });
-    var c = m.autorun(function() { b.get(); });
+    var a = m.observable(3)
+    var b = m.computed(function() {
+        return a.get() * 2
+    })
+    var c = m.autorun(function() {
+        b.get()
+    })
     var stop = m.spy(function(line) {
-        lines.push(line);
-    });
+        lines.push(line)
+    })
 
-    a.set(4);
-    stop();
-    a.set(5);
+    a.set(4)
+    stop()
+    a.set(5)
     t.deepEqual(stripTrackerOutput(lines), [
-		{ newValue: 4, oldValue: 3, spyReportStart: true, type: 'update' },
-		{ type: 'compute' },
-		{ spyReportStart: true, type: 'reaction' },
-		{ spyReportEnd: true },
-		{ spyReportEnd: true }
-	]);
+        { newValue: 4, oldValue: 3, spyReportStart: true, type: "update" },
+        { type: "compute" },
+        { spyReportStart: true, type: "reaction" },
+        { spyReportEnd: true },
+        { spyReportEnd: true }
+    ])
 
-    t.end();
+    t.end()
 })
 
-test('get atom', function(t) {
-	mobx.extras.resetGlobalState();
-	mobx.extras.getGlobalState().mobxGuid = 0; // hmm dangerous reset?
+test("get atom", function(t) {
+    mobx.extras.resetGlobalState()
+    mobx.extras.getGlobalState().mobxGuid = 0 // hmm dangerous reset?
 
-	function Clazz () {
-		mobx.extendObservable(this, {
-			a: 17
-		});
-	}
+    function Clazz() {
+        mobx.extendObservable(this, {
+            a: 17
+        })
+    }
 
-	var a = mobx.observable(3);
-	var b = mobx.observable({ a: 3 });
-	var c = mobx.map({ a: 3});
-	var d = mobx.observable([1, 2]);
-	var e = mobx.computed(() => 3);
-	var f = mobx.autorun(() => c.has('b'));
-	var g = new Clazz();
+    var a = mobx.observable(3)
+    var b = mobx.observable({ a: 3 })
+    var c = mobx.map({ a: 3 })
+    var d = mobx.observable([1, 2])
+    var e = mobx.computed(() => 3)
+    var f = mobx.autorun(() => c.has("b"))
+    var g = new Clazz()
 
-	function atom(thing, prop) {
-		return mobx.extras.getAtom(thing, prop).constructor.name;
-	}
+    function atom(thing, prop) {
+        return mobx.extras.getAtom(thing, prop).constructor.name
+    }
 
-	var ovClassName = mobx.observable(3).constructor.name;
-	var atomClassName = mobx.BaseAtom.name;
-	var reactionClassName = mobx.Reaction.name;
+    var ovClassName = mobx.observable(3).constructor.name
+    var atomClassName = mobx.BaseAtom.name
+    var reactionClassName = mobx.Reaction.name
 
-	t.equal(atom(a), ovClassName);
+    t.equal(atom(a), ovClassName)
 
-	t.equal(atom(b, "a"), ovClassName);
-	t.throws(() => atom(b), /please specify a property/, "expected throw");
-	t.throws(() => atom(b, "b"), /no observable property 'b' found on the observable object 'ObservableObject@2'/, "expected throw");
+    t.equal(atom(b, "a"), ovClassName)
+    t.throws(() => atom(b), /please specify a property/, "expected throw")
+    t.throws(
+        () => atom(b, "b"),
+        /no observable property 'b' found on the observable object 'ObservableObject@2'/,
+        "expected throw"
+    )
 
-	t.equal(atom(c), atomClassName); // returns ke, "bla".constructor, === "Atomys
-	t.equal(atom(c, "a"), ovClassName); // returns ent, "bla".constructor, === "Atomry
-	t.equal(atom(c, "b"), ovClassName); // returns has entry (see autoru, "bla", "Atomn)
-	t.throws(() => atom(c, "c"), /the entry 'c' does not exist in the observable map 'ObservableMap@3'/, "expected throw");
+    t.equal(atom(c), atomClassName) // returns ke, "bla".constructor, === "Atomys
+    t.equal(atom(c, "a"), ovClassName) // returns ent, "bla".constructor, === "Atomry
+    t.equal(atom(c, "b"), ovClassName) // returns has entry (see autoru, "bla", "Atomn)
+    t.throws(
+        () => atom(c, "c"),
+        /the entry 'c' does not exist in the observable map 'ObservableMap@3'/,
+        "expected throw"
+    )
 
-	t.equal(atom(d), atomClassName);
-	t.throws(() => atom(d, 0), /It is not possible to get index atoms from arrays/, "expected throw");
+    t.equal(atom(d), atomClassName)
+    t.throws(
+        () => atom(d, 0),
+        /It is not possible to get index atoms from arrays/,
+        "expected throw"
+    )
 
-	t.equal(atom(e), mobx.computed(() => {}).constructor.name);
-	t.equal(atom(f), mobx.Reaction.name);
+    t.equal(atom(e), mobx.computed(() => {}).constructor.name)
+    t.equal(atom(f), mobx.Reaction.name)
 
-	t.throws(() => atom(g), /please specify a property/);
-	t.equal(atom(g, "a"), ovClassName);
+    t.throws(() => atom(g), /please specify a property/)
+    t.equal(atom(g, "a"), ovClassName)
 
-	f();
-	t.end();
-});
+    f()
+    t.end()
+})
 
-test('get debug name', function(t) {
-	mobx.extras.resetGlobalState();
-	mobx.extras.getGlobalState().mobxGuid = 0; // hmm dangerous reset?
+test("get debug name", function(t) {
+    mobx.extras.resetGlobalState()
+    mobx.extras.getGlobalState().mobxGuid = 0 // hmm dangerous reset?
 
-	function Clazz () {
-		mobx.extendObservable(this, {
-			a: 17
-		});
-	}
+    function Clazz() {
+        mobx.extendObservable(this, {
+            a: 17
+        })
+    }
 
-	var a = mobx.observable(3);
-	var b = mobx.observable({ a: 3 });
-	var c = mobx.map({ a: 3});
-	var d = mobx.observable([1, 2]);
-	var e = mobx.computed(() => 3);
-	var f = mobx.autorun(() => c.has('b'));
-	var g = new Clazz();
-	var h = mobx.observable({ b: function() {}, c: mobx.computed(function(){}) });
+    var a = mobx.observable(3)
+    var b = mobx.observable({ a: 3 })
+    var c = mobx.map({ a: 3 })
+    var d = mobx.observable([1, 2])
+    var e = mobx.computed(() => 3)
+    var f = mobx.autorun(() => c.has("b"))
+    var g = new Clazz()
+    var h = mobx.observable({ b: function() {}, c: mobx.computed(function() {}) })
 
-	function name(thing, prop) {
-		return mobx.extras.getDebugName(thing, prop);
-	}
+    function name(thing, prop) {
+        return mobx.extras.getDebugName(thing, prop)
+    }
 
-	t.equal(name(a), "ObservableValue@1");
+    t.equal(name(a), "ObservableValue@1")
 
-	t.equal(name(b, "a"), "ObservableObject@2.a");
-	t.throws(() => name(b, "b"), /no observable property 'b' found on the observable object 'ObservableObject@2'/, "expected throw");
+    t.equal(name(b, "a"), "ObservableObject@2.a")
+    t.throws(
+        () => name(b, "b"),
+        /no observable property 'b' found on the observable object 'ObservableObject@2'/,
+        "expected throw"
+    )
 
-	t.equal(name(c), "ObservableMap@3"); // returns ke, "bla"ys
-	t.equal(name(c, "a"), "ObservableMap@3.a"); // returns ent, "bla"ry
-	t.equal(name(c, "b"), "ObservableMap@3.b?"); // returns has entry (see autoru, "bla"n)
-	t.throws(() => name(c, "c"), /the entry 'c' does not exist in the observable map 'ObservableMap@3'/, "expected throw");
+    t.equal(name(c), "ObservableMap@3") // returns ke, "bla"ys
+    t.equal(name(c, "a"), "ObservableMap@3.a") // returns ent, "bla"ry
+    t.equal(name(c, "b"), "ObservableMap@3.b?") // returns has entry (see autoru, "bla"n)
+    t.throws(
+        () => name(c, "c"),
+        /the entry 'c' does not exist in the observable map 'ObservableMap@3'/,
+        "expected throw"
+    )
 
-	t.equal(name(d), "ObservableArray@4");
-	t.throws(() => name(d, 0), /It is not possible to get index atoms from arrays/, "expected throw");
+    t.equal(name(d), "ObservableArray@4")
+    t.throws(
+        () => name(d, 0),
+        /It is not possible to get index atoms from arrays/,
+        "expected throw"
+    )
 
-	t.equal(name(e), "ComputedValue@6");
-	t.equal(name(f), "Autorun@7");
+    t.equal(name(e), "ComputedValue@6")
+    t.equal(name(f), "Autorun@7")
 
-	t.equal(name(g), "Clazz@9");
-	t.equal(name(g, "a"), "Clazz@9.a");
+    t.equal(name(g), "Clazz@9")
+    t.equal(name(g, "a"), "Clazz@9.a")
 
-	t.equal(name(h, "b"), "ObservableObject@12.b");
-	t.equal(name(h, "c"), "ObservableObject@12.c");
+    t.equal(name(h, "b"), "ObservableObject@12.b")
+    t.equal(name(h, "c"), "ObservableObject@12.c")
 
-	f();
-	t.end();
-});
+    f()
+    t.end()
+})
 
-test('get administration', function(t) {
-	mobx.extras.resetGlobalState();
-	mobx.extras.getGlobalState().mobxGuid = 0; // hmm dangerous reset?
+test("get administration", function(t) {
+    mobx.extras.resetGlobalState()
+    mobx.extras.getGlobalState().mobxGuid = 0 // hmm dangerous reset?
 
-	function Clazz () {
-		mobx.extendObservable(this, {
-			a: 17
-		});
-	}
+    function Clazz() {
+        mobx.extendObservable(this, {
+            a: 17
+        })
+    }
 
-	var a = mobx.observable(3);
-	var b = mobx.observable({ a: 3 });
-	var c = mobx.map({ a: 3});
-	var d = mobx.observable([1, 2]);
-	var e = mobx.computed(() => 3);
-	var f = mobx.autorun(() => c.has('b'));
-	var g = new Clazz();
+    var a = mobx.observable(3)
+    var b = mobx.observable({ a: 3 })
+    var c = mobx.map({ a: 3 })
+    var d = mobx.observable([1, 2])
+    var e = mobx.computed(() => 3)
+    var f = mobx.autorun(() => c.has("b"))
+    var g = new Clazz()
 
-	function adm(thing, prop) {
-		return mobx.extras.getAdministration(thing, prop).constructor.name;
-	}
+    function adm(thing, prop) {
+        return mobx.extras.getAdministration(thing, prop).constructor.name
+    }
 
-	var ovClassName = mobx.observable(3).constructor.name;
+    var ovClassName = mobx.observable(3).constructor.name
 
-	t.equal(adm(a), ovClassName);
+    t.equal(adm(a), ovClassName)
 
-	t.equal(adm(b, "a"), ovClassName);
-	t.equal(adm(b), b.$mobx.constructor.name);
-	t.throws(() => adm(b, "b"), /no observable property 'b' found on the observable object 'ObservableObject@2'/, "expected throw");
+    t.equal(adm(b, "a"), ovClassName)
+    t.equal(adm(b), b.$mobx.constructor.name)
+    t.throws(
+        () => adm(b, "b"),
+        /no observable property 'b' found on the observable object 'ObservableObject@2'/,
+        "expected throw"
+    )
 
-	t.equal(adm(c), mobx.ObservableMap.name);
-	t.equal(adm(c, "a"), ovClassName);
-	t.equal(adm(c, "b"), ovClassName);
-	t.throws(() => adm(c, "c"), /the entry 'c' does not exist in the observable map 'ObservableMap@3'/, "expected throw");
+    t.equal(adm(c), mobx.ObservableMap.name)
+    t.equal(adm(c, "a"), ovClassName)
+    t.equal(adm(c, "b"), ovClassName)
+    t.throws(
+        () => adm(c, "c"),
+        /the entry 'c' does not exist in the observable map 'ObservableMap@3'/,
+        "expected throw"
+    )
 
-	t.equal(adm(d), d.$mobx.constructor.name);
-	t.throws(() => adm(d, 0), /It is not possible to get index atoms from arrays/, "expected throw");
+    t.equal(adm(d), d.$mobx.constructor.name)
+    t.throws(() => adm(d, 0), /It is not possible to get index atoms from arrays/, "expected throw")
 
-	t.equal(adm(e), mobx.computed(() => {}).constructor.name);
-	t.equal(adm(f), mobx.Reaction.name);
+    t.equal(adm(e), mobx.computed(() => {}).constructor.name)
+    t.equal(adm(f), mobx.Reaction.name)
 
-	t.equal(adm(g), b.$mobx.constructor.name);
-	t.equal(adm(g, "a"), ovClassName);
+    t.equal(adm(g), b.$mobx.constructor.name)
+    t.equal(adm(g, "a"), ovClassName)
 
-	f();
-	t.end();
-});
+    f()
+    t.end()
+})

--- a/test/flow/test.js
+++ b/test/flow/test.js
@@ -1,28 +1,25 @@
 //@flow
 
-import type { IObservableValue, IObservableArray, IComputedValue } from 'mobx';
-import mobx from 'mobx';
+import type { IObservableValue, IObservableArray, IComputedValue } from "mobx"
+import mobx from "mobx"
 
-
-const action = mobx.action(() => console.log(1));
+const action = mobx.action(() => console.log(1))
 // $ExpectError
-const isAction: string = mobx.isAction(action);
+const isAction: string = mobx.isAction(action)
 
-const observableValue: IObservableValue<number> = mobx.observable(1);
+const observableValue: IObservableValue<number> = mobx.observable(1)
 // $ExpectError
-const initialValue: string = observableValue.get();
+const initialValue: string = observableValue.get()
 
-
-const observableArray: IObservableArray<number> = mobx.observable([1,2,3]);
+const observableArray: IObservableArray<number> = mobx.observable([1, 2, 3])
 // $ExpectError
-const initialArray: Array<string> = observableArray.peek();
+const initialArray: Array<string> = observableArray.peek()
 
 const sum: IComputedValue<number> = mobx.computed(() => {
-  return observableArray.reduce((a: number, b: number): number => {
-    return a + b;
-  }, 0);
-});
+    return observableArray.reduce((a: number, b: number): number => {
+        return a + b
+    }, 0)
+})
 
-const disposer = mobx.autorun(() => console.log(sum.get()));
-disposer();
-
+const disposer = mobx.autorun(() => console.log(sum.get()))
+disposer()

--- a/test/intercept.js
+++ b/test/intercept.js
@@ -1,200 +1,197 @@
-var test = require('tape');
-var m = require('..');
-var intercept = m.intercept;
+var test = require("tape")
+var m = require("..")
+var intercept = m.intercept
 
-test('intercept observable value', t => {
-	var a = m.observable(1);
+test("intercept observable value", t => {
+    var a = m.observable(1)
 
-	var d = intercept(a, () => {
-		return null;
-	});
+    var d = intercept(a, () => {
+        return null
+    })
 
-	a.set(2);
+    a.set(2)
 
-	t.equal(a.get(), 1, "should be unchanged");
+    t.equal(a.get(), 1, "should be unchanged")
 
-	d();
+    d()
 
-	a.set(3);
-	t.equal(a.get(), 3, "should be changed");
+    a.set(3)
+    t.equal(a.get(), 3, "should be changed")
 
-	d = intercept(a, (c) => {
-		if (c.newValue % 2 === 0) {
-			debugger;
-			throw "value should be odd!";
-		}
-		return c;
-	});
+    d = intercept(a, c => {
+        if (c.newValue % 2 === 0) {
+            debugger
+            throw "value should be odd!"
+        }
+        return c
+    })
 
-	t.throws(() => {
-		a.set(4);
-	}, "value should be odd!");
+    t.throws(() => {
+        a.set(4)
+    }, "value should be odd!")
 
-	t.equal(a.get(), 3, "unchanged");
-	a.set(5);
-	t.equal(a.get(), 5, "changed");
+    t.equal(a.get(), 3, "unchanged")
+    a.set(5)
+    t.equal(a.get(), 5, "changed")
 
-	d();
-	d = intercept(a, c => {
-		c.newValue *= 2;
-		return c;
-	});
+    d()
+    d = intercept(a, c => {
+        c.newValue *= 2
+        return c
+    })
 
-	a.set(6);
-	t.equal(a.get(), 12, "should be doubled");
+    a.set(6)
+    t.equal(a.get(), 12, "should be doubled")
 
-	var d2 = intercept(a, c => {
-		c.newValue += 1;
-		return c;
-	});
+    var d2 = intercept(a, c => {
+        c.newValue += 1
+        return c
+    })
 
-	a.set(7);
-	t.equal(a.get(), 15, "doubled and added");
+    a.set(7)
+    t.equal(a.get(), 15, "doubled and added")
 
-	d();
-	a.set(8);
-	t.equal(a.get(), 9, "just added");
+    d()
+    a.set(8)
+    t.equal(a.get(), 9, "just added")
 
-	t.end();
-});
+    t.end()
+})
 
-test('intercept array', t => {
-	var a = m.observable([1, 2]);
+test("intercept array", t => {
+    var a = m.observable([1, 2])
 
-	var d = a.intercept(c => null);
-	a.push(2);
-	t.deepEqual(a.slice(), [1, 2]);
+    var d = a.intercept(c => null)
+    a.push(2)
+    t.deepEqual(a.slice(), [1, 2])
 
-	d();
+    d()
 
-	d = intercept(a, c => {
-		if (c.type === "splice") {
-			c.added.push(c.added[0] * 2);
-			c.removedCount = 1;
-			return c;
-		} else if (c.type === "update") {
-			c.newValue = c.newValue * 3;
-			return c;
-		}
-	});
+    d = intercept(a, c => {
+        if (c.type === "splice") {
+            c.added.push(c.added[0] * 2)
+            c.removedCount = 1
+            return c
+        } else if (c.type === "update") {
+            c.newValue = c.newValue * 3
+            return c
+        }
+    })
 
-	a.unshift(3,4);
+    a.unshift(3, 4)
 
-	t.deepEqual(a.slice(), [3, 4, 6, 2], "splice has been modified");
-	a[2] = 5;
-	t.deepEqual(a.slice(), [3, 4, 15, 2], "update has tripled");
+    t.deepEqual(a.slice(), [3, 4, 6, 2], "splice has been modified")
+    a[2] = 5
+    t.deepEqual(a.slice(), [3, 4, 15, 2], "update has tripled")
 
-	t.end();
-});
+    t.end()
+})
 
-test('intercept object', t => {
-	var a = m.observable({
-		b: 3
-	})
+test("intercept object", t => {
+    var a = m.observable({
+        b: 3
+    })
 
-	// bit magical, but intercept makes a observable, to be consistent with observe.
-	// deprecated immediately :)
-	var d = intercept(a, c => {
-		c.newValue *= 3;
-		return c;
-	});
+    // bit magical, but intercept makes a observable, to be consistent with observe.
+    // deprecated immediately :)
+    var d = intercept(a, c => {
+        c.newValue *= 3
+        return c
+    })
 
-	a.b = 4;
+    a.b = 4
 
-	t.equal(a.b, 12, "intercept applied");
+    t.equal(a.b, 12, "intercept applied")
 
-	var d2 = intercept(a, "b", c => {
-		c.newValue += 1;
-		return c;
-	});
+    var d2 = intercept(a, "b", c => {
+        c.newValue += 1
+        return c
+    })
 
-	a.b = 5;
-	t.equal(a.b, 16, "attribute selector applied last");
+    a.b = 5
+    t.equal(a.b, 16, "attribute selector applied last")
 
-	var d3 = intercept(a, c => {
-		t.equal(c.name, "b"),
-		t.equal(c.object, a);
-		t.equal(c.type, "update");
-		return null;
-	})
+    var d3 = intercept(a, c => {
+        t.equal(c.name, "b"), t.equal(c.object, a)
+        t.equal(c.type, "update")
+        return null
+    })
 
-	a.b = 7;
-	t.equal(a.b, 16, "interceptor not applied");
+    a.b = 7
+    t.equal(a.b, 16, "interceptor not applied")
 
-	d3();
-	a.b = 7;
-	t.equal(a.b, 22, "interceptor applied again");
+    d3()
+    a.b = 7
+    t.equal(a.b, 22, "interceptor applied again")
 
-	var d4 = intercept(a, c => {
-		if (c.type === "add") {
-			return null;
-		}
-		return c;
-	});
+    var d4 = intercept(a, c => {
+        if (c.type === "add") {
+            return null
+        }
+        return c
+    })
 
-	m.extendObservable(a, { c: 1 });
-	t.equal(a.c, undefined, "extension intercepted");
-	t.equal(m.isObservable(a, "c"), false);
+    m.extendObservable(a, { c: 1 })
+    t.equal(a.c, undefined, "extension intercepted")
+    t.equal(m.isObservable(a, "c"), false)
 
-	d4();
+    d4()
 
-	m.extendObservable(a, { c: 2 });
-	t.equal(a.c, 6, "extension not intercepted");
-	t.equal(m.isObservable(a, "c"), true);
+    m.extendObservable(a, { c: 2 })
+    t.equal(a.c, 6, "extension not intercepted")
+    t.equal(m.isObservable(a, "c"), true)
 
-	t.end();
-});
+    t.end()
+})
 
-test('intercept map', t => {
-	var a = m.map({
-		b: 3
-	})
+test("intercept map", t => {
+    var a = m.map({
+        b: 3
+    })
 
-	var d = intercept(a, c => {
-		c.newValue *= 3;
-		return c;
-	});
+    var d = intercept(a, c => {
+        c.newValue *= 3
+        return c
+    })
 
-	a.set("b", 4);
+    a.set("b", 4)
 
-	t.equal(a.get("b"), 12, "intercept applied");
+    t.equal(a.get("b"), 12, "intercept applied")
 
-	var d2 = intercept(a, "b", c => {
-		c.newValue += 1;
-		return c;
-	});
+    var d2 = intercept(a, "b", c => {
+        c.newValue += 1
+        return c
+    })
 
-	a.set("b", 5);
-	t.equal(a.get("b"), 16, "attribute selector applied last");
+    a.set("b", 5)
+    t.equal(a.get("b"), 16, "attribute selector applied last")
 
-	var d3 = intercept(a, c => {
-		t.equal(c.name, "b"),
-		t.equal(c.object, a);
-		t.equal(c.type, "update");
-		return null;
-	})
+    var d3 = intercept(a, c => {
+        t.equal(c.name, "b"), t.equal(c.object, a)
+        t.equal(c.type, "update")
+        return null
+    })
 
-	a.set("b", 7);
-	t.equal(a.get("b"), 16, "interceptor not applied");
+    a.set("b", 7)
+    t.equal(a.get("b"), 16, "interceptor not applied")
 
-	d3();
-	a.set("b", 7);
-	t.equal(a.get("b"), 22, "interceptor applied again");
+    d3()
+    a.set("b", 7)
+    t.equal(a.get("b"), 22, "interceptor applied again")
 
-	var d4 = intercept(a, c => {
-		if (c.type === "delete")
-			return null;
-		return c;
-	});
+    var d4 = intercept(a, c => {
+        if (c.type === "delete") return null
+        return c
+    })
 
-	a.delete("b");
-	t.equal(a.has("b"), true);
-	t.equal(a.get("b"), 22, "delete intercepted");
+    a.delete("b")
+    t.equal(a.has("b"), true)
+    t.equal(a.get("b"), 22, "delete intercepted")
 
-	d4();
-	a.delete("b");
-	t.equal(a.has("b"), false);
-	t.equal(a.get("c"), undefined, "delete not intercepted");
+    d4()
+    a.delete("b")
+    t.equal(a.has("b"), false)
+    t.equal(a.get("c"), undefined, "delete not intercepted")
 
-	t.end();
-});
+    t.end()
+})

--- a/test/makereactive.js
+++ b/test/makereactive.js
@@ -1,84 +1,81 @@
-var test = require('tape');
-var mobx = require('..');
-var m = mobx;
-var o = mobx.observable;
+var test = require("tape")
+var mobx = require("..")
+var m = mobx
+var o = mobx.observable
 
-var value = mobx.value;
-var voidObserver = function(){};
+var value = mobx.value
+var voidObserver = function() {}
 
 function buffer() {
-    var b = [];
+    var b = []
     var res = function(x) {
-        b.push(x);
-    };
-    res.toArray = function() {
-        return b;
+        b.push(x)
     }
-    return res;
+    res.toArray = function() {
+        return b
+    }
+    return res
 }
 
-
-test('isObservable', function(t) {
-    function Order(price) {
-
-    }
+test("isObservable", function(t) {
+    function Order(price) {}
 
     function ReactiveOrder(price) {
         m.extendObservable(this, {
             price: price
-        });
+        })
     }
-    t.equal(m.isObservable(null), false);
-    t.equal(m.isObservable(null), false);
+    t.equal(m.isObservable(null), false)
+    t.equal(m.isObservable(null), false)
 
-    t.equal(m.isObservable(m.observable([])), true);
-    t.equal(m.isObservable(m.observable({})), true);
-    t.equal(m.isObservable(m.observable(function() {})), true);
-    t.equal(m.isObservable(m.computed(function() {})), true);
+    t.equal(m.isObservable(m.observable([])), true)
+    t.equal(m.isObservable(m.observable({})), true)
+    t.equal(m.isObservable(m.observable(function() {})), true)
+    t.equal(m.isObservable(m.computed(function() {})), true)
 
-    t.equal(m.isObservable([]), false);
-    t.equal(m.isObservable({}), false);
-    t.equal(m.isObservable(function() {}), false);
+    t.equal(m.isObservable([]), false)
+    t.equal(m.isObservable({}), false)
+    t.equal(m.isObservable(function() {}), false)
 
-    t.equal(m.isObservable(new Order()), false);
-    t.equal(m.isObservable(m.observable(new Order())), true);
+    t.equal(m.isObservable(new Order()), false)
+    t.equal(m.isObservable(m.observable(new Order())), true)
 
-    t.equal(m.isObservable(new ReactiveOrder), true);
-    t.equal(m.isObservable(m.observable(3)), true);
+    t.equal(m.isObservable(new ReactiveOrder()), true)
+    t.equal(m.isObservable(m.observable(3)), true)
 
-    var obj = {};
-    t.equal(m.isObservable(obj), false);
+    var obj = {}
+    t.equal(m.isObservable(obj), false)
 
-    t.equal(m.isObservable(m.observable(function(){})), true);
-    t.equal(m.isObservable(m.autorun(function(){})), true);
+    t.equal(m.isObservable(m.observable(function() {})), true)
+    t.equal(m.isObservable(m.autorun(function() {})), true)
 
-    t.equal(m.isObservable(m.observable({ a: 1}), "a"), true);
-    t.equal(m.isObservable(m.observable({ a: 1}), "b"), false);
+    t.equal(m.isObservable(m.observable({ a: 1 }), "a"), true)
+    t.equal(m.isObservable(m.observable({ a: 1 }), "b"), false)
 
-    t.equal(m.isObservable(m.map()), true);
+    t.equal(m.isObservable(m.map()), true)
 
-	const base = { a: 3 };
-	const obs = m.observable(base);
-	t.equal(m.isObservable(base), false);
-	t.equal(m.isObservable(base, "a"), false);
-	t.equal(m.isObservable(obs), true);
-	t.equal(m.isObservable(obs, "a"), true);
+    const base = { a: 3 }
+    const obs = m.observable(base)
+    t.equal(m.isObservable(base), false)
+    t.equal(m.isObservable(base, "a"), false)
+    t.equal(m.isObservable(obs), true)
+    t.equal(m.isObservable(obs, "a"), true)
 
-    t.end();
+    t.end()
 })
 
-test('isBoxedObservable', function(t) {
-	t.equal(m.isBoxedObservable(m.observable({})), false);
-	t.equal(m.isBoxedObservable(m.computed(() => 3)), false);
-	t.equal(m.isBoxedObservable(m.observable(3)), true);
-	t.equal(m.isBoxedObservable(m.observable.box(3)), true);
-	t.equal(m.isBoxedObservable(m.observable.box({})), true);
-	t.equal(m.isBoxedObservable(m.observable.shallowBox({})), true);
-	t.end()
+test("isBoxedObservable", function(t) {
+    t.equal(m.isBoxedObservable(m.observable({})), false)
+    t.equal(m.isBoxedObservable(m.computed(() => 3)), false)
+    t.equal(m.isBoxedObservable(m.observable(3)), true)
+    t.equal(m.isBoxedObservable(m.observable.box(3)), true)
+    t.equal(m.isBoxedObservable(m.observable.box({})), true)
+    t.equal(m.isBoxedObservable(m.observable.shallowBox({})), true)
+    t.end()
 })
 
-test('observable1', function(t) {
-    m.extras.resetGlobalState();
+test("observable1", function(t) {
+    m.extras.resetGlobalState()
 
     // recursive structure
     var x = m.observable({
@@ -87,36 +84,36 @@ test('observable1', function(t) {
                 c: 3
             }
         }
-    });
-    var b = buffer();
+    })
+    var b = buffer()
     m.autorun(function() {
         b(x.a.b.c)
-    });
-    x.a = { b : { c : 4 }};
-    x.a.b.c = 5; // new structure was reactive as well
-    t.deepEqual(b.toArray(), [3, 4, 5]);
+    })
+    x.a = { b: { c: 4 } }
+    x.a.b.c = 5 // new structure was reactive as well
+    t.deepEqual(b.toArray(), [3, 4, 5])
 
     // recursive structure, but asReference passed in
-    t.equal(m.isObservable(x.a.b), true);
+    t.equal(m.isObservable(x.a.b), true)
     var x2 = m.observable({
         a: m.observable.ref({
             b: {
                 c: 3
             }
         })
-    });
+    })
 
-    t.equal(m.isObservable(x2), true);
-    t.equal(m.isObservable(x2.a), false);
-    t.equal(m.isObservable(x2.a.b), false);
+    t.equal(m.isObservable(x2), true)
+    t.equal(m.isObservable(x2.a), false)
+    t.equal(m.isObservable(x2.a.b), false)
 
-    var b2 = buffer();
+    var b2 = buffer()
     m.autorun(function() {
         b2(x2.a.b.c)
-    });
-    x2.a = { b : { c : 4 }};
-    x2.a.b.c = 5; // not picked up, not reactive, since passed as reference
-    t.deepEqual(b2.toArray(), [3, 4]);
+    })
+    x2.a = { b: { c: 4 } }
+    x2.a.b.c = 5 // not picked up, not reactive, since passed as reference
+    t.deepEqual(b2.toArray(), [3, 4])
 
     // non recursive structure
     var x3 = o.shallowObject({
@@ -125,581 +122,596 @@ test('observable1', function(t) {
                 c: 3
             }
         }
-    });
-    var b3 = buffer();
+    })
+    var b3 = buffer()
     m.autorun(function() {
         b3(x3.a.b.c)
-    });
-    x3.a = { b : { c : 4 }};
-    x3.a.b.c = 5; // sub structure not reactive
-    t.deepEqual(b3.toArray(), [3, 4]);
+    })
+    x3.a = { b: { c: 4 } }
+    x3.a.b.c = 5 // sub structure not reactive
+    t.deepEqual(b3.toArray(), [3, 4])
 
-    t.end();
+    t.end()
 })
 
-test('observable3', function(t) {
+test("observable3", function(t) {
     function Order(price) {
-        this.price = price;
+        this.price = price
     }
 
     var x = m.observable({
         orders: [new Order(1), new Order(2)]
-    });
+    })
 
-    var b = buffer();
+    var b = buffer()
     m.autorun(function() {
-        b(x.orders.length);
-    });
+        b(x.orders.length)
+    })
 
-    t.equal(m.isObservable(x.orders), true);
-    t.equal(m.isObservable(x.orders[0]), false);
-    x.orders[2] = new Order(3);
-    x.orders = [];
-    t.equal(m.isObservable(x.orders), true);
-    x.orders[0] = new Order(2);
-    t.deepEqual(b.toArray(), [2, 3, 0, 1]);
+    t.equal(m.isObservable(x.orders), true)
+    t.equal(m.isObservable(x.orders[0]), false)
+    x.orders[2] = new Order(3)
+    x.orders = []
+    t.equal(m.isObservable(x.orders), true)
+    x.orders[0] = new Order(2)
+    t.deepEqual(b.toArray(), [2, 3, 0, 1])
 
-    t.end();
+    t.end()
 })
 
-test('observable4', function(t) {
-    var x = m.observable([
-        { x : 1 },
-        { x : 2 }
-    ]);
+test("observable4", function(t) {
+    var x = m.observable([{ x: 1 }, { x: 2 }])
 
-    var b = buffer();
-    m.observe(m.computed(function() {
-        return x.map(function(d) { return d.x });
-	}), x => b(x.newValue), true);
+    var b = buffer()
+    m.observe(
+        m.computed(function() {
+            return x.map(function(d) {
+                return d.x
+            })
+        }),
+        x => b(x.newValue),
+        true
+    )
 
-    x[0].x = 3;
-    x.shift();
-    x.push({ x : 5 });
-    t.deepEqual(b.toArray(), [[1,2], [3,2], [2], [2, 5]]);
+    x[0].x = 3
+    x.shift()
+    x.push({ x: 5 })
+    t.deepEqual(b.toArray(), [[1, 2], [3, 2], [2], [2, 5]])
 
     // non recursive
-    var x2 = o.shallowArray([
-        { x : 1 },
-        { x : 2 }
-    ]);
+    var x2 = o.shallowArray([{ x: 1 }, { x: 2 }])
 
-    var b2 = buffer();
-    m.observe(m.computed(function() {
-        return x2.map(function(d) { return d.x });
-    }), x => b2(x.newValue), true);
+    var b2 = buffer()
+    m.observe(
+        m.computed(function() {
+            return x2.map(function(d) {
+                return d.x
+            })
+        }),
+        x => b2(x.newValue),
+        true
+    )
 
-    x2[0].x = 3;
-    x2.shift();
-    x2.push({ x : 5 });
-    t.deepEqual(b2.toArray(), [[1,2], [2], [2, 5]]);
+    x2[0].x = 3
+    x2.shift()
+    x2.push({ x: 5 })
+    t.deepEqual(b2.toArray(), [[1, 2], [2], [2, 5]])
 
-    t.end();
+    t.end()
 })
 
-test('observable5', function(t) {
-
-    var x = m.computed(function() { });
+test("observable5", function(t) {
+    var x = m.computed(function() {})
     t.throws(function() {
-        x.set(7); // set not allowed
-    });
+        x.set(7) // set not allowed
+    })
 
-    var f = function() {};
-    var x2 = m.observable(f);
-    t.equal(x2.get(), f);
-    x2.set(null); // allowed
+    var f = function() {}
+    var x2 = m.observable(f)
+    t.equal(x2.get(), f)
+    x2.set(null) // allowed
 
-    f = function() { return this.price };
+    f = function() {
+        return this.price
+    }
 
     var x = m.observable({
-        price : 17,
+        price: 17,
         reactive: m.computed(f),
         nonReactive: f
-    });
+    })
 
-    var b = buffer();
+    var b = buffer()
     m.autorun(function() {
-        b([x.reactive, x.nonReactive, x.nonReactive()]);
-    });
+        b([x.reactive, x.nonReactive, x.nonReactive()])
+    })
 
-    x.price = 18;
-    var three = function() { return 3; }
-    x.nonReactive = three;
-    t.deepEqual(b.toArray(), [[17, f, 17], [18, f, 18], [18, three, 3]]);
+    x.price = 18
+    var three = function() {
+        return 3
+    }
+    x.nonReactive = three
+    t.deepEqual(b.toArray(), [[17, f, 17], [18, f, 18], [18, three, 3]])
 
-    t.end();
+    t.end()
 })
 
-test('flat array', function(t) {
+test("flat array", function(t) {
     var x = m.observable({
-        x: m.observable.shallow([{
-            a: 1
-        }])
-    });
+        x: m.observable.shallow([
+            {
+                a: 1
+            }
+        ])
+    })
 
-    var result;
-    var updates = 0;
+    var result
+    var updates = 0
     var dis = m.autorun(function() {
-        updates++;
-        result = JSON.stringify(mobx.toJS(x));
-    });
+        updates++
+        result = JSON.stringify(mobx.toJS(x))
+    })
 
-    t.deepEqual(result, JSON.stringify({ x: [{ a: 1 }]}));
-    t.equal(updates, 1);
+    t.deepEqual(result, JSON.stringify({ x: [{ a: 1 }] }))
+    t.equal(updates, 1)
 
-    x.x[0].a = 2; // not picked up; object is not made reactive
-    t.deepEqual(result, JSON.stringify({ x: [{ a: 1 }]}));
-    t.equal(updates, 1);
+    x.x[0].a = 2 // not picked up; object is not made reactive
+    t.deepEqual(result, JSON.stringify({ x: [{ a: 1 }] }))
+    t.equal(updates, 1)
 
-    x.x.push({ a: 3 }); // picked up, array is reactive
-    t.deepEqual(result, JSON.stringify({ x: [{ a: 2}, { a: 3 }]}));
-    t.equal(updates, 2);
+    x.x.push({ a: 3 }) // picked up, array is reactive
+    t.deepEqual(result, JSON.stringify({ x: [{ a: 2 }, { a: 3 }] }))
+    t.equal(updates, 2)
 
-    x.x[0] = { a: 4 }; // picked up, array is reactive
-    t.deepEqual(result, JSON.stringify({ x: [{ a: 4 }, { a: 3 }]}));
-    t.equal(updates, 3);
+    x.x[0] = { a: 4 } // picked up, array is reactive
+    t.deepEqual(result, JSON.stringify({ x: [{ a: 4 }, { a: 3 }] }))
+    t.equal(updates, 3)
 
-    x.x[1].a = 6; // not picked up
-    t.deepEqual(result, JSON.stringify({ x: [{ a: 4 }, { a: 3 }]}));
-    t.equal(updates, 3);
+    x.x[1].a = 6 // not picked up
+    t.deepEqual(result, JSON.stringify({ x: [{ a: 4 }, { a: 3 }] }))
+    t.equal(updates, 3)
 
-    t.end();
+    t.end()
 })
 
-test('flat object', function(t) {
+test("flat object", function(t) {
     var y = m.observable.shallowObject({
-        x : { z: 3 }
-    });
+        x: { z: 3 }
+    })
 
-    var result;
-    var updates = 0;
+    var result
+    var updates = 0
     var dis = m.autorun(function() {
-        updates++;
-        result = JSON.stringify(mobx.toJS(y));
-    });
+        updates++
+        result = JSON.stringify(mobx.toJS(y))
+    })
 
-    t.deepEqual(result, JSON.stringify({ x: { z: 3 }}));
-    t.equal(updates, 1);
+    t.deepEqual(result, JSON.stringify({ x: { z: 3 } }))
+    t.equal(updates, 1)
 
-    y.x.z = 4; // not picked up
-    t.deepEqual(result, JSON.stringify({ x: { z: 3 }}));
-    t.equal(updates, 1);
+    y.x.z = 4 // not picked up
+    t.deepEqual(result, JSON.stringify({ x: { z: 3 } }))
+    t.equal(updates, 1)
 
-    y.x = { z: 5 };
-    t.deepEqual(result, JSON.stringify({ x: { z: 5 }}));
-    t.equal(updates, 2);
+    y.x = { z: 5 }
+    t.deepEqual(result, JSON.stringify({ x: { z: 5 } }))
+    t.equal(updates, 2)
 
-    y.x.z = 6; // not picked up
-    t.deepEqual(result, JSON.stringify({ x: { z: 5 }}));
-    t.equal(updates, 2);
+    y.x.z = 6 // not picked up
+    t.deepEqual(result, JSON.stringify({ x: { z: 5 } }))
+    t.equal(updates, 2)
 
-    t.end();
+    t.end()
 })
 
-test('as structure', function(t) {
-
+test("as structure", function(t) {
     var x = m.observable({
         x: m.observable.struct(null)
-    });
+    })
 
-    var changed = 0;
+    var changed = 0
     var dis = m.autorun(function() {
-        changed++;
-        JSON.stringify(x);
-    });
+        changed++
+        JSON.stringify(x)
+    })
 
     function c() {
-        t.equal(changed, 1, "expected a change");
-        if (changed !== 1)
-            console.trace();
-        changed = 0;
+        t.equal(changed, 1, "expected a change")
+        if (changed !== 1) console.trace()
+        changed = 0
     }
 
     function nc() {
-        t.equal(changed, 0, "expected no change");
-        if (changed !== 0)
-            console.trace();
-        changed = 0;
+        t.equal(changed, 0, "expected no change")
+        if (changed !== 0) console.trace()
+        changed = 0
     }
 
     // nc = no change, c = changed.
-    c();
-    x.x = null;
-    nc();
-    x.x = undefined;
-    c();
-    x.x = 3;
-    c();
-    x.x = 1* x.x;
-    nc();
-    x.x = "3";
-    c();
+    c()
+    x.x = null
+    nc()
+    x.x = undefined
+    c()
+    x.x = 3
+    c()
+    x.x = 1 * x.x
+    nc()
+    x.x = "3"
+    c()
 
     x.x = {
         y: 3
-    };
-    c();
-    x.x.y = 3;
-    nc();
+    }
+    c()
+    x.x.y = 3
+    nc()
     x.x = {
         y: 3
-    };
-    nc();
+    }
+    nc()
     x.x = {
         y: 4
-    };
-    c();
+    }
+    c()
     x.x = {
         y: 3
-    };
-    c();
+    }
+    c()
     x.x = {
         y: {
             y: 3
         }
-    };
-    c();
-    x.x.y.y = 3;
-	console.log("test")
-    nc();
-    x.x.y = { y: 3 };
-    nc();
-    x.x = { y: { y: 3 }};
-    nc();
-    x.x = { y: { y: 4 }};
-    c();
-    x.x = {};
-    c();
-    x.x = {};
-    nc();
+    }
+    c()
+    x.x.y.y = 3
+    console.log("test")
+    nc()
+    x.x.y = { y: 3 }
+    nc()
+    x.x = { y: { y: 3 } }
+    nc()
+    x.x = { y: { y: 4 } }
+    c()
+    x.x = {}
+    c()
+    x.x = {}
+    nc()
 
-    x.x = [];
-    c();
-    x.x = [];
-    nc();
-    x.x = [3,2,1];
-    c();
-    x.x.sort();
-    nc();
-    x.x.sort();
-    nc();
-    x.x[1] = 2;
-    nc();
-    x.x[0] = 0;
-    c();
+    x.x = []
+    c()
+    x.x = []
+    nc()
+    x.x = [3, 2, 1]
+    c()
+    x.x.sort()
+    nc()
+    x.x.sort()
+    nc()
+    x.x[1] = 2
+    nc()
+    x.x[0] = 0
+    c()
     x.x[1] = {
-        a: [1,2]
-    };
-    c();
-    x.x[1].a = [1,2];
-    nc();
-    x.x[1].a[1] = 3;
-    c();
-    x.x[1].a[2] = 3;
-    c();
+        a: [1, 2]
+    }
+    c()
+    x.x[1].a = [1, 2]
+    nc()
+    x.x[1].a[1] = 3
+    c()
+    x.x[1].a[2] = 3
+    c()
     x.x = {
-        a : [ {
-            b : 3
-        }]
-    };
-    c();
+        a: [
+            {
+                b: 3
+            }
+        ]
+    }
+    c()
     x.x = {
-        a : [ {
-            b : 3
-        }]
-    };
-    nc();
-    x.x.a = [{ b : 3 }]
-    nc();
-    x.x.a[0] = { b: 3 };
-    nc();
-    x.x.a[0].b = 3;
-    nc();
+        a: [
+            {
+                b: 3
+            }
+        ]
+    }
+    nc()
+    x.x.a = [{ b: 3 }]
+    nc()
+    x.x.a[0] = { b: 3 }
+    nc()
+    x.x.a[0].b = 3
+    nc()
 
-    dis();
-    t.end();
+    dis()
+    t.end()
 })
 
-test('as structure view', function(t) {
+test("as structure view", function(t) {
     var x = m.observable({
         a: 1,
         aa: 1,
         get b() {
-            this.a;
-            return { a: this.aa };
+            this.a
+            return { a: this.aa }
         },
-        c: m.computed((function() {
-            this.b
-            return { a : this.aa };
-        }), { compareStructural: true })
-    });
+        c: m.computed(
+            function() {
+                this.b
+                return { a: this.aa }
+            },
+            { compareStructural: true }
+        )
+    })
 
-    var bc = 0;
+    var bc = 0
     var bo = m.autorun(function() {
-        x.b;
-        bc++;
-    });
-    t.equal(bc, 1);
+        x.b
+        bc++
+    })
+    t.equal(bc, 1)
 
-    var cc = 0;
+    var cc = 0
     var co = m.autorun(function() {
-        x.c;
-        cc++;
-    });
-    t.equal(cc, 1);
+        x.c
+        cc++
+    })
+    t.equal(cc, 1)
 
-    x.a = 2;
-    x.a = 3;
-    t.equal(bc, 3);
-    t.equal(cc, 1);
-    x.aa = 3;
-    t.equal(bc, 4);
-    t.equal(cc, 2);
-    t.end();
+    x.a = 2
+    x.a = 3
+    t.equal(bc, 3)
+    t.equal(cc, 1)
+    x.aa = 3
+    t.equal(bc, 4)
+    t.equal(cc, 2)
+    t.end()
 })
 
-test('ES5 non reactive props', function (t) {
-  var te = {}
-  Object.defineProperty(te, 'nonConfigurable', {
-    enumerable: true,
-    configurable: false,
-    writable: true,
-    value: 'static'
-  })
-  // should throw if trying to reconfigure an existing non-configurable prop
-  t.throws(function() {
-	 const a = m.extendObservable(te2, { notConfigurable: 1 });
-  });
-  // should skip non-configurable / writable props when using `observable`
-  te = m.extendObservable(te, te);
-  const d1 = Object.getOwnPropertyDescriptor(te, 'nonConfigurable')
-  t.equal(d1.value, 'static')
-
-  var te2 = {};
-  Object.defineProperty(te2, 'notWritable', {
-    enumerable: true,
-    configurable: true,
-    writable: false,
-    value: 'static'
-  })
-  // should throw if trying to reconfigure an existing non-writable prop
-  t.throws(function() {
-	 const a = m.extendObservable(te2, { notWritable: 1 });
-  });
-  const d2 = Object.getOwnPropertyDescriptor(te2, 'notWritable')
-  t.equal(d2.value, 'static')
-
-  // should not throw for other props
-  t.equal(m.extendObservable(te, { 'bla' : 3}).bla, 3);
-
-  t.end();
-})
-
-test('exceptions', function(t) {
+test("ES5 non reactive props", function(t) {
+    var te = {}
+    Object.defineProperty(te, "nonConfigurable", {
+        enumerable: true,
+        configurable: false,
+        writable: true,
+        value: "static"
+    })
+    // should throw if trying to reconfigure an existing non-configurable prop
     t.throws(function() {
-        m.asReference(m.asFlat(3));
-    }, "nested");
+        const a = m.extendObservable(te2, { notConfigurable: 1 })
+    })
+    // should skip non-configurable / writable props when using `observable`
+    te = m.extendObservable(te, te)
+    const d1 = Object.getOwnPropertyDescriptor(te, "nonConfigurable")
+    t.equal(d1.value, "static")
+
+    var te2 = {}
+    Object.defineProperty(te2, "notWritable", {
+        enumerable: true,
+        configurable: true,
+        writable: false,
+        value: "static"
+    })
+    // should throw if trying to reconfigure an existing non-writable prop
+    t.throws(function() {
+        const a = m.extendObservable(te2, { notWritable: 1 })
+    })
+    const d2 = Object.getOwnPropertyDescriptor(te2, "notWritable")
+    t.equal(d2.value, "static")
+
+    // should not throw for other props
+    t.equal(m.extendObservable(te, { bla: 3 }).bla, 3)
+
+    t.end()
+})
+
+test("exceptions", function(t) {
+    t.throws(function() {
+        m.asReference(m.asFlat(3))
+    }, "nested")
 
     var x = m.observable({
         y: m.observable.ref(null),
-		z: 2
-    });
+        z: 2
+    })
 
     t.throws(function() {
         x.z = m.asReference(3)
-    });
+    })
 
-    var ar = m.observable([2]);
+    var ar = m.observable([2])
 
     t.throws(function() {
         ar[0] = m.asReference(3)
-    });
+    })
 
     t.throws(function() {
         ar[1] = m.asReference(3)
-    });
+    })
 
     t.throws(function() {
-        ar = m.observable([m.asStructure(3)]);
-    });
+        ar = m.observable([m.asStructure(3)])
+    })
 
-    return t.end();
+    return t.end()
 })
 
 test("540 - extendobservable should not report cycles", function(t) {
-	t.throws(
-		() => m.extendObservable(Object.freeze({}), {}),
-		/Cannot make the designated object observable/
-	);
+    t.throws(
+        () => m.extendObservable(Object.freeze({}), {}),
+        /Cannot make the designated object observable/
+    )
 
-	var objWrapper = mobx.observable({
-		value: null,
-	});
+    var objWrapper = mobx.observable({
+        value: null
+    })
 
-	var obj = {
-		name: "Hello",
-	};
+    var obj = {
+        name: "Hello"
+    }
 
-	objWrapper.value = obj;
-	t.throws(
-		() => mobx.extendObservable(objWrapper, objWrapper.value),
-		/extending an object with another observable \(object\) is not supported/
-	);
+    objWrapper.value = obj
+    t.throws(
+        () => mobx.extendObservable(objWrapper, objWrapper.value),
+        /extending an object with another observable \(object\) is not supported/
+    )
 
-	mobx.autorun(() => {
-		console.log(objWrapper.name);
-	});
-	t.end();
+    mobx.autorun(() => {
+        console.log(objWrapper.name)
+    })
+    t.end()
 })
 
-test('mobx 3', t => {
-	const x = mobx.observable({ a: 1 })
+test("mobx 3", t => {
+    const x = mobx.observable({ a: 1 })
 
-	t.ok(x === mobx.observable(x));
+    t.ok(x === mobx.observable(x))
 
-	const y = mobx.observable.shallowBox(null);
-	const obj = { a: 2 };
-	y.set(obj);
-	t.ok(y.get() === obj);
-	t.equal(mobx.isObservable(y.get()), false);
+    const y = mobx.observable.shallowBox(null)
+    const obj = { a: 2 }
+    y.set(obj)
+    t.ok(y.get() === obj)
+    t.equal(mobx.isObservable(y.get()), false)
 
-
-
-	t.end()
+    t.end()
 })
 
 test("computed value", t => {
-	mobx.extras.getGlobalState().mobxGuid = 0;
-	var c = mobx.computed(() => 3);
+    mobx.extras.getGlobalState().mobxGuid = 0
+    var c = mobx.computed(() => 3)
 
-	t.equal(c.toJSON(), 3);
-	t.equal(mobx.isComputed(c), true);
-	t.equal(c.toString(), "ComputedValue@2[() => 3]");
-	t.end();
-
+    t.equal(c.toJSON(), 3)
+    t.equal(mobx.isComputed(c), true)
+    t.equal(c.toString(), "ComputedValue@2[() => 3]")
+    t.end()
 })
 
 test("boxed value json", t => {
-	var a = mobx.observable.box({ x: 1 })
-	t.deepEqual(a.get().x, 1);
-	a.set(3);
-	t.deepEqual(a.get(), 3);
-	t.equal("" + a, '3');
-	t.equal(a.toJSON(), 3);
-	t.end();
+    var a = mobx.observable.box({ x: 1 })
+    t.deepEqual(a.get().x, 1)
+    a.set(3)
+    t.deepEqual(a.get(), 3)
+    t.equal("" + a, "3")
+    t.equal(a.toJSON(), 3)
+    t.end()
 })
 
 test("computed value scope", t => {
-	var a = mobx.observable({
-		x: 1,
-		y: mobx.computed(function() {
-			return this.x * 2
-		}, function(v) {
-			this.x = v;
-		})
-	})
+    var a = mobx.observable({
+        x: 1,
+        y: mobx.computed(
+            function() {
+                return this.x * 2
+            },
+            function(v) {
+                this.x = v
+            }
+        )
+    })
 
-	t.equal(a.y, 2);
-	a.x = 2;
-	t.equal(a.y, 4);
-	a.y = 3;
-	t.equal(a.y, 6);
+    t.equal(a.y, 2)
+    a.x = 2
+    t.equal(a.y, 4)
+    a.y = 3
+    t.equal(a.y, 6)
 
-	t.end();
-});
-
-test("shallow array", t => {
-	var a = mobx.observable.shallowArray();
-	a.push({ x: 1 }, [], 2, mobx.observable({ y: 3 }));
-
-	t.equal(mobx.isObservable(a), true);
-	t.equal(mobx.isObservable(a[0]), false);
-	t.equal(mobx.isObservable(a[1]), false);
-	t.equal(mobx.isObservable(a[2]), false);
-	t.equal(mobx.isObservable(a[3]), true);
-
-	t.end();
+    t.end()
 })
 
-test("761 - deeply nested modifiers work", t=> {
-	var a = {}
-	mobx.extendObservable(a, {
-		someKey: {
-			someNestedKey: mobx.observable.ref([])
-		}
-	})
+test("shallow array", t => {
+    var a = mobx.observable.shallowArray()
+    a.push({ x: 1 }, [], 2, mobx.observable({ y: 3 }))
 
-	t.equal(mobx.isObservable(a), true)
-	t.equal(mobx.isObservable(a, "someKey"), true)
-	t.equal(mobx.isObservable(a.someKey), true)
-	t.equal(mobx.isObservable(a.someKey, "someNestedKey"), true)
-	t.equal(mobx.isObservable(a.someKey.someNestedKey), false)
-	t.equal(Array.isArray(a.someKey.someNestedKey), true)
+    t.equal(mobx.isObservable(a), true)
+    t.equal(mobx.isObservable(a[0]), false)
+    t.equal(mobx.isObservable(a[1]), false)
+    t.equal(mobx.isObservable(a[2]), false)
+    t.equal(mobx.isObservable(a[3]), true)
 
-	Object.assign(a, { someKey: { someNestedKey: [1, 2, 3 ]}})
-	t.equal(mobx.isObservable(a), true)
-	t.equal(mobx.isObservable(a, "someKey"), true)
-	t.equal(mobx.isObservable(a.someKey), true)
-	t.equal(mobx.isObservable(a.someKey, "someNestedKey"), true)
-	t.equal(mobx.isObservable(a.someKey.someNestedKey), true) // Too bad: no deep merge with Object.assign! someKey object gets replaced in its entirity
-	t.equal(Array.isArray(a.someKey.someNestedKey), false)
+    t.end()
+})
 
-	t.end();
-});
+test("761 - deeply nested modifiers work", t => {
+    var a = {}
+    mobx.extendObservable(a, {
+        someKey: {
+            someNestedKey: mobx.observable.ref([])
+        }
+    })
+
+    t.equal(mobx.isObservable(a), true)
+    t.equal(mobx.isObservable(a, "someKey"), true)
+    t.equal(mobx.isObservable(a.someKey), true)
+    t.equal(mobx.isObservable(a.someKey, "someNestedKey"), true)
+    t.equal(mobx.isObservable(a.someKey.someNestedKey), false)
+    t.equal(Array.isArray(a.someKey.someNestedKey), true)
+
+    Object.assign(a, { someKey: { someNestedKey: [1, 2, 3] } })
+    t.equal(mobx.isObservable(a), true)
+    t.equal(mobx.isObservable(a, "someKey"), true)
+    t.equal(mobx.isObservable(a.someKey), true)
+    t.equal(mobx.isObservable(a.someKey, "someNestedKey"), true)
+    t.equal(mobx.isObservable(a.someKey.someNestedKey), true) // Too bad: no deep merge with Object.assign! someKey object gets replaced in its entirity
+    t.equal(Array.isArray(a.someKey.someNestedKey), false)
+
+    t.end()
+})
 
 test("compare structurally, deep", t => {
-	var a = mobx.observable.object({
-		x: mobx.observable.deep.struct()
-	})
+    var a = mobx.observable.object({
+        x: mobx.observable.deep.struct()
+    })
 
-	var changed = 0
-	var d = mobx.autorun(() => {
-		mobx.toJS(a)
-		changed++
-	})
+    var changed = 0
+    var d = mobx.autorun(() => {
+        mobx.toJS(a)
+        changed++
+    })
 
-	t.equal(changed, 1)
-	a.x = { y: 2 }
-	t.equal(changed, 2)
-	a.x.y = 3
-	t.equal(changed, 3, "reacted to deep observability")
+    t.equal(changed, 1)
+    a.x = { y: 2 }
+    t.equal(changed, 2)
+    a.x.y = 3
+    t.equal(changed, 3, "reacted to deep observability")
 
-	a.x = { y: 3 }
-	t.equal(changed, 3, "did not react; structurally the same")
+    a.x = { y: 3 }
+    t.equal(changed, 3, "did not react; structurally the same")
 
-	a.x.y = { a: 1 }
-	t.equal(changed, 4, "did react")
-	a.x.y = { a: 1 }
-	t.equal(changed, 4, "did not react; structurally comparison was infective")
+    a.x.y = { a: 1 }
+    t.equal(changed, 4, "did react")
+    a.x.y = { a: 1 }
+    t.equal(changed, 4, "did not react; structurally comparison was infective")
 
-	d()
-	t.end()
+    d()
+    t.end()
 })
 
 test("compare structurally, ref", t => {
-	var a = mobx.observable.object({
-		x: mobx.observable.ref.struct()
-	})
+    var a = mobx.observable.object({
+        x: mobx.observable.ref.struct()
+    })
 
-	var changed = 0
-	var d = mobx.autorun(() => {
-		mobx.toJS(a)
-		changed++
-	})
+    var changed = 0
+    var d = mobx.autorun(() => {
+        mobx.toJS(a)
+        changed++
+    })
 
-	t.equal(changed, 1)
-	a.x = { y: 2 }
-	t.equal(changed, 2)
-	a.x.y = 3
-	t.equal(mobx.isObservable(a.x), false)
-	t.equal(changed, 2, "didn't react, not observed")
+    t.equal(changed, 1)
+    a.x = { y: 2 }
+    t.equal(changed, 2)
+    a.x.y = 3
+    t.equal(mobx.isObservable(a.x), false)
+    t.equal(changed, 2, "didn't react, not observed")
 
-	a.x = { y: 3 }
-	t.equal(changed, 2, "did not react; structurally the same")
+    a.x = { y: 3 }
+    t.equal(changed, 2, "did not react; structurally the same")
 
-	a.x = { y: 4 }
-	t.equal(changed, 3, "did react; ref change")
+    a.x = { y: 4 }
+    t.equal(changed, 3, "did react; ref change")
 
-	d()
-	t.end()
+    d()
+    t.end()
 })

--- a/test/map.js
+++ b/test/map.js
@@ -1,622 +1,618 @@
 "use strict"
 
-var test = require('tape');
-var mobx = require('..');
-var map = mobx.map;
-var autorun = mobx.autorun;
-var iterall = require('iterall');
+var test = require("tape")
+var mobx = require("..")
+var map = mobx.map
+var autorun = mobx.autorun
+var iterall = require("iterall")
 
-test('map crud', function (t) {
-	mobx.extras.getGlobalState().mobxGuid = 0; // hmm dangerous reset?
+test("map crud", function(t) {
+    mobx.extras.getGlobalState().mobxGuid = 0 // hmm dangerous reset?
 
-	var events = [];
-	var m = map({ a: 1 });
-	m.observe(function (changes) {
-		events.push(changes);
-	});
+    var events = []
+    var m = map({ a: 1 })
+    m.observe(function(changes) {
+        events.push(changes)
+    })
 
-	t.equal(m.has("a"), true);
-	t.equal(m.has("b"), false);
-	t.equal(m.get("a"), 1);
-	t.equal(m.get("b"), undefined);
-	t.equal(m.size, 1);
+    t.equal(m.has("a"), true)
+    t.equal(m.has("b"), false)
+    t.equal(m.get("a"), 1)
+    t.equal(m.get("b"), undefined)
+    t.equal(m.size, 1)
 
-	m.set("a", 2);
-	t.equal(m.has("a"), true);
-	t.equal(m.get("a"), 2);
+    m.set("a", 2)
+    t.equal(m.has("a"), true)
+    t.equal(m.get("a"), 2)
 
-	m.set("b", 3);
-	t.equal(m.has("b"), true);
-	t.equal(m.get("b"), 3);
+    m.set("b", 3)
+    t.equal(m.has("b"), true)
+    t.equal(m.get("b"), 3)
 
-	t.deepEqual(m.keys(), ["a", "b"]);
-	t.deepEqual(m.values(), [2, 3]);
-	t.deepEqual(m.entries(), [["a", 2], ["b", 3]]);
-	t.deepEqual(m.toJS(), { a: 2, b: 3 });
-	t.deepEqual(JSON.stringify(m), '{"a":2,"b":3}');
-	t.deepEqual(m.toString(), "ObservableMap@1[{ a: 2, b: 3 }]");
-	t.equal(m.size, 2);
+    t.deepEqual(m.keys(), ["a", "b"])
+    t.deepEqual(m.values(), [2, 3])
+    t.deepEqual(m.entries(), [["a", 2], ["b", 3]])
+    t.deepEqual(m.toJS(), { a: 2, b: 3 })
+    t.deepEqual(JSON.stringify(m), '{"a":2,"b":3}')
+    t.deepEqual(m.toString(), "ObservableMap@1[{ a: 2, b: 3 }]")
+    t.equal(m.size, 2)
 
-	m.clear();
-	t.deepEqual(m.keys(), []);
-	t.deepEqual(m.values(), []);
-	t.deepEqual(m.toJS(), {});
-	t.deepEqual(m.toString(), "ObservableMap@1[{  }]");
-	t.equal(m.size, 0);
+    m.clear()
+    t.deepEqual(m.keys(), [])
+    t.deepEqual(m.values(), [])
+    t.deepEqual(m.toJS(), {})
+    t.deepEqual(m.toString(), "ObservableMap@1[{  }]")
+    t.equal(m.size, 0)
 
-	t.equal(m.has("a"), false);
-	t.equal(m.has("b"), false);
-	t.equal(m.get("a"), undefined);
-	t.equal(m.get("b"), undefined);
+    t.equal(m.has("a"), false)
+    t.equal(m.has("b"), false)
+    t.equal(m.get("a"), undefined)
+    t.equal(m.get("b"), undefined)
 
-	function removeObjectProp(item) {
-		delete item.object;
-		return item;
-	};
-	t.deepEqual(events.map(removeObjectProp),
-		[{
-			type: 'update',
-			name: 'a',
-			oldValue: 1,
-			newValue: 2
-		},
-		{
-			type: 'add',
-			name: 'b',
-			newValue: 3
-		},
-		{
-			type: 'delete',
-			name: 'a',
-			oldValue: 2
-		},
-		{
-			type: 'delete',
-			name: 'b',
-			oldValue: 3
-		}
-		]
-	);
-	t.end();
+    function removeObjectProp(item) {
+        delete item.object
+        return item
+    }
+    t.deepEqual(events.map(removeObjectProp), [
+        {
+            type: "update",
+            name: "a",
+            oldValue: 1,
+            newValue: 2
+        },
+        {
+            type: "add",
+            name: "b",
+            newValue: 3
+        },
+        {
+            type: "delete",
+            name: "a",
+            oldValue: 2
+        },
+        {
+            type: "delete",
+            name: "b",
+            oldValue: 3
+        }
+    ])
+    t.end()
 })
 
-test('map merge', function (t) {
-	var a = map({ a: 1, b: 2, c: 2 });
-	var b = map({ c: 3, d: 4 });
-	a.merge(b);
-	t.deepEqual(a.toJS(), { a: 1, b: 2, c: 3, d: 4 });
+test("map merge", function(t) {
+    var a = map({ a: 1, b: 2, c: 2 })
+    var b = map({ c: 3, d: 4 })
+    a.merge(b)
+    t.deepEqual(a.toJS(), { a: 1, b: 2, c: 3, d: 4 })
 
-	t.end();
+    t.end()
 })
 
-test('observe value', function (t) {
-	var a = map();
-	var hasX = false;
-	var valueX = undefined;
-	var valueY = undefined;
+test("observe value", function(t) {
+    var a = map()
+    var hasX = false
+    var valueX = undefined
+    var valueY = undefined
 
-	autorun(function () {
-		hasX = a.has("x");
-	});
+    autorun(function() {
+        hasX = a.has("x")
+    })
 
-	autorun(function () {
-		valueX = a.get("x");
-	});
+    autorun(function() {
+        valueX = a.get("x")
+    })
 
-	autorun(function () {
-		valueY = a.get("y");
-	});
+    autorun(function() {
+        valueY = a.get("y")
+    })
 
-	t.equal(hasX, false);
-	t.equal(valueX, undefined);
+    t.equal(hasX, false)
+    t.equal(valueX, undefined)
 
-	a.set("x", 3);
-	t.equal(hasX, true);
-	t.equal(valueX, 3);
+    a.set("x", 3)
+    t.equal(hasX, true)
+    t.equal(valueX, 3)
 
-	a.set("x", 4);
-	t.equal(hasX, true);
-	t.equal(valueX, 4);
+    a.set("x", 4)
+    t.equal(hasX, true)
+    t.equal(valueX, 4)
 
-	a.delete("x");
-	t.equal(hasX, false);
-	t.equal(valueX, undefined);
+    a.delete("x")
+    t.equal(hasX, false)
+    t.equal(valueX, undefined)
 
-	a.set("x", 5);
-	t.equal(hasX, true);
-	t.equal(valueX, 5);
+    a.set("x", 5)
+    t.equal(hasX, true)
+    t.equal(valueX, 5)
 
-	t.equal(valueY, undefined);
-	a.merge({ y: 'hi' });
-	t.equal(valueY, 'hi');
-	a.merge({ y: 'hello' });
-	t.equal(valueY, 'hello');
+    t.equal(valueY, undefined)
+    a.merge({ y: "hi" })
+    t.equal(valueY, "hi")
+    a.merge({ y: "hello" })
+    t.equal(valueY, "hello")
 
-	a.replace({ y: "stuff", z: "zoef" });
-	t.equal(valueY, "stuff");
-	t.deepEqual(a.keys(), ["y", "z"])
+    a.replace({ y: "stuff", z: "zoef" })
+    t.equal(valueY, "stuff")
+    t.deepEqual(a.keys(), ["y", "z"])
 
-	t.end();
+    t.end()
 })
 
-test('initialize with entries', function (t) {
-	var a = map([["a", 1], ["b", 2]]);
-	t.deepEqual(a.toJS(), { a: 1, b: 2 });
-	t.end();
+test("initialize with entries", function(t) {
+    var a = map([["a", 1], ["b", 2]])
+    t.deepEqual(a.toJS(), { a: 1, b: 2 })
+    t.end()
 })
 
-test('initialize with empty value', function (t) {
-	var a = map();
-	var b = map({});
-	var c = map([]);
+test("initialize with empty value", function(t) {
+    var a = map()
+    var b = map({})
+    var c = map([])
 
-	a.set('0', 0);
-	b.set('0', 0);
-	c.set('0', 0);
+    a.set("0", 0)
+    b.set("0", 0)
+    c.set("0", 0)
 
-	t.deepEqual(a.toJS(), { '0': 0 });
-	t.deepEqual(b.toJS(), { '0': 0 });
-	t.deepEqual(c.toJS(), { '0': 0 });
+    t.deepEqual(a.toJS(), { "0": 0 })
+    t.deepEqual(b.toJS(), { "0": 0 })
+    t.deepEqual(c.toJS(), { "0": 0 })
 
-	t.end();
+    t.end()
 })
 
-test('observe collections', function (t) {
-	var x = map();
-	var keys, values, entries;
+test("observe collections", function(t) {
+    var x = map()
+    var keys, values, entries
 
-	autorun(function () {
-		keys = x.keys();
-	});
-	autorun(function () {
-		values = x.values();
-	});
-	autorun(function () {
-		entries = x.entries();
-	});
+    autorun(function() {
+        keys = x.keys()
+    })
+    autorun(function() {
+        values = x.values()
+    })
+    autorun(function() {
+        entries = x.entries()
+    })
 
-	x.set("a", 1);
-	t.deepEqual(keys, ["a"]);
-	t.deepEqual(values, [1]);
-	t.deepEqual(entries, [["a", 1]]);
+    x.set("a", 1)
+    t.deepEqual(keys, ["a"])
+    t.deepEqual(values, [1])
+    t.deepEqual(entries, [["a", 1]])
 
-	// should not retrigger:
-	keys = null;
-	values = null;
-	entries = null;
-	x.set("a", 1);
-	t.deepEqual(keys, null);
-	t.deepEqual(values, null);
-	t.deepEqual(entries, null);
+    // should not retrigger:
+    keys = null
+    values = null
+    entries = null
+    x.set("a", 1)
+    t.deepEqual(keys, null)
+    t.deepEqual(values, null)
+    t.deepEqual(entries, null)
 
-	x.set("a", 2);
-	t.deepEqual(values, [2]);
-	t.deepEqual(entries, [["a", 2]]);
+    x.set("a", 2)
+    t.deepEqual(values, [2])
+    t.deepEqual(entries, [["a", 2]])
 
-	x.set("b", 3);
-	t.deepEqual(keys, ["a", "b"]);
-	t.deepEqual(values, [2, 3]);
-	t.deepEqual(entries, [["a", 2], ["b", 3]]);
+    x.set("b", 3)
+    t.deepEqual(keys, ["a", "b"])
+    t.deepEqual(values, [2, 3])
+    t.deepEqual(entries, [["a", 2], ["b", 3]])
 
-	x.has("c");
-	t.deepEqual(keys, ["a", "b"]);
-	t.deepEqual(values, [2, 3]);
-	t.deepEqual(entries, [["a", 2], ["b", 3]]);
+    x.has("c")
+    t.deepEqual(keys, ["a", "b"])
+    t.deepEqual(values, [2, 3])
+    t.deepEqual(entries, [["a", 2], ["b", 3]])
 
-	x.delete("a");
-	t.deepEqual(keys, ["b"]);
-	t.deepEqual(values, [3]);
-	t.deepEqual(entries, [["b", 3]]);
+    x.delete("a")
+    t.deepEqual(keys, ["b"])
+    t.deepEqual(values, [3])
+    t.deepEqual(entries, [["b", 3]])
 
-	t.end();
+    t.end()
 })
 
-test.skip('asStructure', function (t) {
-	var x = mobx.observable.structureMap({});
-	var triggerCount = 0;
-	var value = null;
+test.skip("asStructure", function(t) {
+    var x = mobx.observable.structureMap({})
+    var triggerCount = 0
+    var value = null
 
-	x.set("a", { b: { c: 1 } });
-	autorun(function () {
-		triggerCount += 1;
-		value = x.get("a").b.c;
-	});
+    x.set("a", { b: { c: 1 } })
+    autorun(function() {
+        triggerCount += 1
+        value = x.get("a").b.c
+    })
 
-	t.equal(triggerCount, 1);
-	t.equal(value, 1);
+    t.equal(triggerCount, 1)
+    t.equal(value, 1)
 
-	x.get("a").b.c = 1;
-	x.get("a").b = { c: 1 };
-	x.set("a", { b: { c: 1 } });
+    x.get("a").b.c = 1
+    x.get("a").b = { c: 1 }
+    x.set("a", { b: { c: 1 } })
 
-	t.equal(triggerCount, 1);
-	t.equal(value, 1);
+    t.equal(triggerCount, 1)
+    t.equal(value, 1)
 
-	x.get("a").b.c = 2;
-	t.equal(triggerCount, 2);
-	t.equal(value, 2);
+    x.get("a").b.c = 2
+    t.equal(triggerCount, 2)
+    t.equal(value, 2)
 
-	t.end();
+    t.end()
 })
 
-test('cleanup', function (t) {
-	var x = map({ a: 1 });
+test("cleanup", function(t) {
+    var x = map({ a: 1 })
 
-	var aValue;
-	var disposer = autorun(function () {
-		aValue = x.get("a");
-	});
+    var aValue
+    var disposer = autorun(function() {
+        aValue = x.get("a")
+    })
 
-	var observable = x._data.a;
+    var observable = x._data.a
 
-	t.equal(aValue, 1);
-	t.equal(observable.observers.length, 1);
-	t.equal(x._hasMap.a.observers.length, 1);
+    t.equal(aValue, 1)
+    t.equal(observable.observers.length, 1)
+    t.equal(x._hasMap.a.observers.length, 1)
 
-	t.equal(x.delete("a"), true);
-	t.equal(x.delete("not-existing"), false);
+    t.equal(x.delete("a"), true)
+    t.equal(x.delete("not-existing"), false)
 
-	t.equal(aValue, undefined);
-	t.equal(observable.observers.length, 0);
-	t.equal(x._hasMap.a.observers.length, 1);
+    t.equal(aValue, undefined)
+    t.equal(observable.observers.length, 0)
+    t.equal(x._hasMap.a.observers.length, 1)
 
-	x.set("a", 2);
-	observable = x._data.a;
+    x.set("a", 2)
+    observable = x._data.a
 
-	t.equal(aValue, 2);
-	t.equal(observable.observers.length, 1);
-	t.equal(x._hasMap.a.observers.length, 1);
+    t.equal(aValue, 2)
+    t.equal(observable.observers.length, 1)
+    t.equal(x._hasMap.a.observers.length, 1)
 
-	disposer();
-	t.equal(aValue, 2);
-	t.equal(observable.observers.length, 0);
-	t.equal(x._hasMap.a.observers.length, 0);
-	t.end();
+    disposer()
+    t.equal(aValue, 2)
+    t.equal(observable.observers.length, 0)
+    t.equal(x._hasMap.a.observers.length, 0)
+    t.end()
 })
 
-test('strict', function (t) {
-	var x = map();
-	autorun(function () {
-		x.get("y"); // should not throw
-	});
-	t.end();
+test("strict", function(t) {
+    var x = map()
+    autorun(function() {
+        x.get("y") // should not throw
+    })
+    t.end()
 })
 
-test('issue 100', function (t) {
-	var that = {};
-	mobx.extendObservable(that, {
-		myMap: map()
-	})
-	t.equal(mobx.isObservableMap(that.myMap), true);
-	t.equal(typeof that.myMap.observe, "function");
-	t.end();
-});
-
-test('issue 119 - unobserve before delete', function (t) {
-	var propValues = [];
-	var myObservable = mobx.observable({
-		myMap: map()
-	});
-	myObservable.myMap.set('myId', {
-		myProp: 'myPropValue',
-		myCalculatedProp: mobx.computed(function () {
-			if (myObservable.myMap.has('myId'))
-				return myObservable.myMap.get('myId').myProp + ' calculated';
-			return undefined;
-		})
-	});
-	// the error only happens if the value is observed
-	mobx.autorun(function () {
-		myObservable.myMap.values().forEach(function (value) {
-			console.log('x');
-			propValues.push(value.myCalculatedProp);
-		});
-	});
-	myObservable.myMap.delete('myId');
-
-	t.deepEqual(propValues, ['myPropValue calculated']);
-	t.end();
+test("issue 100", function(t) {
+    var that = {}
+    mobx.extendObservable(that, {
+        myMap: map()
+    })
+    t.equal(mobx.isObservableMap(that.myMap), true)
+    t.equal(typeof that.myMap.observe, "function")
+    t.end()
 })
 
-test('issue 116 - has should not throw on invalid keys', function (t) {
-	var x = map();
-	t.equal(x.has(undefined), false);
-	t.equal(x.has({}), false);
-	t.equal(x.get({}), undefined);
-	t.equal(x.get(undefined), undefined);
-	t.throws(function () {
-		x.set({});
-	});
-	t.end();
-});
+test("issue 119 - unobserve before delete", function(t) {
+    var propValues = []
+    var myObservable = mobx.observable({
+        myMap: map()
+    })
+    myObservable.myMap.set("myId", {
+        myProp: "myPropValue",
+        myCalculatedProp: mobx.computed(function() {
+            if (myObservable.myMap.has("myId"))
+                return myObservable.myMap.get("myId").myProp + " calculated"
+            return undefined
+        })
+    })
+    // the error only happens if the value is observed
+    mobx.autorun(function() {
+        myObservable.myMap.values().forEach(function(value) {
+            console.log("x")
+            propValues.push(value.myCalculatedProp)
+        })
+    })
+    myObservable.myMap.delete("myId")
 
-test('map modifier', t => {
-	var x = mobx.observable.map({ a: 1 });
-	t.equal(x instanceof mobx.ObservableMap, true);
-	t.equal(mobx.isObservableMap(x), true);
-	t.equal(x.get("a"), 1);
-	x.set("b", {});
-	t.equal(mobx.isObservableObject(x.get("b")), true);
-
-	x = mobx.observable.map([["a", 1]]);
-	t.equal(x instanceof mobx.ObservableMap, true);
-	t.equal(x.get("a"), 1);
-
-	x = mobx.observable.map();
-	t.equal(x instanceof mobx.ObservableMap, true);
-	t.deepEqual(x.keys(), []);
-
-	x = mobx.observable({ a: mobx.observable.map({ b: { c: 3 } }) });
-	t.equal(mobx.isObservableObject(x), true);
-	t.equal(mobx.isObservableObject(x.a), false);
-	t.equal(mobx.isObservableMap(x.a), true);
-	t.equal(mobx.isObservableObject(x.a.get("b")), true);
-
-	t.end();
-});
-
-test('map modifier with modifier', t => {
-	var x = mobx.observable.map({ a: { c: 3 } });
-	t.equal(mobx.isObservableObject(x.get("a")), true);
-	x.set("b", { d: 4 });
-	t.equal(mobx.isObservableObject(x.get("b")), true);
-
-	x = mobx.observable.shallowMap({ a: { c: 3 } });
-	t.equal(mobx.isObservableObject(x.get("a")), false);
-	x.set("b", { d: 4 });
-	t.equal(mobx.isObservableObject(x.get("b")), false);
-
-	x = mobx.observable({ a: mobx.observable.shallowMap({ b: {} }) });
-	t.equal(mobx.isObservableObject(x), true);
-	t.equal(mobx.isObservableMap(x.a), true);
-	t.equal(mobx.isObservableObject(x.a.get("b")), false);
-	x.a.set("e", {});
-	t.equal(mobx.isObservableObject(x.a.get("e")), false);
-
-	t.end();
-});
-
-test('256, map.clear should not be tracked', t => {
-	var x = new mobx.ObservableMap({ a: 3 });
-	var c = 0;
-	var d = mobx.autorun(() => { c++; x.clear() });
-
-	t.equal(c, 1);
-	x.set("b", 3);
-	t.equal(c, 1);
-
-	d();
-	t.end();
+    t.deepEqual(propValues, ["myPropValue calculated"])
+    t.end()
 })
 
-
-test('256, map.merge should be not be tracked for target', t => {
-	var x = mobx.observable.map({ a: 3 });
-	var y = mobx.observable.map({ b: 3 });
-	var c = 0;
-
-	var d = mobx.autorun(() => {
-		c++;
-		x.merge(y);
-	});
-
-	t.equal(c, 1);
-	t.deepEqual(x.keys(), ["a", "b"]);
-
-	y.set("c", 4)
-	t.equal(c, 2);
-	t.deepEqual(x.keys(), ["a", "b", "c"]);
-
-	x.set("d", 5);
-	t.equal(c, 2, "autorun should not have been triggered");
-	t.deepEqual(x.keys(), ["a", "b", "c", "d"]);
-
-	d();
-	t.end();
+test("issue 116 - has should not throw on invalid keys", function(t) {
+    var x = map()
+    t.equal(x.has(undefined), false)
+    t.equal(x.has({}), false)
+    t.equal(x.get({}), undefined)
+    t.equal(x.get(undefined), undefined)
+    t.throws(function() {
+        x.set({})
+    })
+    t.end()
 })
 
-test('308, map keys should be coerced to strings correctly', t => {
-	var m = mobx.map()
-	m.set(1, true) // => "[mobx.map { 1: true }]"
-	m.delete(1) // => "[mobx.map { }]"
-	t.deepEqual(m.keys(), [])
+test("map modifier", t => {
+    var x = mobx.observable.map({ a: 1 })
+    t.equal(x instanceof mobx.ObservableMap, true)
+    t.equal(mobx.isObservableMap(x), true)
+    t.equal(x.get("a"), 1)
+    x.set("b", {})
+    t.equal(mobx.isObservableObject(x.get("b")), true)
 
-	m.set(1, true) // => "[mobx.map { 1: true }]"
-	m.delete('1') // => "[mobx.map { 1: undefined }]"
-	t.deepEqual(m.keys(), [])
+    x = mobx.observable.map([["a", 1]])
+    t.equal(x instanceof mobx.ObservableMap, true)
+    t.equal(x.get("a"), 1)
 
-	m.set(1, true) // => "[mobx.map { 1: true, 1: true }]"
-	m.delete('1') // => "[mobx.map { 1: undefined, 1: undefined }]"
-	t.deepEqual(m.keys(), [])
+    x = mobx.observable.map()
+    t.equal(x instanceof mobx.ObservableMap, true)
+    t.deepEqual(x.keys(), [])
 
-	m.set(true, true)
-	t.equal(m.get("true"), true)
-	m.delete(true)
-	t.deepEqual(m.keys(), [])
+    x = mobx.observable({ a: mobx.observable.map({ b: { c: 3 } }) })
+    t.equal(mobx.isObservableObject(x), true)
+    t.equal(mobx.isObservableObject(x.a), false)
+    t.equal(mobx.isObservableMap(x.a), true)
+    t.equal(mobx.isObservableObject(x.a.get("b")), true)
 
-	t.end()
+    t.end()
 })
 
-test('map should support iterall / iterable ', t => {
-	var a = mobx.map({ a: 1, b: 2 })
+test("map modifier with modifier", t => {
+    var x = mobx.observable.map({ a: { c: 3 } })
+    t.equal(mobx.isObservableObject(x.get("a")), true)
+    x.set("b", { d: 4 })
+    t.equal(mobx.isObservableObject(x.get("b")), true)
 
-	function leech(iter) {
-		var values = [];
-		do {
-			var v = iter.next();
-			if (!v.done)
-				values.push(v.value);
-		} while (!v.done)
-		return values;
-	}
+    x = mobx.observable.shallowMap({ a: { c: 3 } })
+    t.equal(mobx.isObservableObject(x.get("a")), false)
+    x.set("b", { d: 4 })
+    t.equal(mobx.isObservableObject(x.get("b")), false)
 
-	t.equal(iterall.isIterable(a), true)
+    x = mobx.observable({ a: mobx.observable.shallowMap({ b: {} }) })
+    t.equal(mobx.isObservableObject(x), true)
+    t.equal(mobx.isObservableMap(x.a), true)
+    t.equal(mobx.isObservableObject(x.a.get("b")), false)
+    x.a.set("e", {})
+    t.equal(mobx.isObservableObject(x.a.get("e")), false)
 
-	t.deepEqual(leech(iterall.getIterator(a)), [
-		["a", 1],
-		["b", 2]
-	])
-
-	t.deepEqual(leech(a.entries()), [
-		["a", 1],
-		["b", 2]
-	])
-
-	t.deepEqual(leech(a.keys()), ["a", "b"])
-	t.deepEqual(leech(a.values()), [1, 2])
-
-	t.end()
+    t.end()
 })
 
-test('support for ES6 Map', t => {
-	var x = new Map()
-	x.set("x", 3)
-	x.set("y", 2)
+test("256, map.clear should not be tracked", t => {
+    var x = new mobx.ObservableMap({ a: 3 })
+    var c = 0
+    var d = mobx.autorun(() => {
+        c++
+        x.clear()
+    })
 
-	var m = mobx.observable(x);
-	t.equal(mobx.isObservableMap(m), true);
-	t.deepEqual(m.entries(), [["x", 3], ["y", 2]]);
+    t.equal(c, 1)
+    x.set("b", 3)
+    t.equal(c, 1)
 
-	var x2 = new Map()
-	x2.set("y", 4)
-	x2.set("z", 5)
-	m.merge(x2);
-	t.deepEqual(m.get("z"), 5)
-
-	var x3 = new Map()
-	x3.set({ y: 2 }, { z: 4 })
-
-	t.throws(() => mobx.observable.shallowMap(x3), /only strings, numbers and booleans are accepted as key in observable maps/)
-
-	t.end();
+    d()
+    t.end()
 })
 
-test('deepEqual map', t => {
-	var x = new Map()
-	x.set("x", 3)
-	x.set("y", { z: 2 })
+test("256, map.merge should be not be tracked for target", t => {
+    var x = mobx.observable.map({ a: 3 })
+    var y = mobx.observable.map({ b: 3 })
+    var c = 0
 
-	var x2 = mobx.observable.map();
-	x2.set("x", 3)
-	x2.set("y", { z: 3 })
+    var d = mobx.autorun(() => {
+        c++
+        x.merge(y)
+    })
 
-	t.equals(mobx.extras.deepEqual(x, x2), false)
-	x2.get("y").z = 2
-	t.equals(mobx.extras.deepEqual(x, x2), true)
+    t.equal(c, 1)
+    t.deepEqual(x.keys(), ["a", "b"])
 
-	x2.set("z", 1)
-	t.equals(mobx.extras.deepEqual(x, x2), false)
-	x2.delete("z")
-	t.equals(mobx.extras.deepEqual(x, x2), true)
-	x2.delete("y")
-	t.equals(mobx.extras.deepEqual(x, x2), false)
+    y.set("c", 4)
+    t.equal(c, 2)
+    t.deepEqual(x.keys(), ["a", "b", "c"])
 
-	t.end();
+    x.set("d", 5)
+    t.equal(c, 2, "autorun should not have been triggered")
+    t.deepEqual(x.keys(), ["a", "b", "c", "d"])
+
+    d()
+    t.end()
 })
 
-test('798, cannot return observable map from computed prop', t => {
-	// MWE: this is an anti pattern, yet should be possible in certain cases nonetheless..?
-	// https://jsfiddle.net/7e6Ltscr/
+test("308, map keys should be coerced to strings correctly", t => {
+    var m = mobx.map()
+    m.set(1, true) // => "[mobx.map { 1: true }]"
+    m.delete(1) // => "[mobx.map { }]"
+    t.deepEqual(m.keys(), [])
 
-	const form = function (settings) {
-		var form = mobx.observable({
-			reactPropsMap: mobx.observable.map({
-				onSubmit: function () {
-					console.log('onSubmit init!');
-				}
-			}),
-			model: {
-				value: 'TEST'
-			}
-		});
+    m.set(1, true) // => "[mobx.map { 1: true }]"
+    m.delete("1") // => "[mobx.map { 1: undefined }]"
+    t.deepEqual(m.keys(), [])
 
-		form.reactPropsMap.set('onSubmit', function () {
-			console.log('onSubmit overwritten!');
-		});
+    m.set(1, true) // => "[mobx.map { 1: true, 1: true }]"
+    m.delete("1") // => "[mobx.map { 1: undefined, 1: undefined }]"
+    t.deepEqual(m.keys(), [])
 
-		return form;
-	};
+    m.set(true, true)
+    t.equal(m.get("true"), true)
+    m.delete(true)
+    t.deepEqual(m.keys(), [])
 
-	const customerSearchStore = function () {
-
-		var customerSearchStore = mobx.observable({
-			customerType: 'RUBY',
-			searchTypeFormStore: mobx.computed(function () {
-				return form(customerSearchStore.customerType);
-			}),
-			customerSearchType: mobx.computed(function () {
-				return form(customerSearchStore.searchTypeFormStore.model.value);
-			})
-		});
-		return customerSearchStore;
-	};
-	var cs = customerSearchStore();
-
-	t.doesNotThrow(() => {
-		console.log(cs.customerSearchType);
-	})
-
-	t.end()
+    t.end()
 })
 
-test('869, deeply observable map should make added items observables as well', t => {
-  var store = {
-    map_deep1: mobx.observable(new Map()),
-    map_deep2: mobx.observable.map(),
-  };
+test("map should support iterall / iterable ", t => {
+    var a = mobx.map({ a: 1, b: 2 })
 
-  t.ok(mobx.isObservable(store.map_deep1), 'should make map Observable');
-  t.ok(mobx.isObservableMap(store.map_deep1), 'should make map ObservableMap');
-  t.ok(mobx.isObservable(store.map_deep2), 'should make map Observable');
-  t.ok(mobx.isObservableMap(store.map_deep2), 'should make map ObservableMap');
+    function leech(iter) {
+        var values = []
+        do {
+            var v = iter.next()
+            if (!v.done) values.push(v.value)
+        } while (!v.done)
+        return values
+    }
 
-  store.map_deep2.set('a', []);
-  t.ok(mobx.isObservable(store.map_deep2.get('a')), 'should make added items observables');
+    t.equal(iterall.isIterable(a), true)
 
-  store.map_deep1.set('a', []);
-  t.ok(mobx.isObservable(store.map_deep1.get('a')), 'should make added items observables');
+    t.deepEqual(leech(iterall.getIterator(a)), [["a", 1], ["b", 2]])
 
-  t.end();
-});
+    t.deepEqual(leech(a.entries()), [["a", 1], ["b", 2]])
 
-test('using deep map', t => {
-  var store = {
-    map_deep: mobx.observable(new Map()),
-  };
+    t.deepEqual(leech(a.keys()), ["a", "b"])
+    t.deepEqual(leech(a.values()), [1, 2])
 
-  // Creating autorun triggers one observation, hence -1
-  let observed = -1;
-  mobx.autorun(function () {
-    // Use the map, to observe all changes
-    var _ = mobx.toJS(store.map_deep);
-    observed++;
-  });
+    t.end()
+})
 
-  store.map_deep.set('shoes', []);
-  t.equal(observed, 1, 'should observe new item added');
+test("support for ES6 Map", t => {
+    var x = new Map()
+    x.set("x", 3)
+    x.set("y", 2)
 
-  store.map_deep.get('shoes').push({ color: 'black' });
-  t.equal(observed, 2, 'should observe item mutated');
+    var m = mobx.observable(x)
+    t.equal(mobx.isObservableMap(m), true)
+    t.deepEqual(m.entries(), [["x", 3], ["y", 2]])
 
-  store.map_deep.get('shoes')[0].color = 'red';
-  t.equal(observed, 3, 'should observe nested item mutated');
+    var x2 = new Map()
+    x2.set("y", 4)
+    x2.set("z", 5)
+    m.merge(x2)
+    t.deepEqual(m.get("z"), 5)
 
-  t.end();
-});
+    var x3 = new Map()
+    x3.set({ y: 2 }, { z: 4 })
+
+    t.throws(
+        () => mobx.observable.shallowMap(x3),
+        /only strings, numbers and booleans are accepted as key in observable maps/
+    )
+
+    t.end()
+})
+
+test("deepEqual map", t => {
+    var x = new Map()
+    x.set("x", 3)
+    x.set("y", { z: 2 })
+
+    var x2 = mobx.observable.map()
+    x2.set("x", 3)
+    x2.set("y", { z: 3 })
+
+    t.equals(mobx.extras.deepEqual(x, x2), false)
+    x2.get("y").z = 2
+    t.equals(mobx.extras.deepEqual(x, x2), true)
+
+    x2.set("z", 1)
+    t.equals(mobx.extras.deepEqual(x, x2), false)
+    x2.delete("z")
+    t.equals(mobx.extras.deepEqual(x, x2), true)
+    x2.delete("y")
+    t.equals(mobx.extras.deepEqual(x, x2), false)
+
+    t.end()
+})
+
+test("798, cannot return observable map from computed prop", t => {
+    // MWE: this is an anti pattern, yet should be possible in certain cases nonetheless..?
+    // https://jsfiddle.net/7e6Ltscr/
+
+    const form = function(settings) {
+        var form = mobx.observable({
+            reactPropsMap: mobx.observable.map({
+                onSubmit: function() {
+                    console.log("onSubmit init!")
+                }
+            }),
+            model: {
+                value: "TEST"
+            }
+        })
+
+        form.reactPropsMap.set("onSubmit", function() {
+            console.log("onSubmit overwritten!")
+        })
+
+        return form
+    }
+
+    const customerSearchStore = function() {
+        var customerSearchStore = mobx.observable({
+            customerType: "RUBY",
+            searchTypeFormStore: mobx.computed(function() {
+                return form(customerSearchStore.customerType)
+            }),
+            customerSearchType: mobx.computed(function() {
+                return form(customerSearchStore.searchTypeFormStore.model.value)
+            })
+        })
+        return customerSearchStore
+    }
+    var cs = customerSearchStore()
+
+    t.doesNotThrow(() => {
+        console.log(cs.customerSearchType)
+    })
+
+    t.end()
+})
+
+test("869, deeply observable map should make added items observables as well", t => {
+    var store = {
+        map_deep1: mobx.observable(new Map()),
+        map_deep2: mobx.observable.map()
+    }
+
+    t.ok(mobx.isObservable(store.map_deep1), "should make map Observable")
+    t.ok(mobx.isObservableMap(store.map_deep1), "should make map ObservableMap")
+    t.ok(mobx.isObservable(store.map_deep2), "should make map Observable")
+    t.ok(mobx.isObservableMap(store.map_deep2), "should make map ObservableMap")
+
+    store.map_deep2.set("a", [])
+    t.ok(mobx.isObservable(store.map_deep2.get("a")), "should make added items observables")
+
+    store.map_deep1.set("a", [])
+    t.ok(mobx.isObservable(store.map_deep1.get("a")), "should make added items observables")
+
+    t.end()
+})
+
+test("using deep map", t => {
+    var store = {
+        map_deep: mobx.observable(new Map())
+    }
+
+    // Creating autorun triggers one observation, hence -1
+    let observed = -1
+    mobx.autorun(function() {
+        // Use the map, to observe all changes
+        var _ = mobx.toJS(store.map_deep)
+        observed++
+    })
+
+    store.map_deep.set("shoes", [])
+    t.equal(observed, 1, "should observe new item added")
+
+    store.map_deep.get("shoes").push({ color: "black" })
+    t.equal(observed, 2, "should observe item mutated")
+
+    store.map_deep.get("shoes")[0].color = "red"
+    t.equal(observed, 3, "should observe nested item mutated")
+
+    t.end()
+})
 
 test("issue 893", t => {
-  const m = mobx.observable.map();
-  const keys = ['constructor', 'toString', 'assertValidKey', 'isValidKey', 'toJSON', 'toJS']
-  for (let key of keys) {
-	  t.equal(m.get(key), undefined);
-  }
-  t.end();
-});
+    const m = mobx.observable.map()
+    const keys = ["constructor", "toString", "assertValidKey", "isValidKey", "toJSON", "toJS"]
+    for (let key of keys) {
+        t.equal(m.get(key), undefined)
+    }
+    t.end()
+})
 
 test("work with 'toString' key", t => {
-	const m = mobx.observable.map();
-	t.equal(m.get('toString'), undefined);
-	m.set('toString', 'test');
-	t.equal(m.get('toString'), 'test');
-	t.end();
-});
+    const m = mobx.observable.map()
+    t.equal(m.get("toString"), undefined)
+    m.set("toString", "test")
+    t.equal(m.get("toString"), "test")
+    t.end()
+})

--- a/test/mixed-versions/mixed-versions.js
+++ b/test/mixed-versions/mixed-versions.js
@@ -3,73 +3,77 @@ const mobx1 = require("../../")
 /* istanbul ignore next */
 const mobx2 = require("../../lib/mobx.umd.min.js")
 
-test("two versions should not work together if state is not shared", (t) => {
-	const a = mobx1.observable({
-		x: 1,
-	})
-	const b = mobx2.observable({
-		x: 3,
-	})
+test("two versions should not work together if state is not shared", t => {
+    const a = mobx1.observable({
+        x: 1
+    })
+    const b = mobx2.observable({
+        x: 3
+    })
 
-	values = []
-	const d1 = mobx1.autorun(() => {
-		values.push(b.x)
-	})
-	const d2 = mobx2.autorun(() => {
-		values.push(a.x)
-	})
+    values = []
+    const d1 = mobx1.autorun(() => {
+        values.push(b.x)
+    })
+    const d2 = mobx2.autorun(() => {
+        values.push(a.x)
+    })
 
-	a.x = 2
-	b.x = 4
+    a.x = 2
+    b.x = 4
 
-	d1()
-	d2()
+    d1()
+    d2()
 
-	t.deepEqual(values, [
-		3, 1 // no re-runs
-	])
+    t.deepEqual(values, [
+        3,
+        1 // no re-runs
+    ])
 
-	t.end()
+    t.end()
 })
 
-test("two versions should work together if state is shared", (t) => {
-	mobx1.extras.shareGlobalState();
-	mobx2.extras.shareGlobalState();
+test("two versions should work together if state is shared", t => {
+    mobx1.extras.shareGlobalState()
+    mobx2.extras.shareGlobalState()
 
-	const a = mobx1.observable({
-		x: 1,
-		get y() {
-			return this.x + b.x
-		}
-	})
-	const b = mobx2.observable({
-		x: 3,
-		get y() {
-			return (this.x + a.x) * 2
-		}
-	})
+    const a = mobx1.observable({
+        x: 1,
+        get y() {
+            return this.x + b.x
+        }
+    })
+    const b = mobx2.observable({
+        x: 3,
+        get y() {
+            return (this.x + a.x) * 2
+        }
+    })
 
-	const values = []
-	const d1 = mobx1.autorun(() => {
-		values.push(a.y - b.y)
-	})
-	const d2 = mobx2.autorun(() => {
-		values.push(b.y - a.y)
-	})
+    const values = []
+    const d1 = mobx1.autorun(() => {
+        values.push(a.y - b.y)
+    })
+    const d2 = mobx2.autorun(() => {
+        values.push(b.y - a.y)
+    })
 
-	a.x = 2
-	b.x = 4
+    a.x = 2
+    b.x = 4
 
-	d1()
-	d2()
-	a.x = 87
-	a.x = 23
+    d1()
+    d2()
+    a.x = 87
+    a.x = 23
 
-	t.deepEqual(values, [
-		-4, 4,
-		5, -5, // n.b: depending execution order columns could be swapped
-		6, -6
-	])
+    t.deepEqual(values, [
+        -4,
+        4,
+        5,
+        -5, // n.b: depending execution order columns could be swapped
+        6,
+        -6
+    ])
 
-	t.end()
+    t.end()
 })

--- a/test/modifiers2.js
+++ b/test/modifiers2.js
@@ -1,9 +1,8 @@
 "use strict"
 
-const test = require('tape')
-const mobx = require('../')
+const test = require("tape")
+const mobx = require("../")
 
 test("extend observable", t => {
-
-	t.end()
+    t.end()
 })

--- a/test/nested.js
+++ b/test/nested.js
@@ -1,40 +1,36 @@
 "use strict"
 
-const test = require('tape')
-const mobx = require('../')
+const test = require("tape")
+const mobx = require("../")
 
-test('nested computeds should not run unnecessary', t => {
-	function Item(name) {
-		mobx.extendObservable(this, {
-			name: name,
-			get index() {
-				const i = store.items.indexOf(this)
-				if (i === -1)
-					throw "not found"
-				return i
-			}
-		})
-	}
+test("nested computeds should not run unnecessary", t => {
+    function Item(name) {
+        mobx.extendObservable(this, {
+            name: name,
+            get index() {
+                const i = store.items.indexOf(this)
+                if (i === -1) throw "not found"
+                return i
+            }
+        })
+    }
 
-	const store = mobx.observable({
-		items: [],
-		get asString() {
-			return this.items.map(item => item.index + ":" + item.name).join(",")
-		}
-	})
-	store.items.push(new Item("item1"))
+    const store = mobx.observable({
+        items: [],
+        get asString() {
+            return this.items.map(item => item.index + ":" + item.name).join(",")
+        }
+    })
+    store.items.push(new Item("item1"))
 
-	const values = []
-	mobx.autorun(() => {
-		values.push(store.asString)
-	})
+    const values = []
+    mobx.autorun(() => {
+        values.push(store.asString)
+    })
 
-	store.items.replace([new Item("item2")])
+    store.items.replace([new Item("item2")])
 
-	t.deepEqual(values, [
-		"0:item1",
-		"0:item2"
-	])
+    t.deepEqual(values, ["0:item1", "0:item2"])
 
-	t.end()
+    t.end()
 })

--- a/test/observables.js
+++ b/test/observables.js
@@ -1,1840 +1,1944 @@
 "use strict"
 
-var test = require('tape');
-var mobx = require('..');
-var m = mobx;
-var observable = mobx.observable;
-var computed = mobx.computed;
-var transaction = mobx.transaction;
+var test = require("tape")
+var mobx = require("..")
+var m = mobx
+var observable = mobx.observable
+var computed = mobx.computed
+var transaction = mobx.transaction
 
-var voidObserver = function(){};
+var voidObserver = function() {}
 
 function buffer() {
-    var b = [];
+    var b = []
     var res = function(x) {
-        b.push(x.newValue);
-    };
-    res.toArray = function() {
-        return b;
+        b.push(x.newValue)
     }
-    return res;
+    res.toArray = function() {
+        return b
+    }
+    return res
 }
 
-test('argumentless observable', t => {
-	var a = observable();
+test("argumentless observable", t => {
+    var a = observable()
 
-	t.equal(m.isObservable(a), true);
-	t.equal(a.get(), undefined);
+    t.equal(m.isObservable(a), true)
+    t.equal(a.get(), undefined)
 
-	t.end();
+    t.end()
 })
 
-test('basic', function(t) {
-    var x = observable(3);
-    var b = buffer();
-    m.observe(x, b);
-    t.equal(3, x.get());
+test("basic", function(t) {
+    var x = observable(3)
+    var b = buffer()
+    m.observe(x, b)
+    t.equal(3, x.get())
 
-    x.set(5);
-    t.equal(5, x.get());
-    t.deepEqual([5], b.toArray());
-    t.equal(mobx.extras.isComputingDerivation(), false);
-    t.end();
+    x.set(5)
+    t.equal(5, x.get())
+    t.deepEqual([5], b.toArray())
+    t.equal(mobx.extras.isComputingDerivation(), false)
+    t.end()
 })
 
-test('basic2', function(t) {
-    var x = observable(3);
-    var z = computed(function () { return x.get() * 2});
-    var y = computed(function () { return x.get() * 3});
+test("basic2", function(t) {
+    var x = observable(3)
+    var z = computed(function() {
+        return x.get() * 2
+    })
+    var y = computed(function() {
+        return x.get() * 3
+    })
 
-    m.observe(z, voidObserver);
+    m.observe(z, voidObserver)
 
-    t.equal(z.get(), 6);
-    t.equal(y.get(), 9);
+    t.equal(z.get(), 6)
+    t.equal(y.get(), 9)
 
-    x.set(5);
-    t.equal(z.get(), 10);
-    t.equal(y.get(), 15);
+    x.set(5)
+    t.equal(z.get(), 10)
+    t.equal(y.get(), 15)
 
-    t.equal(mobx.extras.isComputingDerivation(), false);
-    t.end();
+    t.equal(mobx.extras.isComputingDerivation(), false)
+    t.end()
 })
 
-test('computed with asStructure modifier', function(t) {
+test("computed with asStructure modifier", function(t) {
     try {
-        var x1 = observable(3);
-        var x2 = observable(5);
-        var y = m.computed(function() {
-            return {
-              sum: x1.get() + x2.get()
-            }
-        }, { struct: true });
-        var b = buffer();
-        m.observe(y, b, true);
+        var x1 = observable(3)
+        var x2 = observable(5)
+        var y = m.computed(
+            function() {
+                return {
+                    sum: x1.get() + x2.get()
+                }
+            },
+            { struct: true }
+        )
+        var b = buffer()
+        m.observe(y, b, true)
 
-        t.equal(8, y.get().sum);
+        t.equal(8, y.get().sum)
 
-        x1.set(4);
-        t.equal(9, y.get().sum);
+        x1.set(4)
+        t.equal(9, y.get().sum)
 
         m.transaction(function() {
-          // swap values, computation results is structuraly unchanged
-          x1.set(5);
-          x2.set(4);
+            // swap values, computation results is structuraly unchanged
+            x1.set(5)
+            x2.set(4)
         })
 
-        t.deepEqual(b.toArray(), [{sum: 8}, {sum: 9}]);
-        t.equal(mobx.extras.isComputingDerivation(), false);
+        t.deepEqual(b.toArray(), [{ sum: 8 }, { sum: 9 }])
+        t.equal(mobx.extras.isComputingDerivation(), false)
 
-        t.end();
-    }
-    catch(e) {
-        console.log(e.stack);
+        t.end()
+    } catch (e) {
+        console.log(e.stack)
     }
 })
 
-test('dynamic', function(t) {
+test("dynamic", function(t) {
     try {
-        var x = observable(3);
+        var x = observable(3)
         var y = m.computed(function() {
-            return x.get();
-        });
-        var b = buffer();
-        m.observe(y, b, true);
+            return x.get()
+        })
+        var b = buffer()
+        m.observe(y, b, true)
 
-        t.equal(3, y.get()); // First evaluation here..
+        t.equal(3, y.get()) // First evaluation here..
 
-        x.set(5);
-        t.equal(5, y.get());
+        x.set(5)
+        t.equal(5, y.get())
 
-        t.deepEqual(b.toArray(), [3, 5]);
-        t.equal(mobx.extras.isComputingDerivation(), false);
+        t.deepEqual(b.toArray(), [3, 5])
+        t.equal(mobx.extras.isComputingDerivation(), false)
 
-        t.end();
-    }
-    catch(e) {
-        console.log(e.stack);
+        t.end()
+    } catch (e) {
+        console.log(e.stack)
     }
 })
 
-test('dynamic2', function(t) {
+test("dynamic2", function(t) {
     try {
-        var x = observable(3);
+        var x = observable(3)
         var y = computed(function() {
-            return x.get() * x.get();
-        });
+            return x.get() * x.get()
+        })
 
-        t.equal(9, y.get());
-        var b = buffer();
-        m.observe(y, b);
+        t.equal(9, y.get())
+        var b = buffer()
+        m.observe(y, b)
 
-        x.set(5);
-        t.equal(25, y.get());
+        x.set(5)
+        t.equal(25, y.get())
 
         //no intermediate value 15!
-        t.deepEqual([25], b.toArray());
-        t.equal(mobx.extras.isComputingDerivation(), false);
+        t.deepEqual([25], b.toArray())
+        t.equal(mobx.extras.isComputingDerivation(), false)
 
-        t.end();
-    }
-    catch(e) {
-        console.log(e.stack);
+        t.end()
+    } catch (e) {
+        console.log(e.stack)
     }
 })
 
-test('readme1', function(t) {
+test("readme1", function(t) {
     try {
-        var b = buffer();
+        var b = buffer()
 
-        var vat = observable(0.20);
-        var order = {};
-        order.price = observable(10);
+        var vat = observable(0.2)
+        var order = {}
+        order.price = observable(10)
         // Prints: New price: 24
         //in TS, just: value(() => this.price() * (1+vat()))
         order.priceWithVat = computed(function() {
-            return order.price.get() * (1 + vat.get());
-        });
+            return order.price.get() * (1 + vat.get())
+        })
 
-        m.observe(order.priceWithVat, b);
+        m.observe(order.priceWithVat, b)
 
-        order.price.set(20);
-        t.deepEqual([24],b.toArray());
-        order.price.set(10);
-        t.deepEqual([24,12],b.toArray());
-        t.equal(mobx.extras.isComputingDerivation(), false);
+        order.price.set(20)
+        t.deepEqual([24], b.toArray())
+        order.price.set(10)
+        t.deepEqual([24, 12], b.toArray())
+        t.equal(mobx.extras.isComputingDerivation(), false)
 
-        t.end();
+        t.end()
     } catch (e) {
-        console.log(e.stack); throw e;
+        console.log(e.stack)
+        throw e
     }
 })
 
-test('batch', function(t) {
-    var a = observable(2);
-    var b = observable(3);
-    var c = computed(function() { return a.get() * b.get() });
-    var d = computed(function() { return c.get() * b.get() });
-    var buf = buffer();
-    m.observe(d, buf);
+test("batch", function(t) {
+    var a = observable(2)
+    var b = observable(3)
+    var c = computed(function() {
+        return a.get() * b.get()
+    })
+    var d = computed(function() {
+        return c.get() * b.get()
+    })
+    var buf = buffer()
+    m.observe(d, buf)
 
-    a.set(4);
-    b.set(5);
+    a.set(4)
+    b.set(5)
     // Note, 60 should not happen! (that is d beign computed before c after update of b)
-    t.deepEqual(buf.toArray(), [36, 100]);
+    t.deepEqual(buf.toArray(), [36, 100])
 
     var x = mobx.transaction(function() {
-        a.set(2);
-        b.set(3);
-        a.set(6);
-        t.equal(d.value, 100); // not updated; in transaction
-        t.equal(d.get(), 54); // consistent due to inspection
-        return 2;
-    });
+        a.set(2)
+        b.set(3)
+        a.set(6)
+        t.equal(d.value, 100) // not updated; in transaction
+        t.equal(d.get(), 54) // consistent due to inspection
+        return 2
+    })
 
-    t.equal(x, 2); // test return value
-    t.deepEqual(buf.toArray(), [36, 100, 54]);// only one new value for d
-    t.end();
+    t.equal(x, 2) // test return value
+    t.deepEqual(buf.toArray(), [36, 100, 54]) // only one new value for d
+    t.end()
 })
 
-test('transaction with inspection', function(t) {
-    var a = observable(2);
-    var calcs = 0;
+test("transaction with inspection", function(t) {
+    var a = observable(2)
+    var calcs = 0
     var b = computed(function() {
-        calcs++;
-        return a.get() * 2;
-    });
+        calcs++
+        return a.get() * 2
+    })
 
     // if not inspected during transaction, postpone value to end
     mobx.transaction(function() {
-        a.set(3);
-        t.equal(b.get(), 6);
-        t.equal(calcs, 1);
-    });
-    t.equal(b.get(), 6);
-    t.equal(calcs, 2);
+        a.set(3)
+        t.equal(b.get(), 6)
+        t.equal(calcs, 1)
+    })
+    t.equal(b.get(), 6)
+    t.equal(calcs, 2)
 
     // if inspected, evaluate eagerly
     mobx.transaction(function() {
-        a.set(4);
-        t.equal(b.get(), 8);
-        t.equal(calcs, 3);
-    });
-    t.equal(b.get(), 8);
-    t.equal(calcs, 4);
+        a.set(4)
+        t.equal(b.get(), 8)
+        t.equal(calcs, 3)
+    })
+    t.equal(b.get(), 8)
+    t.equal(calcs, 4)
 
-    t.end();
-});
+    t.end()
+})
 
-test('transaction with inspection 2', function(t) {
-    var a = observable(2);
-    var calcs = 0;
-    var b;
+test("transaction with inspection 2", function(t) {
+    var a = observable(2)
+    var calcs = 0
+    var b
     mobx.autorun(function() {
-        calcs++;
-        b = a.get() * 2;
-    });
+        calcs++
+        b = a.get() * 2
+    })
 
     // if not inspected during transaction, postpone value to end
     mobx.transaction(function() {
-        a.set(3);
-        t.equal(b, 4);
-        t.equal(calcs, 1);
-    });
-    t.equal(b, 6);
-    t.equal(calcs, 2);
+        a.set(3)
+        t.equal(b, 4)
+        t.equal(calcs, 1)
+    })
+    t.equal(b, 6)
+    t.equal(calcs, 2)
 
     // if inspected, evaluate eagerly
     mobx.transaction(function() {
-        a.set(4);
-        t.equal(b, 6);
-        t.equal(calcs, 2);
-    });
-    t.equal(b, 8);
-    t.equal(calcs, 3);
+        a.set(4)
+        t.equal(b, 6)
+        t.equal(calcs, 2)
+    })
+    t.equal(b, 8)
+    t.equal(calcs, 3)
 
-    t.end();
+    t.end()
 })
 
-test('scope', function(t) {
-    var vat = observable(0.2);
+test("scope", function(t) {
+    var vat = observable(0.2)
     var Order = function() {
-        this.price = observable(20);
-        this.amount = observable(2);
-        this.total = computed(function() {
-            return (1+vat.get()) * this.price.get() * this.amount.get();
-        }, { context: this });
-    };
+        this.price = observable(20)
+        this.amount = observable(2)
+        this.total = computed(
+            function() {
+                return (1 + vat.get()) * this.price.get() * this.amount.get()
+            },
+            { context: this }
+        )
+    }
 
-    var order = new Order();
-    m.observe(order.total, voidObserver);
-    order.price.set(10);
-    order.amount.set(3);
-    t.equal(36, order.total.get());
-    t.equal(mobx.extras.isComputingDerivation(), false);
+    var order = new Order()
+    m.observe(order.total, voidObserver)
+    order.price.set(10)
+    order.amount.set(3)
+    t.equal(36, order.total.get())
+    t.equal(mobx.extras.isComputingDerivation(), false)
 
-    t.end();
+    t.end()
 })
 
-test('props1', function(t) {
-    var vat = observable(0.2);
-    var Order = function() {
-        mobx.extendObservable(this, {
-            'price' : 20,
-            'amount' : 2,
-            get total() {
-                return (1+vat.get()) * this.price * this.amount; // price and amount are now properties!
-            }
-        });
-    };
-
-    var order = new Order();
-    t.equal(48, order.total);
-    order.price = 10;
-    order.amount = 3;
-    t.equal(36, order.total);
-
-    var totals = [];
-    var sub = mobx.autorun(function() {
-        totals.push(order.total);
-    });
-    order.amount = 4;
-    sub();
-    order.amount = 5;
-    t.deepEqual(totals, [36,48]);
-
-    t.equal(mobx.extras.isComputingDerivation(), false);
-    t.end();
-})
-
-test('props2', function(t) {
-    var vat = observable(0.2);
+test("props1", function(t) {
+    var vat = observable(0.2)
     var Order = function() {
         mobx.extendObservable(this, {
             price: 20,
             amount: 2,
             get total() {
-                return (1+vat.get()) * this.price * this.amount; // price and amount are now properties!
+                return (1 + vat.get()) * this.price * this.amount // price and amount are now properties!
             }
-        });
-    };
-
-    var order = new Order();
-    t.equal(48, order.total);
-    order.price = 10;
-    order.amount = 3;
-    t.equal(36, order.total);
-    t.end();
-})
-
-test('props3', function(t) {
-    var vat = observable(0.2);
-    var Order = function() {
-        this.price = 20;
-        this.amount = 2;
-        this.total = mobx.computed(function() {
-            return (1+vat.get()) * this.price * this.amount; // price and amount are now properties!
-        });
-        mobx.extendObservable(this, this);
-    };
-
-    var order = new Order();
-    t.equal(48, order.total);
-    order.price = 10;
-    order.amount = 3;
-    t.equal(36, order.total);
-    t.end();
-})
-
-test('props4', function(t) {
-    function Bzz() {
-        mobx.extendObservable(this, {
-            fluff: [1,2],
-            get sum() {
-                return this.fluff.reduce(function(a,b) {
-                    return a + b;
-                }, 0);
-            }
-        });
+        })
     }
 
-    var x = new Bzz();
-    var ar = x.fluff;
-    t.equal(x.sum, 3);
-    x.fluff.push(3);
-    t.equal(x.sum, 6);
-    x.fluff = [5,6];
-    t.equal(x.sum, 11);
-    x.fluff.push(2);
-    t.equal(x.sum, 13);
-    t.end();
+    var order = new Order()
+    t.equal(48, order.total)
+    order.price = 10
+    order.amount = 3
+    t.equal(36, order.total)
+
+    var totals = []
+    var sub = mobx.autorun(function() {
+        totals.push(order.total)
+    })
+    order.amount = 4
+    sub()
+    order.amount = 5
+    t.deepEqual(totals, [36, 48])
+
+    t.equal(mobx.extras.isComputingDerivation(), false)
+    t.end()
 })
 
-test('extend observable multiple prop maps', function(t) {
-    var x = { a: 1 };
-    mobx.extendObservable(x, {
-        b: 2,
-        c: 2
-    }, {
-        c: 3,
-        d: 4
-    }, {
-        a: 5
-    });
+test("props2", function(t) {
+    var vat = observable(0.2)
+    var Order = function() {
+        mobx.extendObservable(this, {
+            price: 20,
+            amount: 2,
+            get total() {
+                return (1 + vat.get()) * this.price * this.amount // price and amount are now properties!
+            }
+        })
+    }
 
-    var sum = 0;
+    var order = new Order()
+    t.equal(48, order.total)
+    order.price = 10
+    order.amount = 3
+    t.equal(36, order.total)
+    t.end()
+})
+
+test("props3", function(t) {
+    var vat = observable(0.2)
+    var Order = function() {
+        this.price = 20
+        this.amount = 2
+        this.total = mobx.computed(function() {
+            return (1 + vat.get()) * this.price * this.amount // price and amount are now properties!
+        })
+        mobx.extendObservable(this, this)
+    }
+
+    var order = new Order()
+    t.equal(48, order.total)
+    order.price = 10
+    order.amount = 3
+    t.equal(36, order.total)
+    t.end()
+})
+
+test("props4", function(t) {
+    function Bzz() {
+        mobx.extendObservable(this, {
+            fluff: [1, 2],
+            get sum() {
+                return this.fluff.reduce(function(a, b) {
+                    return a + b
+                }, 0)
+            }
+        })
+    }
+
+    var x = new Bzz()
+    var ar = x.fluff
+    t.equal(x.sum, 3)
+    x.fluff.push(3)
+    t.equal(x.sum, 6)
+    x.fluff = [5, 6]
+    t.equal(x.sum, 11)
+    x.fluff.push(2)
+    t.equal(x.sum, 13)
+    t.end()
+})
+
+test("extend observable multiple prop maps", function(t) {
+    var x = { a: 1 }
+    mobx.extendObservable(
+        x,
+        {
+            b: 2,
+            c: 2
+        },
+        {
+            c: 3,
+            d: 4
+        },
+        {
+            a: 5
+        }
+    )
+
+    var sum = 0
     var disposer = mobx.autorun(function() {
-        sum = x.a + x.b + x.c + x.d;
-    });
-    t.equal(sum, 14);
-    x.a = 1;
-    t.equal(sum, 10);
+        sum = x.a + x.b + x.c + x.d
+    })
+    t.equal(sum, 14)
+    x.a = 1
+    t.equal(sum, 10)
 
-    t.end();
+    t.end()
 })
 
-test('object enumerable props', function(t) {
+test("object enumerable props", function(t) {
     var x = mobx.observable({
         a: 3,
         b: mobx.computed(function() {
-            return 2 * this.a;
+            return 2 * this.a
         })
-    });
-    mobx.extendObservable(x, { c: 4 });
-    var ar = [];
-    for(var key in x)
-        ar.push(key);
-    t.deepEqual(ar, ['a', 'c']); // or should 'b' be in here as well?
-    t.end();
+    })
+    mobx.extendObservable(x, { c: 4 })
+    var ar = []
+    for (var key in x) ar.push(key)
+    t.deepEqual(ar, ["a", "c"]) // or should 'b' be in here as well?
+    t.end()
 })
 
-test('observe property', function(t) {
-    var sb = [];
-    var mb = [];
+test("observe property", function(t) {
+    var sb = []
+    var mb = []
 
-    var Wrapper = function (chocolateBar) {
+    var Wrapper = function(chocolateBar) {
         mobx.extendObservable(this, {
             chocolateBar: chocolateBar,
-            get calories () {
-                return this.chocolateBar.calories;
+            get calories() {
+                return this.chocolateBar.calories
             }
-        });
-    };
+        })
+    }
 
     var snickers = mobx.observable({
         calories: null
-    });
+    })
     var mars = mobx.observable({
         calories: undefined
-    });
+    })
 
-    var wrappedSnickers = new Wrapper(snickers);
-    var wrappedMars = new Wrapper(mars);
+    var wrappedSnickers = new Wrapper(snickers)
+    var wrappedMars = new Wrapper(mars)
 
-    var disposeSnickers = mobx.autorun(function () {
-        sb.push(wrappedSnickers.calories);
-    });
-    var disposeMars = mobx.autorun(function () {
-        mb.push(wrappedMars.calories);
-    });
-    snickers.calories = 10;
-    mars.calories = 15;
+    var disposeSnickers = mobx.autorun(function() {
+        sb.push(wrappedSnickers.calories)
+    })
+    var disposeMars = mobx.autorun(function() {
+        mb.push(wrappedMars.calories)
+    })
+    snickers.calories = 10
+    mars.calories = 15
 
-    disposeSnickers();
-    disposeMars();
-    snickers.calories = 5;
-    mars.calories = 7;
+    disposeSnickers()
+    disposeMars()
+    snickers.calories = 5
+    mars.calories = 7
 
-    t.deepEqual(sb, [null, 10]);
-    t.deepEqual(mb, [undefined, 15]);
+    t.deepEqual(sb, [null, 10])
+    t.deepEqual(mb, [undefined, 15])
 
-    t.end();
+    t.end()
 })
 
-test('observe object', function(t) {
-    var events = [];
+test("observe object", function(t) {
+    var events = []
     var a = observable({
         a: 1,
-        get da() { return this.a * 2 }
-    });
+        get da() {
+            return this.a * 2
+        }
+    })
     var stop = m.observe(a, function(change) {
-        events.push(change);
-    });
+        events.push(change)
+    })
 
-    a.a = 2;
+    a.a = 2
     mobx.extendObservable(a, {
-        a: 3, b: 3
-    });
-    a.a = 4;
-    a.b = 5;
+        a: 3,
+        b: 3
+    })
+    a.a = 4
+    a.b = 5
     t.deepEqual(events, [
-        { type: 'update',
+        {
+            type: "update",
             object: a,
-            name: 'a',
-			newValue: 2,
-            oldValue: 1 },
-        { type: 'update',
+            name: "a",
+            newValue: 2,
+            oldValue: 1
+        },
+        {
+            type: "update",
             object: a,
-            name: 'a',
-			newValue: 3,
-            oldValue: 2 },
-        { type: 'add',
+            name: "a",
+            newValue: 3,
+            oldValue: 2
+        },
+        {
+            type: "add",
             object: a,
-			newValue: 3,
-            name: 'b' },
-        { type: 'update',
+            newValue: 3,
+            name: "b"
+        },
+        {
+            type: "update",
             object: a,
-            name: 'a',
-			newValue: 4,
-            oldValue: 3 },
-        { type: 'update',
+            name: "a",
+            newValue: 4,
+            oldValue: 3
+        },
+        {
+            type: "update",
             object: a,
-            name: 'b',
-			newValue: 5,
-            oldValue: 3 }
-    ]);
+            name: "b",
+            newValue: 5,
+            oldValue: 3
+        }
+    ])
 
-    stop();
-    events = [];
-    a.a = 6;
-    t.equals(events.length, 0);
+    stop()
+    events = []
+    a.a = 6
+    t.equals(events.length, 0)
 
-    t.end();
-});
+    t.end()
+})
 
-test('mobx.observe', function(t) {
-    var events = [];
-    var o = observable({ b: 2 });
-    var ar = observable([ 3 ]);
-    var map = mobx.map({ });
+test("mobx.observe", function(t) {
+    var events = []
+    var o = observable({ b: 2 })
+    var ar = observable([3])
+    var map = mobx.map({})
 
-    var push = function(event) { events.push(event); };
+    var push = function(event) {
+        events.push(event)
+    }
 
-    var stop2 = mobx.observe(o, push);
-    var stop3 = mobx.observe(ar, push);
-    var stop4 = mobx.observe(map, push);
+    var stop2 = mobx.observe(o, push)
+    var stop3 = mobx.observe(ar, push)
+    var stop4 = mobx.observe(map, push)
 
-    o.b = 5;
-    ar[0] = 6;
-    map.set("d", 7);
+    o.b = 5
+    ar[0] = 6
+    map.set("d", 7)
 
-    stop2();
-    stop3();
-    stop4();
+    stop2()
+    stop3()
+    stop4()
 
-    o.b = 9;
-    ar[0] = 10;
-    map.set("d", 11);
+    o.b = 9
+    ar[0] = 10
+    map.set("d", 11)
 
     t.deepEqual(events, [
-        { type: 'update',
+        {
+            type: "update",
             object: o,
-            name: 'b',
-			newValue: 5,
-            oldValue: 2 },
-        { object: ar,
-            type: 'update',
+            name: "b",
+            newValue: 5,
+            oldValue: 2
+        },
+        {
+            object: ar,
+            type: "update",
             index: 0,
-			newValue: 6,
-            oldValue: 3 },
-        { type: 'add',
+            newValue: 6,
+            oldValue: 3
+        },
+        {
+            type: "add",
             object: map,
-			newValue: 7,
-            name: 'd' }
-    ]);
+            newValue: 7,
+            name: "d"
+        }
+    ])
 
-    t.end();
-});
-
-test('change count optimization', function(t) {
-    var bCalcs = 0;
-    var cCalcs = 0;
-    var a = observable(3);
-    var b = computed(function() {
-        bCalcs += 1;
-        return 4 + a.get() - a.get();
-    });
-    var c = computed(function() {
-        cCalcs += 1;
-        return b.get();
-    });
-
-    m.observe(c, voidObserver);
-
-    t.equal(b.get(), 4);
-    t.equal(c.get(), 4);
-    t.equal(bCalcs, 1);
-    t.equal(cCalcs, 1);
-
-    a.set(5);
-
-    t.equal(b.get(), 4);
-    t.equal(c.get(), 4);
-    t.equal(bCalcs, 2);
-    t.equal(cCalcs, 1);
-
-    t.equal(mobx.extras.isComputingDerivation(), false);
-    t.end();
+    t.end()
 })
 
-test('observables removed', function(t) {
-    var calcs = 0;
-    var a = observable(1);
-    var b = observable(2);
+test("change count optimization", function(t) {
+    var bCalcs = 0
+    var cCalcs = 0
+    var a = observable(3)
+    var b = computed(function() {
+        bCalcs += 1
+        return 4 + a.get() - a.get()
+    })
     var c = computed(function() {
-        calcs ++;
-        if (a.get() === 1)
-        return b.get() * a.get() * b.get();
-        return 3;
-    });
+        cCalcs += 1
+        return b.get()
+    })
 
+    m.observe(c, voidObserver)
 
-    t.equal(calcs, 0);
-    m.observe(c, voidObserver);
-    t.equal(c.get(), 4);
-    t.equal(calcs, 1);
-    a.set(2);
-    t.equal(c.get(), 3);
-    t.equal(calcs, 2);
+    t.equal(b.get(), 4)
+    t.equal(c.get(), 4)
+    t.equal(bCalcs, 1)
+    t.equal(cCalcs, 1)
 
-    b.set(3); // should not retrigger calc
-    t.equal(c.get(), 3);
-    t.equal(calcs, 2);
+    a.set(5)
 
-    a.set(1);
-    t.equal(c.get(), 9);
-    t.equal(calcs, 3);
+    t.equal(b.get(), 4)
+    t.equal(c.get(), 4)
+    t.equal(bCalcs, 2)
+    t.equal(cCalcs, 1)
 
-    t.equal(mobx.extras.isComputingDerivation(), false);
-    t.end();
+    t.equal(mobx.extras.isComputingDerivation(), false)
+    t.end()
 })
 
-test('lazy evaluation', function (t) {
-    var bCalcs = 0;
-    var cCalcs = 0;
-    var dCalcs = 0;
-    var observerChanges = 0;
+test("observables removed", function(t) {
+    var calcs = 0
+    var a = observable(1)
+    var b = observable(2)
+    var c = computed(function() {
+        calcs++
+        if (a.get() === 1) return b.get() * a.get() * b.get()
+        return 3
+    })
 
-    var a = observable(1);
+    t.equal(calcs, 0)
+    m.observe(c, voidObserver)
+    t.equal(c.get(), 4)
+    t.equal(calcs, 1)
+    a.set(2)
+    t.equal(c.get(), 3)
+    t.equal(calcs, 2)
+
+    b.set(3) // should not retrigger calc
+    t.equal(c.get(), 3)
+    t.equal(calcs, 2)
+
+    a.set(1)
+    t.equal(c.get(), 9)
+    t.equal(calcs, 3)
+
+    t.equal(mobx.extras.isComputingDerivation(), false)
+    t.end()
+})
+
+test("lazy evaluation", function(t) {
+    var bCalcs = 0
+    var cCalcs = 0
+    var dCalcs = 0
+    var observerChanges = 0
+
+    var a = observable(1)
     var b = computed(function() {
-        bCalcs += 1;
-        return a.get() +1;
-    });
+        bCalcs += 1
+        return a.get() + 1
+    })
 
     var c = computed(function() {
-        cCalcs += 1;
-        return b.get() +1;
-    });
+        cCalcs += 1
+        return b.get() + 1
+    })
 
-    t.equal(bCalcs, 0);
-    t.equal(cCalcs, 0);
-    t.equal(c.get(), 3);
-    t.equal(bCalcs,1);
-    t.equal(cCalcs,1);
+    t.equal(bCalcs, 0)
+    t.equal(cCalcs, 0)
+    t.equal(c.get(), 3)
+    t.equal(bCalcs, 1)
+    t.equal(cCalcs, 1)
 
-    t.equal(c.get(), 3);
-    t.equal(bCalcs,2);
-    t.equal(cCalcs,2);
+    t.equal(c.get(), 3)
+    t.equal(bCalcs, 2)
+    t.equal(cCalcs, 2)
 
-    a.set(2);
-    t.equal(bCalcs,2);
-    t.equal(cCalcs,2);
+    a.set(2)
+    t.equal(bCalcs, 2)
+    t.equal(cCalcs, 2)
 
-    t.equal(c.get(), 4);
-    t.equal(bCalcs,3);
-    t.equal(cCalcs,3);
+    t.equal(c.get(), 4)
+    t.equal(bCalcs, 3)
+    t.equal(cCalcs, 3)
 
     var d = computed(function() {
-        dCalcs += 1;
-        return b.get() * 2;
-    });
+        dCalcs += 1
+        return b.get() * 2
+    })
 
-    var handle = m.observe(d, function() {
-        observerChanges += 1;
-    }, false);
-    t.equal(bCalcs,4);
-    t.equal(cCalcs,3);
-    t.equal(dCalcs,1); // d is evaluated, so that its dependencies are known
+    var handle = m.observe(
+        d,
+        function() {
+            observerChanges += 1
+        },
+        false
+    )
+    t.equal(bCalcs, 4)
+    t.equal(cCalcs, 3)
+    t.equal(dCalcs, 1) // d is evaluated, so that its dependencies are known
 
-    a.set(3);
-    t.equal(d.get(), 8);
-    t.equal(bCalcs,5);
-    t.equal(cCalcs,3);
-    t.equal(dCalcs,2);
+    a.set(3)
+    t.equal(d.get(), 8)
+    t.equal(bCalcs, 5)
+    t.equal(cCalcs, 3)
+    t.equal(dCalcs, 2)
 
-    t.equal(c.get(), 5);
-    t.equal(bCalcs,5);
-    t.equal(cCalcs,4);
-    t.equal(dCalcs,2);
+    t.equal(c.get(), 5)
+    t.equal(bCalcs, 5)
+    t.equal(cCalcs, 4)
+    t.equal(dCalcs, 2)
 
-    t.equal(b.get(), 4);
-    t.equal(bCalcs,5);
-    t.equal(cCalcs,4);
-    t.equal(dCalcs,2);
+    t.equal(b.get(), 4)
+    t.equal(bCalcs, 5)
+    t.equal(cCalcs, 4)
+    t.equal(dCalcs, 2)
 
-    handle(); // unlisten
-    t.equal(d.get(), 8);
-    t.equal(bCalcs,6); // gone to sleep
-    t.equal(cCalcs,4);
-    t.equal(dCalcs,3);
+    handle() // unlisten
+    t.equal(d.get(), 8)
+    t.equal(bCalcs, 6) // gone to sleep
+    t.equal(cCalcs, 4)
+    t.equal(dCalcs, 3)
 
-    t.equal(observerChanges, 1);
+    t.equal(observerChanges, 1)
 
-    t.equal(mobx.extras.isComputingDerivation(), false);
-    t.end();
+    t.equal(mobx.extras.isComputingDerivation(), false)
+    t.end()
 })
 
-test('multiple view dependencies', function(t) {
-    var bCalcs = 0;
-    var dCalcs = 0;
-    var a = observable(1);
+test("multiple view dependencies", function(t) {
+    var bCalcs = 0
+    var dCalcs = 0
+    var a = observable(1)
     var b = computed(function() {
-        bCalcs++;
-        return 2 * a.get();
-    });
-    var c = observable(2);
+        bCalcs++
+        return 2 * a.get()
+    })
+    var c = observable(2)
     var d = computed(function() {
-        dCalcs++;
-        return 3 * c.get();
-    });
+        dCalcs++
+        return 3 * c.get()
+    })
 
-    var zwitch = true;
-    var buffer = [];
-    var fCalcs = 0;
+    var zwitch = true
+    var buffer = []
+    var fCalcs = 0
     var dis = mobx.autorun(function() {
-        fCalcs++;
-        if (zwitch)
-            buffer.push(b.get() + d.get());
-        else
-            buffer.push(d.get() + b.get());
-    });
+        fCalcs++
+        if (zwitch) buffer.push(b.get() + d.get())
+        else buffer.push(d.get() + b.get())
+    })
 
-    zwitch = false;
-    c.set(3);
-    t.equal(bCalcs, 1);
-    t.equal(dCalcs, 2);
-    t.equal(fCalcs, 2);
-    t.deepEqual(buffer, [8, 11]);
+    zwitch = false
+    c.set(3)
+    t.equal(bCalcs, 1)
+    t.equal(dCalcs, 2)
+    t.equal(fCalcs, 2)
+    t.deepEqual(buffer, [8, 11])
 
-    c.set(4);
-    t.equal(bCalcs, 1);
-    t.equal(dCalcs, 3);
-    t.equal(fCalcs, 3);
-    t.deepEqual(buffer, [8, 11, 14]);
+    c.set(4)
+    t.equal(bCalcs, 1)
+    t.equal(dCalcs, 3)
+    t.equal(fCalcs, 3)
+    t.deepEqual(buffer, [8, 11, 14])
 
-    dis();
-    c.set(5);
-    t.equal(bCalcs, 1);
-    t.equal(dCalcs, 3);
-    t.equal(fCalcs, 3);
-    t.deepEqual(buffer, [8, 11, 14]);
+    dis()
+    c.set(5)
+    t.equal(bCalcs, 1)
+    t.equal(dCalcs, 3)
+    t.equal(fCalcs, 3)
+    t.deepEqual(buffer, [8, 11, 14])
 
-    t.end();
+    t.end()
 })
 
-test('nested observable2', function(t) {
-    var factor = observable(0);
-    var price = observable(100);
-    var totalCalcs = 0;
-    var innerCalcs = 0;
+test("nested observable2", function(t) {
+    var factor = observable(0)
+    var price = observable(100)
+    var totalCalcs = 0
+    var innerCalcs = 0
 
     var total = computed(function() {
-        totalCalcs += 1; // outer observable shouldn't recalc if inner observable didn't publish a real change
-        return price.get() * computed(function() {
-            innerCalcs += 1;
-            return factor.get() % 2 === 0 ? 1 : 3;
-        }).get();
-    });
+        totalCalcs += 1 // outer observable shouldn't recalc if inner observable didn't publish a real change
+        return (
+            price.get() *
+            computed(function() {
+                innerCalcs += 1
+                return factor.get() % 2 === 0 ? 1 : 3
+            }).get()
+        )
+    })
 
-    var b = [];
-    var sub = m.observe(total, function(x) { b.push(x.newValue); }, true);
+    var b = []
+    var sub = m.observe(
+        total,
+        function(x) {
+            b.push(x.newValue)
+        },
+        true
+    )
 
-    price.set(150);
-    factor.set(7); // triggers innerCalc twice, because changing the outcome triggers the outer calculation which recreates the inner calculation
-    factor.set(5); // doesn't trigger outer calc
-    factor.set(3); // doesn't trigger outer calc
-    factor.set(4); // triggers innerCalc twice
-    price.set(20);
+    price.set(150)
+    factor.set(7) // triggers innerCalc twice, because changing the outcome triggers the outer calculation which recreates the inner calculation
+    factor.set(5) // doesn't trigger outer calc
+    factor.set(3) // doesn't trigger outer calc
+    factor.set(4) // triggers innerCalc twice
+    price.set(20)
 
-    t.deepEqual(b, [100,150,450,150,20]);
-    t.equal(innerCalcs, 9);
-    t.equal(totalCalcs, 5);
+    t.deepEqual(b, [100, 150, 450, 150, 20])
+    t.equal(innerCalcs, 9)
+    t.equal(totalCalcs, 5)
 
-    t.end();
+    t.end()
 })
 
-test('expr', function(t) {
-    var factor = observable(0);
-    var price = observable(100);
-    var totalCalcs = 0;
-    var innerCalcs = 0;
+test("expr", function(t) {
+    var factor = observable(0)
+    var price = observable(100)
+    var totalCalcs = 0
+    var innerCalcs = 0
 
     var total = computed(function() {
-        totalCalcs += 1; // outer observable shouldn't recalc if inner observable didn't publish a real change
-        return price.get() * mobx.expr(function() {
-            innerCalcs += 1;
-            return factor.get() % 2 === 0 ? 1 : 3;
-        });
-    });
+        totalCalcs += 1 // outer observable shouldn't recalc if inner observable didn't publish a real change
+        return (
+            price.get() *
+            mobx.expr(function() {
+                innerCalcs += 1
+                return factor.get() % 2 === 0 ? 1 : 3
+            })
+        )
+    })
 
-    var b = [];
-    var sub = m.observe(total, function(x) { b.push(x.newValue); }, true);
+    var b = []
+    var sub = m.observe(
+        total,
+        function(x) {
+            b.push(x.newValue)
+        },
+        true
+    )
 
-    price.set(150);
-    factor.set(7); // triggers innerCalc twice, because changing the outcome triggers the outer calculation which recreates the inner calculation
-    factor.set(5); // doesn't trigger outer calc
-    factor.set(3); // doesn't trigger outer calc
-    factor.set(4); // triggers innerCalc twice
-    price.set(20);
+    price.set(150)
+    factor.set(7) // triggers innerCalc twice, because changing the outcome triggers the outer calculation which recreates the inner calculation
+    factor.set(5) // doesn't trigger outer calc
+    factor.set(3) // doesn't trigger outer calc
+    factor.set(4) // triggers innerCalc twice
+    price.set(20)
 
-    t.deepEqual(b, [100,150,450,150,20]);
-    t.equal(innerCalcs, 9);
-    t.equal(totalCalcs, 5);
+    t.deepEqual(b, [100, 150, 450, 150, 20])
+    t.equal(innerCalcs, 9)
+    t.equal(totalCalcs, 5)
 
-    t.end();
+    t.end()
 })
 
-test('observe', function(t) {
-    var x = observable(3);
-    var x2 = computed(function() { return x.get() * 2; });
-    var b = [];
+test("observe", function(t) {
+    var x = observable(3)
+    var x2 = computed(function() {
+        return x.get() * 2
+    })
+    var b = []
 
     var cancel = mobx.autorun(function() {
-        b.push(x2.get());
-    });
+        b.push(x2.get())
+    })
 
-    x.set(4);
-    x.set(5);
-    t.deepEqual(b, [6, 8, 10]);
-    cancel();
-    x.set(7);
-    t.deepEqual(b, [6, 8, 10]);
+    x.set(4)
+    x.set(5)
+    t.deepEqual(b, [6, 8, 10])
+    cancel()
+    x.set(7)
+    t.deepEqual(b, [6, 8, 10])
 
-    t.end();
+    t.end()
 })
 
-test('when', function(t) {
-    var x = observable(3);
+test("when", function(t) {
+    var x = observable(3)
 
-    var called = 0;
-    mobx.when(function() {
-        return (x.get() === 4);
-    }, function() {
-        called += 1;
-    });
+    var called = 0
+    mobx.when(
+        function() {
+            return x.get() === 4
+        },
+        function() {
+            called += 1
+        }
+    )
 
-    x.set(5);
-    t.equal(called, 0);
-    x.set(4);
-    t.equal(called, 1);
-    x.set(3);
-    t.equal(called, 1);
-    x.set(4);
-    t.equal(called, 1);
+    x.set(5)
+    t.equal(called, 0)
+    x.set(4)
+    t.equal(called, 1)
+    x.set(3)
+    t.equal(called, 1)
+    x.set(4)
+    t.equal(called, 1)
 
-    t.end();
+    t.end()
 })
 
-test('when 2', function(t) {
-    var x = observable(3);
+test("when 2", function(t) {
+    var x = observable(3)
 
-    var called = 0;
-    var d = mobx.when("when x is 3", function() {
-        return (x.get() === 3);
-    }, function() {
-        called += 1;
-    });
+    var called = 0
+    var d = mobx.when(
+        "when x is 3",
+        function() {
+            return x.get() === 3
+        },
+        function() {
+            called += 1
+        }
+    )
 
-    t.equal(called, 1);
+    t.equal(called, 1)
     t.equal(x.observers.length, 0)
-    x.set(5);
-    x.set(3);
-    t.equal(called, 1);
+    x.set(5)
+    x.set(3)
+    t.equal(called, 1)
 
-	t.equal(d.$mobx.name, "when x is 3")
+    t.equal(d.$mobx.name, "when x is 3")
 
-    t.end();
+    t.end()
 })
 
-test('expr2', function(t) {
-    var factor = observable(0);
-    var price = observable(100);
-    var totalCalcs = 0;
-    var innerCalcs = 0;
+test("expr2", function(t) {
+    var factor = observable(0)
+    var price = observable(100)
+    var totalCalcs = 0
+    var innerCalcs = 0
 
     var total = computed(function() {
-        totalCalcs += 1; // outer observable shouldn't recalc if inner observable didn't publish a real change
-        return price.get() * mobx.expr(function() {
-            innerCalcs += 1;
-            return factor.get() % 2 === 0 ? 1 : 3;
-        });
-    });
+        totalCalcs += 1 // outer observable shouldn't recalc if inner observable didn't publish a real change
+        return (
+            price.get() *
+            mobx.expr(function() {
+                innerCalcs += 1
+                return factor.get() % 2 === 0 ? 1 : 3
+            })
+        )
+    })
 
-    var b = [];
-    var sub = m.observe(total, function(x) { b.push(x.newValue); }, true);
+    var b = []
+    var sub = m.observe(
+        total,
+        function(x) {
+            b.push(x.newValue)
+        },
+        true
+    )
 
-    price.set(150);
-    factor.set(7); // triggers innerCalc twice, because changing the outcome triggers the outer calculation which recreates the inner calculation
-    factor.set(5); // doesn't trigger outer calc
-    factor.set(3); // doesn't trigger outer calc
-    factor.set(4); // triggers innerCalc twice
-    price.set(20);
+    price.set(150)
+    factor.set(7) // triggers innerCalc twice, because changing the outcome triggers the outer calculation which recreates the inner calculation
+    factor.set(5) // doesn't trigger outer calc
+    factor.set(3) // doesn't trigger outer calc
+    factor.set(4) // triggers innerCalc twice
+    price.set(20)
 
-    t.deepEqual(b, [100,150,450,150,20]);
-    t.equal(innerCalcs, 9);
-    t.equal(totalCalcs, 5);
+    t.deepEqual(b, [100, 150, 450, 150, 20])
+    t.equal(innerCalcs, 9)
+    t.equal(totalCalcs, 5)
 
-    t.end();
+    t.end()
 })
 
 function stripSpyOutput(events) {
-	events.forEach(ev => {
-		delete ev.time;
-		delete ev.fn;
-		delete ev.object;
-	});
-	return events;
+    events.forEach(ev => {
+        delete ev.time
+        delete ev.fn
+        delete ev.object
+    })
+    return events
 }
 
-test('issue 50', function(t) {
-    m.extras.resetGlobalState();
-    mobx.extras.getGlobalState().mobxGuid = 0;
+test("issue 50", function(t) {
+    m.extras.resetGlobalState()
+    mobx.extras.getGlobalState().mobxGuid = 0
     var x = observable({
         a: true,
         b: false,
         get c() {
-            events.push("calc c");
-            return this.b;
+            events.push("calc c")
+            return this.b
         }
-    });
+    })
 
     var result
-    var events = [];
+    var events = []
     var disposer1 = mobx.autorun(function ar() {
-        events.push("auto");
-        result = [x.a, x.b, x.c].join(",");
-    });
+        events.push("auto")
+        result = [x.a, x.b, x.c].join(",")
+    })
 
     var disposer2 = mobx.spy(function(info) {
-        events.push(info);
-    });
+        events.push(info)
+    })
 
     setTimeout(function() {
         mobx.transaction(function() {
-            events.push("transstart");
-            x.a = !x.a;
-            x.b = !x.b;
-            events.push("transpreend");
-        });
-        events.push("transpostend");
-        t.equal(result, "false,true,true");
-        t.equal(x.c, x.b);
+            events.push("transstart")
+            x.a = !x.a
+            x.b = !x.b
+            events.push("transpreend")
+        })
+        events.push("transpostend")
+        t.equal(result, "false,true,true")
+        t.equal(x.c, x.b)
 
         t.deepEqual(stripSpyOutput(events), [
-			'auto',
-			'calc c',
-			'transstart',
-			{ name: 'a', newValue: false, oldValue: true, spyReportStart: true, type: 'update' }, { spyReportEnd: true },
-			{ name: 'b', newValue: true, oldValue: false, spyReportStart: true, type: 'update' }, { spyReportEnd: true },
-			'transpreend',
-			{ spyReportStart: true, type: 'reaction' },
-			'auto',
-      { type: 'compute' },
-      'calc c',
-			{ spyReportEnd: true },
-			'transpostend'
-        ]);
+            "auto",
+            "calc c",
+            "transstart",
+            { name: "a", newValue: false, oldValue: true, spyReportStart: true, type: "update" },
+            { spyReportEnd: true },
+            { name: "b", newValue: true, oldValue: false, spyReportStart: true, type: "update" },
+            { spyReportEnd: true },
+            "transpreend",
+            { spyReportStart: true, type: "reaction" },
+            "auto",
+            { type: "compute" },
+            "calc c",
+            { spyReportEnd: true },
+            "transpostend"
+        ])
 
-        disposer1();
-        disposer2();
-        t.end();
-    }, 500);
+        disposer1()
+        disposer2()
+        t.end()
+    }, 500)
+})
 
-});
-
-test('verify transaction events', function(t) {
-    m.extras.resetGlobalState();
-    mobx.extras.getGlobalState().mobxGuid = 0;
+test("verify transaction events", function(t) {
+    m.extras.resetGlobalState()
+    mobx.extras.getGlobalState().mobxGuid = 0
 
     var x = observable({
         b: 1,
         get c() {
-            events.push("calc c");
-            return this.b;
+            events.push("calc c")
+            return this.b
         }
-    });
+    })
 
-    var events = [];
+    var events = []
     var disposer1 = mobx.autorun(function ar() {
-        events.push("auto");
-        x.c;
-    });
+        events.push("auto")
+        x.c
+    })
 
     var disposer2 = mobx.spy(function(info) {
-        events.push(info);
-    });
+        events.push(info)
+    })
 
     mobx.transaction(function() {
-        events.push("transstart");
-        x.b = 1;
-        x.b = 2;
-        events.push("transpreend");
-    });
-    events.push("transpostend");
+        events.push("transstart")
+        x.b = 1
+        x.b = 2
+        events.push("transpreend")
+    })
+    events.push("transpostend")
 
-	t.deepEqual(stripSpyOutput(events), [
-		'auto',
-		'calc c',
-		'transstart',
-		{ name: 'b', newValue: 2, oldValue: 1, spyReportStart: true, type: 'update' }, { spyReportEnd: true },
-		'transpreend', { type: 'compute' },
-		'calc c',
-		{ spyReportStart: true, type: 'reaction' },
-		'auto',
-		{ spyReportEnd: true },
-		'transpostend'
-    ]);
+    t.deepEqual(stripSpyOutput(events), [
+        "auto",
+        "calc c",
+        "transstart",
+        { name: "b", newValue: 2, oldValue: 1, spyReportStart: true, type: "update" },
+        { spyReportEnd: true },
+        "transpreend",
+        { type: "compute" },
+        "calc c",
+        { spyReportStart: true, type: "reaction" },
+        "auto",
+        { spyReportEnd: true },
+        "transpostend"
+    ])
 
-    disposer1();
-    disposer2();
-    t.end();
-});
-
-test("verify array in transaction", function(t) {
-    var ar = observable([]);
-    var aCount= 0;
-    var aValue;
-
-    mobx.autorun(function() {
-        aCount++;
-        aValue = 0;
-        for(var i = 0; i < ar.length; i++)
-            aValue += ar[i];
-    });
-
-    mobx.transaction(function() {
-        ar.push(2);
-        ar.push(3);
-        ar.push(4);
-        ar.unshift(1);
-    });
-    t.equal(aValue, 10);
-    t.equal(aCount, 2);
-    t.end();
+    disposer1()
+    disposer2()
+    t.end()
 })
 
-test('delay autorun until end of transaction', function(t) {
-    m.extras.resetGlobalState();
-    mobx.extras.getGlobalState().mobxGuid = 0;
-    var events = [];
+test("verify array in transaction", function(t) {
+    var ar = observable([])
+    var aCount = 0
+    var aValue
+
+    mobx.autorun(function() {
+        aCount++
+        aValue = 0
+        for (var i = 0; i < ar.length; i++) aValue += ar[i]
+    })
+
+    mobx.transaction(function() {
+        ar.push(2)
+        ar.push(3)
+        ar.push(4)
+        ar.unshift(1)
+    })
+    t.equal(aValue, 10)
+    t.equal(aCount, 2)
+    t.end()
+})
+
+test("delay autorun until end of transaction", function(t) {
+    m.extras.resetGlobalState()
+    mobx.extras.getGlobalState().mobxGuid = 0
+    var events = []
     var x = observable({
         a: 2,
         get b() {
-            events.push("calc y");
-            return this.a;
+            events.push("calc y")
+            return this.a
         }
-    });
-    var disposer1;
+    })
+    var disposer1
     var disposer2 = mobx.spy(function(info) {
-        events.push(info);
-    });
-    var didRun = false;
+        events.push(info)
+    })
+    var didRun = false
 
     mobx.transaction(function() {
         mobx.transaction(function() {
-
             disposer1 = mobx.autorun(function test() {
-                didRun = true;
-                events.push("auto");
-                x.b;
-            });
+                didRun = true
+                events.push("auto")
+                x.b
+            })
 
-            t.equal(didRun, false, "autorun should not have run yet");
+            t.equal(didRun, false, "autorun should not have run yet")
 
-            x.a = 3;
-            x.a = 4;
+            x.a = 3
+            x.a = 4
 
-            events.push("end1");
-        });
-        t.equal(didRun, false, "autorun should not have run yet");
-        x.a = 5;
-        events.push("end2");
-    });
+            events.push("end1")
+        })
+        t.equal(didRun, false, "autorun should not have run yet")
+        x.a = 5
+        events.push("end2")
+    })
 
-    t.equal(didRun, true, "autorun should not have run yet");
-    events.push("post trans1");
-    x.a = 6;
-    events.push("post trans2");
-    disposer1();
-    x.a = 3;
-    events.push("post trans3");
+    t.equal(didRun, true, "autorun should not have run yet")
+    events.push("post trans1")
+    x.a = 6
+    events.push("post trans2")
+    disposer1()
+    x.a = 3
+    events.push("post trans3")
 
     t.deepEqual(stripSpyOutput(events), [
-		{ name: 'a', newValue: 3, oldValue: 2, spyReportStart: true, type: 'update' }, { spyReportEnd: true },
-		{ name: 'a', newValue: 4, oldValue: 3, spyReportStart: true, type: 'update' }, { spyReportEnd: true },
-		'end1',
-		{ name: 'a', newValue: 5, oldValue: 4, spyReportStart: true, type: 'update' }, { spyReportEnd: true },
-		'end2',
-		{ spyReportStart: true, type: 'reaction' },
-			'auto',
-			{ type: 'compute' },
-			'calc y',
-		{ spyReportEnd: true },
-		'post trans1',
-		{ name: 'a', newValue: 6, oldValue: 5, spyReportStart: true, type: 'update' },
-			{ type: 'compute' },
-			'calc y',
-			{ spyReportStart: true, type: 'reaction' },
-				'auto',
-			{ spyReportEnd: true },
-		{ spyReportEnd: true },
-		'post trans2',
-		{ name: 'a', newValue: 3, oldValue: 6, spyReportStart: true, type: 'update' }, { spyReportEnd: true },
-		'post trans3'
-    ]);
+        { name: "a", newValue: 3, oldValue: 2, spyReportStart: true, type: "update" },
+        { spyReportEnd: true },
+        { name: "a", newValue: 4, oldValue: 3, spyReportStart: true, type: "update" },
+        { spyReportEnd: true },
+        "end1",
+        { name: "a", newValue: 5, oldValue: 4, spyReportStart: true, type: "update" },
+        { spyReportEnd: true },
+        "end2",
+        { spyReportStart: true, type: "reaction" },
+        "auto",
+        { type: "compute" },
+        "calc y",
+        { spyReportEnd: true },
+        "post trans1",
+        { name: "a", newValue: 6, oldValue: 5, spyReportStart: true, type: "update" },
+        { type: "compute" },
+        "calc y",
+        { spyReportStart: true, type: "reaction" },
+        "auto",
+        { spyReportEnd: true },
+        { spyReportEnd: true },
+        "post trans2",
+        { name: "a", newValue: 3, oldValue: 6, spyReportStart: true, type: "update" },
+        { spyReportEnd: true },
+        "post trans3"
+    ])
 
-    disposer2();
-    t.end();
-});
-
-test('prematurely end autorun', function(t) {
-    var x = observable(2);
-    var dis1, dis2;
-    mobx.transaction(function() {
-        dis1 =  mobx.autorun(function() {
-            x.get();
-        });
-        dis2 =  mobx.autorun(function() {
-            x.get();
-        });
-
-        t.equal(x.observers.length, 0);
-        t.equal(dis1.$mobx.observing.length, 0);
-        t.equal(dis2.$mobx.observing.length, 0);
-
-        dis1();
-    });
-    t.equal(x.observers.length, 1);
-    t.equal(dis1.$mobx.observing.length, 0);
-    t.equal(dis2.$mobx.observing.length, 1);
-
-    dis2();
-
-    t.equal(x.observers.length, 0);
-    t.equal(dis1.$mobx.observing.length, 0);
-    t.equal(dis2.$mobx.observing.length, 0);
-
-    t.end();
-});
-
-test('computed values believe NaN === NaN', function(t) {
-	var a = observable(2);
-	var b = observable(3);
-	var c = computed(function() { return String(a.get() * b.get()) });
-	var buf = buffer();
-	m.observe(c, buf);
-
-	a.set(NaN);
-	b.set(NaN);
-	a.set(NaN);
-	a.set(2);
-	b.set(3);
-
-	t.deepEqual(buf.toArray(), ['NaN', '6']);
-	t.end();
+    disposer2()
+    t.end()
 })
 
-test.skip('issue 65; transaction causing transaction', function(t) {
-	// MWE: disabled, bad test; depends on transaction being tracked, transaction should not be used in computed!
+test("prematurely end autorun", function(t) {
+    var x = observable(2)
+    var dis1, dis2
+    mobx.transaction(function() {
+        dis1 = mobx.autorun(function() {
+            x.get()
+        })
+        dis2 = mobx.autorun(function() {
+            x.get()
+        })
+
+        t.equal(x.observers.length, 0)
+        t.equal(dis1.$mobx.observing.length, 0)
+        t.equal(dis2.$mobx.observing.length, 0)
+
+        dis1()
+    })
+    t.equal(x.observers.length, 1)
+    t.equal(dis1.$mobx.observing.length, 0)
+    t.equal(dis2.$mobx.observing.length, 1)
+
+    dis2()
+
+    t.equal(x.observers.length, 0)
+    t.equal(dis1.$mobx.observing.length, 0)
+    t.equal(dis2.$mobx.observing.length, 0)
+
+    t.end()
+})
+
+test("computed values believe NaN === NaN", function(t) {
+    var a = observable(2)
+    var b = observable(3)
+    var c = computed(function() {
+        return String(a.get() * b.get())
+    })
+    var buf = buffer()
+    m.observe(c, buf)
+
+    a.set(NaN)
+    b.set(NaN)
+    a.set(NaN)
+    a.set(2)
+    b.set(3)
+
+    t.deepEqual(buf.toArray(), ["NaN", "6"])
+    t.end()
+})
+
+test.skip("issue 65; transaction causing transaction", function(t) {
+    // MWE: disabled, bad test; depends on transaction being tracked, transaction should not be used in computed!
     var x = mobx.observable({
         a: 3,
         get b() {
             return mobx.transaction(function() {
-                return this.a * 2;
-            }, this);
+                return this.a * 2
+            }, this)
         }
-    });
+    })
 
-    var res;
+    var res
     mobx.autorun(function() {
-        res = x.a + x.b;
-    });
+        res = x.a + x.b
+    })
 
     mobx.transaction(function() {
-        x.a = 2;
-        x.a = 5;
-    });
-    t.equal(res, 15);
-    t.end();
-});
+        x.a = 2
+        x.a = 5
+    })
+    t.equal(res, 15)
+    t.end()
+})
 
-test('issue 71, transacting running transformation', function(t) {
+test("issue 71, transacting running transformation", function(t) {
     var state = mobx.observable({
         things: []
-    });
+    })
 
     function Thing(value) {
         mobx.extendObservable(this, {
             value: value,
             get pos() {
-                return state.things.indexOf(this);
+                return state.things.indexOf(this)
             },
             get isVisible() {
-                return this.pos !== -1;
+                return this.pos !== -1
             }
-        });
+        })
 
-        mobx.when(function() {
-            return this.isVisible;
-        }, function() {
-            if (this.pos < 4)
-                state.things.push(new Thing(value + 1));
-        }, this);
+        mobx.when(
+            function() {
+                return this.isVisible
+            },
+            function() {
+                if (this.pos < 4) state.things.push(new Thing(value + 1))
+            },
+            this
+        )
     }
 
-    var copy;
-    var vSum;
+    var copy
+    var vSum
     mobx.autorun(function() {
-        copy = state.things.map(function(thing) { return thing.value });
+        copy = state.things.map(function(thing) {
+            return thing.value
+        })
         vSum = state.things.reduce(function(a, thing) {
-            return a  + thing.value
-        }, 0);
-    });
+            return a + thing.value
+        }, 0)
+    })
 
-    t.deepEqual(copy, []);
+    t.deepEqual(copy, [])
 
     mobx.transaction(function() {
-        state.things.push(new Thing(1));
-    });
+        state.things.push(new Thing(1))
+    })
 
-    t.deepEqual(copy, [1,2,3,4,5]);
-    t.equal(vSum, 15);
+    t.deepEqual(copy, [1, 2, 3, 4, 5])
+    t.equal(vSum, 15)
 
-    state.things.splice(0,2);
-    state.things.push(new Thing(6));
+    state.things.splice(0, 2)
+    state.things.push(new Thing(6))
 
-    t.deepEqual(copy, [3,4,5,6,7]);
-    t.equal(vSum, 25);
+    t.deepEqual(copy, [3, 4, 5, 6, 7])
+    t.equal(vSum, 25)
 
-    t.end();
-});
+    t.end()
+})
 
-test('eval in transaction', function(t) {
-    var bCalcs = 0;
+test("eval in transaction", function(t) {
+    var bCalcs = 0
     var x = mobx.observable({
         a: 1,
         get b() {
-            bCalcs++;
-            return this.a * 2;
+            bCalcs++
+            return this.a * 2
         }
-    });
-    var c;
+    })
+    var c
 
     mobx.autorun(function() {
-       c = x.b;
-    });
+        c = x.b
+    })
 
-    t.equal(bCalcs, 1);
-    t.equal(c, 2);
+    t.equal(bCalcs, 1)
+    t.equal(c, 2)
 
     mobx.transaction(function() {
-        x.a = 3;
-        t.equal(x.b, 6);
-        t.equal(bCalcs, 2);
-        t.equal(c, 2);
+        x.a = 3
+        t.equal(x.b, 6)
+        t.equal(bCalcs, 2)
+        t.equal(c, 2)
 
-        x.a = 4;
-        t.equal(x.b, 8);
-        t.equal(bCalcs, 3);
-        t.equal(c, 2);
-    });
-    t.equal(bCalcs, 3); // 2 or 3 would be fine as well
-    t.equal(c, 8);
-    t.end();
+        x.a = 4
+        t.equal(x.b, 8)
+        t.equal(bCalcs, 3)
+        t.equal(c, 2)
+    })
+    t.equal(bCalcs, 3) // 2 or 3 would be fine as well
+    t.equal(c, 8)
+    t.end()
 })
 
-test('forcefully tracked reaction should still yield valid results', function(t) {
-    var x = observable(3);
-    var z;
-    var runCount = 0;
+test("forcefully tracked reaction should still yield valid results", function(t) {
+    var x = observable(3)
+    var z
+    var runCount = 0
     var identity = function() {
-        runCount++;
-        z = x.get();
-    };
+        runCount++
+        z = x.get()
+    }
     var a = new mobx.Reaction("test", function() {
-        this.track(identity);
-    });
-    a.runReaction();
+        this.track(identity)
+    })
+    a.runReaction()
 
-    t.equal(z, 3);
-    t.equal(runCount, 1);
-
-    transaction(function() {
-        x.set(4);
-        a.track(identity);
-        t.equal(a.isScheduled(), true);
-        t.equal(z, 4);
-        t.equal(runCount, 2);
-    });
-
-    t.equal(z, 4);
-    t.equal(runCount, 2); // x is observed, so it should recompute only on dependency change
+    t.equal(z, 3)
+    t.equal(runCount, 1)
 
     transaction(function() {
-        x.set(5);
-        t.equal(a.isScheduled(), true);
-        a.track(identity);
-        t.equal(z, 5);
-        t.equal(runCount, 3);
-        t.equal(a.isScheduled(), true);
+        x.set(4)
+        a.track(identity)
+        t.equal(a.isScheduled(), true)
+        t.equal(z, 4)
+        t.equal(runCount, 2)
+    })
 
-        x.set(6);
-        t.equal(z, 5);
-        t.equal(runCount, 3);
-    });
-    t.equal(a.isScheduled(), false);
-    t.equal(z, 6);
-    t.equal(runCount, 4);
-    t.end();
-});
+    t.equal(z, 4)
+    t.equal(runCount, 2) // x is observed, so it should recompute only on dependency change
 
-test('autoruns created in autoruns should kick off', function(t) {
-	var x = observable(3);
-	var x2 = [];
-	var d;
+    transaction(function() {
+        x.set(5)
+        t.equal(a.isScheduled(), true)
+        a.track(identity)
+        t.equal(z, 5)
+        t.equal(runCount, 3)
+        t.equal(a.isScheduled(), true)
 
-	var a = m.autorun(function() {
-		if (d) {
-			// dispose previous autorun
-			d();
-		}
-		d = m.autorun(function() {
-			x2.push(x.get() * 2);
-		});
-	})
-
-	// a should be observed by the inner autorun, not the outer
-	t.equal(a.$mobx.observing.length, 0);
-	t.equal(d.$mobx.observing.length, 1);
-
-	x.set(4);
-	t.deepEqual(x2, [6, 8]);
-
-
-	t.end();
-});
-
-test('#502 extendObservable throws on objects created with Object.create(null)', t => {
-	var a = Object.create(null)
-	mobx.extendObservable(a, { b: 3 })
-	t.equal(mobx.isObservable(a, "b"), true)
-	t.end()
+        x.set(6)
+        t.equal(z, 5)
+        t.equal(runCount, 3)
+    })
+    t.equal(a.isScheduled(), false)
+    t.equal(z, 6)
+    t.equal(runCount, 4)
+    t.end()
 })
 
-test('#328 atom throwing exception if observing stuff in onObserved', t => {
-	var b = mobx.observable(1)
-	var a = new mobx.Atom('test atom', () => {
-		b.get();
-	});
-	var d = mobx.autorun(() => {
-		a.reportObserved(); // threw
-	})
-	d();
-	t.end()
-});
+test("autoruns created in autoruns should kick off", function(t) {
+    var x = observable(3)
+    var x2 = []
+    var d
 
-test('prematurely ended autoruns are cleaned up properly', t => {
-	var a = mobx.observable(1);
-	var b = mobx.observable(2);
-	var c = mobx.observable(3);
-	var called = 0;
+    var a = m.autorun(function() {
+        if (d) {
+            // dispose previous autorun
+            d()
+        }
+        d = m.autorun(function() {
+            x2.push(x.get() * 2)
+        })
+    })
 
-	var d = mobx.autorun(() => {
-		called++;
-		if (a.get() === 2) {
-			d(); // dispose
-			b.get(); // consume
-			a.set(3); // cause itself to re-run, but, disposed!
-		} else {
-			c.get();
-		}
-	})
+    // a should be observed by the inner autorun, not the outer
+    t.equal(a.$mobx.observing.length, 0)
+    t.equal(d.$mobx.observing.length, 1)
 
-	t.equal(called, 1)
-	t.equal(a.observers.length, 1)
-	t.equal(b.observers.length, 0)
-	t.equal(c.observers.length, 1)
-	t.equal(d.$mobx.observing.length, 2)
+    x.set(4)
+    t.deepEqual(x2, [6, 8])
 
-	a.set(2)
-
-	t.equal(called, 2)
-	t.equal(a.observers.length, 0)
-	t.equal(b.observers.length, 0)
-	t.equal(c.observers.length, 0)
-	t.equal(d.$mobx.observing.length, 0)
-
-	t.end()
+    t.end()
 })
 
-test('unoptimizable subscriptions are diffed correctly', t => {
-	var a = mobx.observable(1);
-	var b = mobx.observable(1);
-	var c = mobx.computed(() => {
-		a.get()
-		return 3
-	});
-	var called = 0;
-	var val = 0
-
-	const d = mobx.autorun(() => {
-		called++
-		a.get()
-		c.get() // reads a as well
-		val = a.get()
-		if (b.get() === 1) // only on first run
-			a.get() // second run: one read less for a
-	})
-
-	t.equal(called, 1)
-	t.equal(val, 1)
-	t.equal(a.observers.length, 2)
-	t.equal(b.observers.length, 1)
-	t.equal(c.observers.length, 1)
-	t.equal(d.$mobx.observing.length, 3) // 3 would be better!
-
-	b.set(2)
-
-	t.equal(called, 2)
-	t.equal(val, 1)
-	t.equal(a.observers.length, 2)
-	t.equal(b.observers.length, 1)
-	t.equal(c.observers.length, 1)
-	t.equal(d.$mobx.observing.length, 3) // c was cached so accessing a was optimizable
-
-	a.set(2)
-
-	t.equal(called, 3)
-	t.equal(val, 2)
-	t.equal(a.observers.length, 2)
-	t.equal(b.observers.length, 1)
-	t.equal(c.observers.length, 1)
-	t.equal(d.$mobx.observing.length, 3) // c was cached so accessing a was optimizable
-
-	d();
-
-	t.end()
-
+test("#502 extendObservable throws on objects created with Object.create(null)", t => {
+    var a = Object.create(null)
+    mobx.extendObservable(a, { b: 3 })
+    t.equal(mobx.isObservable(a, "b"), true)
+    t.end()
 })
 
-test('atom events #427', t => {
-	var start = 0;
-	var stop = 0;
+test("#328 atom throwing exception if observing stuff in onObserved", t => {
+    var b = mobx.observable(1)
+    var a = new mobx.Atom("test atom", () => {
+        b.get()
+    })
+    var d = mobx.autorun(() => {
+        a.reportObserved() // threw
+    })
+    d()
+    t.end()
+})
 
-	var a = new mobx.Atom("test", () => start++, () => stop++);
-	a.reportObserved();
-	a.reportObserved();
+test("prematurely ended autoruns are cleaned up properly", t => {
+    var a = mobx.observable(1)
+    var b = mobx.observable(2)
+    var c = mobx.observable(3)
+    var called = 0
 
-	t.equal(start, 2)
-	t.equal(stop, 2)
+    var d = mobx.autorun(() => {
+        called++
+        if (a.get() === 2) {
+            d() // dispose
+            b.get() // consume
+            a.set(3) // cause itself to re-run, but, disposed!
+        } else {
+            c.get()
+        }
+    })
 
-	var d = mobx.autorun(() => {
-		a.reportObserved()
-		t.equal(start, 3)
-		a.reportObserved()
-		t.equal(start, 3)
-	})
+    t.equal(called, 1)
+    t.equal(a.observers.length, 1)
+    t.equal(b.observers.length, 0)
+    t.equal(c.observers.length, 1)
+    t.equal(d.$mobx.observing.length, 2)
 
-	t.equal(start, 3)
-	t.equal(stop, 2)
-	a.reportChanged()
-	t.equal(start, 3)
-	t.equal(stop, 2)
+    a.set(2)
 
-	d()
-	t.equal(start, 3)
-	t.equal(stop, 3)
+    t.equal(called, 2)
+    t.equal(a.observers.length, 0)
+    t.equal(b.observers.length, 0)
+    t.equal(c.observers.length, 0)
+    t.equal(d.$mobx.observing.length, 0)
 
-	t.equal(a.reportObserved(), false);
-	t.equal(start, 4)
-	t.equal(stop, 4)
+    t.end()
+})
 
-	d = mobx.autorun(() => {
-		t.equal(a.reportObserved(), true)
-		t.equal(start, 5)
-		a.reportObserved()
-		t.equal(start, 5)
-	})
+test("unoptimizable subscriptions are diffed correctly", t => {
+    var a = mobx.observable(1)
+    var b = mobx.observable(1)
+    var c = mobx.computed(() => {
+        a.get()
+        return 3
+    })
+    var called = 0
+    var val = 0
 
-	t.equal(start, 5)
-	t.equal(stop, 4)
-	a.reportChanged()
-	t.equal(start, 5)
-	t.equal(stop, 4)
+    const d = mobx.autorun(() => {
+        called++
+        a.get()
+        c.get() // reads a as well
+        val = a.get()
+        if (
+            b.get() === 1 // only on first run
+        )
+            a.get() // second run: one read less for a
+    })
 
-	d()
-	t.equal(stop, 5)
-	t.end()
+    t.equal(called, 1)
+    t.equal(val, 1)
+    t.equal(a.observers.length, 2)
+    t.equal(b.observers.length, 1)
+    t.equal(c.observers.length, 1)
+    t.equal(d.$mobx.observing.length, 3) // 3 would be better!
+
+    b.set(2)
+
+    t.equal(called, 2)
+    t.equal(val, 1)
+    t.equal(a.observers.length, 2)
+    t.equal(b.observers.length, 1)
+    t.equal(c.observers.length, 1)
+    t.equal(d.$mobx.observing.length, 3) // c was cached so accessing a was optimizable
+
+    a.set(2)
+
+    t.equal(called, 3)
+    t.equal(val, 2)
+    t.equal(a.observers.length, 2)
+    t.equal(b.observers.length, 1)
+    t.equal(c.observers.length, 1)
+    t.equal(d.$mobx.observing.length, 3) // c was cached so accessing a was optimizable
+
+    d()
+
+    t.end()
+})
+
+test("atom events #427", t => {
+    var start = 0
+    var stop = 0
+
+    var a = new mobx.Atom("test", () => start++, () => stop++)
+    a.reportObserved()
+    a.reportObserved()
+
+    t.equal(start, 2)
+    t.equal(stop, 2)
+
+    var d = mobx.autorun(() => {
+        a.reportObserved()
+        t.equal(start, 3)
+        a.reportObserved()
+        t.equal(start, 3)
+    })
+
+    t.equal(start, 3)
+    t.equal(stop, 2)
+    a.reportChanged()
+    t.equal(start, 3)
+    t.equal(stop, 2)
+
+    d()
+    t.equal(start, 3)
+    t.equal(stop, 3)
+
+    t.equal(a.reportObserved(), false)
+    t.equal(start, 4)
+    t.equal(stop, 4)
+
+    d = mobx.autorun(() => {
+        t.equal(a.reportObserved(), true)
+        t.equal(start, 5)
+        a.reportObserved()
+        t.equal(start, 5)
+    })
+
+    t.equal(start, 5)
+    t.equal(stop, 4)
+    a.reportChanged()
+    t.equal(start, 5)
+    t.equal(stop, 4)
+
+    d()
+    t.equal(stop, 5)
+    t.end()
 })
 
 test("verify calculation count", t => {
-	var calcs = []
-	var a = observable(1)
-	var b = mobx.computed(() => {
-		calcs.push("b")
-		return a.get()
-	})
-	var c = mobx.computed(() => {
-		calcs.push("c")
-		return b.get()
-	})
-	var d = mobx.autorun(() => {
-		calcs.push("d")
-		return b.get()
-	})
-	var e = mobx.autorun(() => {
-		calcs.push("e")
-		return c.get()
-	})
-	var f = mobx.computed(() => {
-		calcs.push("f")
-		return c.get()
-	})
+    var calcs = []
+    var a = observable(1)
+    var b = mobx.computed(() => {
+        calcs.push("b")
+        return a.get()
+    })
+    var c = mobx.computed(() => {
+        calcs.push("c")
+        return b.get()
+    })
+    var d = mobx.autorun(() => {
+        calcs.push("d")
+        return b.get()
+    })
+    var e = mobx.autorun(() => {
+        calcs.push("e")
+        return c.get()
+    })
+    var f = mobx.computed(() => {
+        calcs.push("f")
+        return c.get()
+    })
 
-	t.equal(f.get(), 1)
+    t.equal(f.get(), 1)
 
-	calcs.push("change")
-	a.set(2)
+    calcs.push("change")
+    a.set(2)
 
-	t.equal(f.get(), 2)
+    t.equal(f.get(), 2)
 
-	calcs.push("transaction")
-	transaction(() => {
-		t.equal(b.get(), 2)
-		t.equal(c.get(), 2)
-		t.equal(f.get(), 2)
-		t.equal(f.get(), 2)
-		calcs.push("change")
-		a.set(3)
-		t.equal(b.get(), 3)
-		t.equal(b.get(), 3)
-		calcs.push("try c")
-		t.equal(c.get(), 3)
-		t.equal(c.get(), 3)
-		calcs.push("try f")
-		t.equal(f.get(), 3)
-		t.equal(f.get(), 3)
-		calcs.push("end transaction")
-	})
+    calcs.push("transaction")
+    transaction(() => {
+        t.equal(b.get(), 2)
+        t.equal(c.get(), 2)
+        t.equal(f.get(), 2)
+        t.equal(f.get(), 2)
+        calcs.push("change")
+        a.set(3)
+        t.equal(b.get(), 3)
+        t.equal(b.get(), 3)
+        calcs.push("try c")
+        t.equal(c.get(), 3)
+        t.equal(c.get(), 3)
+        calcs.push("try f")
+        t.equal(f.get(), 3)
+        t.equal(f.get(), 3)
+        calcs.push("end transaction")
+    })
 
-	t.deepEqual(calcs, [
-		"d", "b", "e", "c",
-		"f",
-		"change", "b", "c", "e", "d", "f", // would have expected b c e d f, but alas
-		"transaction", "f",
-		"change", "b",
-		"try c", "c",
-		"try f", "f",
-		"end transaction", "e", "d" // would have expected e d
-	])
+    t.deepEqual(calcs, [
+        "d",
+        "b",
+        "e",
+        "c",
+        "f",
+        "change",
+        "b",
+        "c",
+        "e",
+        "d",
+        "f", // would have expected b c e d f, but alas
+        "transaction",
+        "f",
+        "change",
+        "b",
+        "try c",
+        "c",
+        "try f",
+        "f",
+        "end transaction",
+        "e",
+        "d" // would have expected e d
+    ])
 
-	d()
-	e()
+    d()
+    e()
 
-	t.end()
+    t.end()
 })
 
 test("support computed property getters / setters", t => {
-	let a = observable({
-		size: 1,
-		volume: mobx.computed(function() {
-			return this.size * this.size
-		})
-	})
+    let a = observable({
+        size: 1,
+        volume: mobx.computed(function() {
+            return this.size * this.size
+        })
+    })
 
-	t.equal(a.volume, 1)
-	a.size = 3
-	t.equal(a.volume, 9)
+    t.equal(a.volume, 1)
+    a.size = 3
+    t.equal(a.volume, 9)
 
-	t.throws(() => a.volume = 9, /It is not possible to assign a new value to a computed value/)
+    t.throws(() => (a.volume = 9), /It is not possible to assign a new value to a computed value/)
 
-	a = {}
-	mobx.extendObservable(a, {
-		size: 2,
-		volume: mobx.computed(
-			function() { return this.size * this.size },
-			function(v) { this.size = Math.sqrt(v) }
-		)
-	})
+    a = {}
+    mobx.extendObservable(a, {
+        size: 2,
+        volume: mobx.computed(
+            function() {
+                return this.size * this.size
+            },
+            function(v) {
+                this.size = Math.sqrt(v)
+            }
+        )
+    })
 
-	const values = []
-	const d = mobx.autorun(() => values.push(a.volume))
+    const values = []
+    const d = mobx.autorun(() => values.push(a.volume))
 
-	a.volume = 9
-	mobx.transaction(() => {
-		a.volume = 100
-		a.volume = 64
-	})
+    a.volume = 9
+    mobx.transaction(() => {
+        a.volume = 100
+        a.volume = 64
+    })
 
-	t.deepEqual(values, [4, 9, 64])
-	t.deepEqual(a.size, 8)
+    t.deepEqual(values, [4, 9, 64])
+    t.deepEqual(a.size, 8)
 
-	d()
-	t.end()
-})
-
-test('computed getter / setter for plan objects should succeed', function (t) {
-	var b = observable({
-		a: 3,
-		get propX() {
-			return this.a * 2;
-		},
-		set propX(v) {
-			this.a = v;
-		}
-	});
-
-	var values = [];
-	mobx.autorun(function () {
-		return values.push(b.propX);
-	});
-	t.equal(b.propX, 6);
-	b.propX = 4;
-	t.equal(b.propX, 8);
-
-	t.deepEqual(values, [6, 8]);
-
-	t.end();
-});
-
-test('helpful error for self referencing setter', function(t) {
-	var a = observable({
-		x: 1,
-		get y() {
-			return this.x
-		},
-		set y(v) {
-			this.y = v // woops...;-)
-		}
-	})
-
-	t.throws(() => a.y = 2, /The setter of computed value/)
-
-	t.end()
-})
-
-test('#558 boxed observables stay boxed observables', function(t) {
-	var a = observable({
-		x: observable(3)
-	})
-
-	t.equal(typeof a.x, "object")
-	t.equal(typeof a.x.get, "function")
-	t.end()
-})
-
-test('iscomputed', function(t) {
-	t.equal(mobx.isComputed(observable(3)), false)
-	t.equal(mobx.isComputed(mobx.computed(function() { return 3 })), true)
-
-	var x = observable({
-		a: 3,
-		get b() {
-			return this.a
-		}
-	})
-
-	t.equal(mobx.isComputed(x, "a"), false)
-	t.equal(mobx.isComputed(x, "b"), true)
-	t.end()
-})
-
-test('603 - transaction should not kill reactions', t => {
-	var a = observable(1)
-	var b = 1;
-	var d = mobx.autorun(() => { b = a.get() })
-
-	try {
-		mobx.transaction(() => {
-			a.set(2)
-			throw 3
-		})
-
-	} catch (e) {
-
-	}
-
-	t.equal(a.observers.length, 1)
-	t.equal(d.$mobx.observing.length, 1)
-	const g = m.extras.getGlobalState()
-	t.deepEqual(g.inBatch, 0)
-	t.deepEqual(g.pendingReactions.length, 0)
-	t.deepEqual(g.pendingUnobservations.length, 0)
-	t.deepEqual(g.trackingDerivation, null)
-
-	t.equal(b, 2)
-	a.set(3)
-	t.equal(b, 3)
-
-	t.end()
-
-})
-
-test('#561 test toPrimitive() of observable objects', function(t) {
-	if (typeof Symbol !== "undefined" && Symbol.toPrimitive) {
-		var x = observable(3);
-
-		t.equal(x.valueOf(), 3);
-		t.equal(x[Symbol.toPrimitive](), 3);
-
-		t.equal(+x, 3);
-		t.equal(++x, 4);
-
-		var y = observable(3);
-
-		t.equal(y + 7, 10);
-
-		var z = computed(() => ({ a: 3 }));
-		t.equal(3 + z, "3[object Object]");
-	} else {
-		var x = observable(3);
-
-		t.equal(x.valueOf(), 3);
-		t.equal(x["@@toPrimitive"](), 3);
-
-		t.equal(+x, 3);
-		t.equal(++x, 4);
-
-		var y = observable(3);
-
-		t.equal(y + 7, 10);
-
-		var z = computed(() => ({ a: 3 }));
-		t.equal("3" + (z["@@toPrimitive"]()), "3[object Object]");
-	}
+    d()
     t.end()
-});
+})
 
-test('observables should not fail when ES6 Map is missing', t => {
-    const globalMapFunction = global.Map;
-    global.Map = undefined;
-    t.equal(global.Map, undefined);
+test("computed getter / setter for plan objects should succeed", function(t) {
+    var b = observable({
+        a: 3,
+        get propX() {
+            return this.a * 2
+        },
+        set propX(v) {
+            this.a = v
+        }
+    })
+
+    var values = []
+    mobx.autorun(function() {
+        return values.push(b.propX)
+    })
+    t.equal(b.propX, 6)
+    b.propX = 4
+    t.equal(b.propX, 8)
+
+    t.deepEqual(values, [6, 8])
+
+    t.end()
+})
+
+test("helpful error for self referencing setter", function(t) {
+    var a = observable({
+        x: 1,
+        get y() {
+            return this.x
+        },
+        set y(v) {
+            this.y = v // woops...;-)
+        }
+    })
+
+    t.throws(() => (a.y = 2), /The setter of computed value/)
+
+    t.end()
+})
+
+test("#558 boxed observables stay boxed observables", function(t) {
+    var a = observable({
+        x: observable(3)
+    })
+
+    t.equal(typeof a.x, "object")
+    t.equal(typeof a.x.get, "function")
+    t.end()
+})
+
+test("iscomputed", function(t) {
+    t.equal(mobx.isComputed(observable(3)), false)
+    t.equal(
+        mobx.isComputed(
+            mobx.computed(function() {
+                return 3
+            })
+        ),
+        true
+    )
+
+    var x = observable({
+        a: 3,
+        get b() {
+            return this.a
+        }
+    })
+
+    t.equal(mobx.isComputed(x, "a"), false)
+    t.equal(mobx.isComputed(x, "b"), true)
+    t.end()
+})
+
+test("603 - transaction should not kill reactions", t => {
+    var a = observable(1)
+    var b = 1
+    var d = mobx.autorun(() => {
+        b = a.get()
+    })
+
     try {
-        var a = observable([1,2,3]); //trigger isES6Map in utils
+        mobx.transaction(() => {
+            a.set(2)
+            throw 3
+        })
+    } catch (e) {}
+
+    t.equal(a.observers.length, 1)
+    t.equal(d.$mobx.observing.length, 1)
+    const g = m.extras.getGlobalState()
+    t.deepEqual(g.inBatch, 0)
+    t.deepEqual(g.pendingReactions.length, 0)
+    t.deepEqual(g.pendingUnobservations.length, 0)
+    t.deepEqual(g.trackingDerivation, null)
+
+    t.equal(b, 2)
+    a.set(3)
+    t.equal(b, 3)
+
+    t.end()
+})
+
+test("#561 test toPrimitive() of observable objects", function(t) {
+    if (typeof Symbol !== "undefined" && Symbol.toPrimitive) {
+        var x = observable(3)
+
+        t.equal(x.valueOf(), 3)
+        t.equal(x[Symbol.toPrimitive](), 3)
+
+        t.equal(+x, 3)
+        t.equal(++x, 4)
+
+        var y = observable(3)
+
+        t.equal(y + 7, 10)
+
+        var z = computed(() => ({ a: 3 }))
+        t.equal(3 + z, "3[object Object]")
+    } else {
+        var x = observable(3)
+
+        t.equal(x.valueOf(), 3)
+        t.equal(x["@@toPrimitive"](), 3)
+
+        t.equal(+x, 3)
+        t.equal(++x, 4)
+
+        var y = observable(3)
+
+        t.equal(y + 7, 10)
+
+        var z = computed(() => ({ a: 3 }))
+        t.equal("3" + z["@@toPrimitive"](), "3[object Object]")
     }
-    catch (e) {
-        t.fail('Should not fail when Map is missing');
+    t.end()
+})
+
+test("observables should not fail when ES6 Map is missing", t => {
+    const globalMapFunction = global.Map
+    global.Map = undefined
+    t.equal(global.Map, undefined)
+    try {
+        var a = observable([1, 2, 3]) //trigger isES6Map in utils
+    } catch (e) {
+        t.fail("Should not fail when Map is missing")
     }
 
-    t.equal(m.isObservable(a), true);
+    t.equal(m.isObservable(a), true)
 
-    global.Map = globalMapFunction;
-    t.end();
+    global.Map = globalMapFunction
+    t.end()
 })
 
 test("computed equals function only invoked when necessary", t => {
-	const comparisons = [];
-	const loggingComparer = (from, to) => {
-		comparisons.push({ from, to });
-		return from === to;
-	};
+    const comparisons = []
+    const loggingComparer = (from, to) => {
+        comparisons.push({ from, to })
+        return from === to
+    }
 
-	const left = mobx.observable("A");
-	const right = mobx.observable("B");
-	const combinedToLowerCase = mobx.computed(
-		() => left.get().toLowerCase() + right.get().toLowerCase(),
-		{ equals: loggingComparer }
-	);
+    const left = mobx.observable("A")
+    const right = mobx.observable("B")
+    const combinedToLowerCase = mobx.computed(
+        () => left.get().toLowerCase() + right.get().toLowerCase(),
+        { equals: loggingComparer }
+    )
 
-	const values = [];
-	const disposeAutorun = mobx.autorun(() => values.push(combinedToLowerCase.get()));
+    const values = []
+    const disposeAutorun = mobx.autorun(() => values.push(combinedToLowerCase.get()))
 
-	// No comparison should be made on the first value
-	t.deepEqual(comparisons, []);
+    // No comparison should be made on the first value
+    t.deepEqual(comparisons, [])
 
-	// First change will cause a comparison
-	left.set("C");
-	t.deepEqual(comparisons, [{ from: "ab", to: "cb" }]);
+    // First change will cause a comparison
+    left.set("C")
+    t.deepEqual(comparisons, [{ from: "ab", to: "cb" }])
 
-	// Transition *to* CaughtException in the computed won't cause a comparison
-	left.set(null);
-	t.deepEqual(comparisons, [{ from: "ab", to: "cb" }]);
+    // Transition *to* CaughtException in the computed won't cause a comparison
+    left.set(null)
+    t.deepEqual(comparisons, [{ from: "ab", to: "cb" }])
 
-	// Transition *between* CaughtException-s in the computed won't cause a comparison
-	right.set(null);
-	t.deepEqual(comparisons, [{ from: "ab", to: "cb" }]);
+    // Transition *between* CaughtException-s in the computed won't cause a comparison
+    right.set(null)
+    t.deepEqual(comparisons, [{ from: "ab", to: "cb" }])
 
-	// Transition *from* CaughtException in the computed won't cause a comparison
-	left.set("D");
-	right.set("E");
-	t.deepEqual(comparisons, [{ from: "ab", to: "cb" }]);
+    // Transition *from* CaughtException in the computed won't cause a comparison
+    left.set("D")
+    right.set("E")
+    t.deepEqual(comparisons, [{ from: "ab", to: "cb" }])
 
-	// Another value change will cause a comparison
-	right.set("F");
-	t.deepEqual(comparisons, [{ from: "ab", to: "cb" }, { from: "de", to: "df" }]);
+    // Another value change will cause a comparison
+    right.set("F")
+    t.deepEqual(comparisons, [{ from: "ab", to: "cb" }, { from: "de", to: "df" }])
 
-	t.deepEqual(values, ["ab", "cb", "de", "df"]);
+    t.deepEqual(values, ["ab", "cb", "de", "df"])
 
-	disposeAutorun();
+    disposeAutorun()
 
-	t.end();
-});
+    t.end()
+})
 
-test('Issue 1092 - Should not access attributes of siblings in the prot. chain', t => {
-  t.plan(2);
+test("Issue 1092 - Should not access attributes of siblings in the prot. chain", t => {
+    t.plan(2)
 
-  // The parent is an observable
-  // and has an attribute
-  const parent = {};
-  mobx.extendObservable(parent, {
-    staticObservable: 11
-  });
-
-  // Child1 "inherit" from the parent
-  // and has an observable attribute
-  const child1 = Object.create(parent);
-  mobx.extendObservable(child1, {
-      attribute: 7
-  });
-
-  // Child2 also "inherit" from the parent
-  // But does not have any observable attribute
-  const child2 = Object.create(parent);
-
-  // The second child should not be aware of the attribute of his
-  // sibling child1
-  t.equals(typeof child2.attribute, 'undefined',
-    'We should not access attributes of siblings');
-
-  // We still should be able to read the value from the parent
-  t.equals(child2.staticObservable, 11,
-    'We should be able to read attributes from parents');
-
-  t.end();
-});
-
-test('Issue 1092 - We should be able to define observable on all siblings', t => {
-  t.plan(1);
-
-  // The parent is an observable
-  const parent = {};
-  mobx.extendObservable(parent, {});
-
-  // Child1 "inherit" from the parent
-  // and has an observable attribute
-  const child1 = Object.create(parent);
-  mobx.extendObservable(child1, {
-      attribute: 7
-  });
-
-  // Child2 also "inherit" from the parent
-  // But does not have any observable attribute
-  const child2 = Object.create(parent);
-  t.doesNotThrow(() => {
-    mobx.extendObservable(child2, {
-      attribute: 8
+    // The parent is an observable
+    // and has an attribute
+    const parent = {}
+    mobx.extendObservable(parent, {
+        staticObservable: 11
     })
-  }, 'The attribute should not collide between the two siblings');
 
-  t.end();
-});
+    // Child1 "inherit" from the parent
+    // and has an observable attribute
+    const child1 = Object.create(parent)
+    mobx.extendObservable(child1, {
+        attribute: 7
+    })
 
+    // Child2 also "inherit" from the parent
+    // But does not have any observable attribute
+    const child2 = Object.create(parent)
+
+    // The second child should not be aware of the attribute of his
+    // sibling child1
+    t.equals(typeof child2.attribute, "undefined", "We should not access attributes of siblings")
+
+    // We still should be able to read the value from the parent
+    t.equals(child2.staticObservable, 11, "We should be able to read attributes from parents")
+
+    t.end()
+})
+
+test("Issue 1092 - We should be able to define observable on all siblings", t => {
+    t.plan(1)
+
+    // The parent is an observable
+    const parent = {}
+    mobx.extendObservable(parent, {})
+
+    // Child1 "inherit" from the parent
+    // and has an observable attribute
+    const child1 = Object.create(parent)
+    mobx.extendObservable(child1, {
+        attribute: 7
+    })
+
+    // Child2 also "inherit" from the parent
+    // But does not have any observable attribute
+    const child2 = Object.create(parent)
+    t.doesNotThrow(() => {
+        mobx.extendObservable(child2, {
+            attribute: 8
+        })
+    }, "The attribute should not collide between the two siblings")
+
+    t.end()
+})

--- a/test/observe.js
+++ b/test/observe.js
@@ -1,69 +1,63 @@
-var test = require('tape');
-var m = require('..');
+var test = require("tape")
+var m = require("..")
 
-test('observe object and map properties', function(t) {
-	var map = m.map({ a : 1 });
-	var events = [];
+test("observe object and map properties", function(t) {
+    var map = m.map({ a: 1 })
+    var events = []
 
-	t.throws(function() {
-		m.observe(map, "b", function() {});
-	});
+    t.throws(function() {
+        m.observe(map, "b", function() {})
+    })
 
-	var d1 = m.observe(map, "a", function(e) {
-		events.push([e.newValue, e.oldValue]);
-	});
+    var d1 = m.observe(map, "a", function(e) {
+        events.push([e.newValue, e.oldValue])
+    })
 
-	map.set("a", 2);
-	map.set("a", 3);
-	d1();
-	map.set("a", 4);
+    map.set("a", 2)
+    map.set("a", 3)
+    d1()
+    map.set("a", 4)
 
-	var o = m.observable({
-		a: 5
-	});
+    var o = m.observable({
+        a: 5
+    })
 
-	t.throws(function() {
-		m.observe(o, "b", function() {});
-	});
-	var d2 = m.observe(o, "a", function(e) {
-		events.push([e.newValue, e.oldValue]);
-	});
+    t.throws(function() {
+        m.observe(o, "b", function() {})
+    })
+    var d2 = m.observe(o, "a", function(e) {
+        events.push([e.newValue, e.oldValue])
+    })
 
-	o.a = 6;
-	o.a = 7;
-	d2();
-	o.a = 8;
+    o.a = 6
+    o.a = 7
+    d2()
+    o.a = 8
 
-	t.deepEqual(events, [
-		[2, 1],
-		[3, 2],
-		[6, 5],
-		[7, 6]
-	]);
+    t.deepEqual(events, [[2, 1], [3, 2], [6, 5], [7, 6]])
 
-	t.end();
-});
+    t.end()
+})
 
-test('observe computed values', function(t) {
-	var events = [];
+test("observe computed values", function(t) {
+    var events = []
 
-	var v = m.observable(0);
-	var f = m.observable(0);
-	var c = m.computed(function() { return v.get(); });
+    var v = m.observable(0)
+    var f = m.observable(0)
+    var c = m.computed(function() {
+        return v.get()
+    })
 
-	var d2 = c.observe(function(e) {
-		v.get();
-		f.get();
-		events.push([e.newValue, e.oldValue]);
-	});
+    var d2 = c.observe(function(e) {
+        v.get()
+        f.get()
+        events.push([e.newValue, e.oldValue])
+    })
 
-	v.set(6);
-	f.set(10);
+    v.set(6)
+    f.set(10)
 
-	t.deepEqual(events, [
-		[6, 0]
-	]);
+    t.deepEqual(events, [[6, 0]])
 
-	t.end();
-
-});
+    t.end()
+})

--- a/test/perf/index.js
+++ b/test/perf/index.js
@@ -1,28 +1,28 @@
-var start = Date.now();
+var start = Date.now()
 
 if (process.env.PERSIST) {
-	var fs = require('fs');
-	var logFile = __dirname + "/perf.txt"
-	// clear previous results
-	if (fs.existsSync(logFile))
-		fs.unlinkSync(logFile)
+    var fs = require("fs")
+    var logFile = __dirname + "/perf.txt"
+    // clear previous results
+    if (fs.existsSync(logFile)) fs.unlinkSync(logFile)
 
-	exports.logMeasurement = function (msg) {
-		console.log(msg)
-		fs.appendFileSync(logFile, "\n" + msg, "utf8")
-	}
-}
-else {
-	exports.logMeasurement = function (msg) {
-		console.log(msg)
-	}
+    exports.logMeasurement = function(msg) {
+        console.log(msg)
+        fs.appendFileSync(logFile, "\n" + msg, "utf8")
+    }
+} else {
+    exports.logMeasurement = function(msg) {
+        console.log(msg)
+    }
 }
 
-require('./perf.js');
-require('./transform-perf.js');
+require("./perf.js")
+require("./transform-perf.js")
 
 // This test runs last..
-require('tape')(t => {
-	exports.logMeasurement("\n\nCompleted performance suite in " + ((Date.now() - start) / 1000) + " sec.")
-	t.end()
-});
+require("tape")(t => {
+    exports.logMeasurement(
+        "\n\nCompleted performance suite in " + (Date.now() - start) / 1000 + " sec."
+    )
+    t.end()
+})

--- a/test/perf/perf.js
+++ b/test/perf/perf.js
@@ -1,12 +1,11 @@
-var test = require('tape');
-var mobx = require('../..');
-var observable = mobx.observable;
-var computed = mobx.computed;
-var log = require('./index.js').logMeasurement;
+var test = require("tape")
+var mobx = require("../..")
+var observable = mobx.observable
+var computed = mobx.computed
+var log = require("./index.js").logMeasurement
 
 function gc() {
-    if (typeof global.gc === "function")
-        global.gc();
+    if (typeof global.gc === "function") global.gc()
 }
 
 function voidObserver() {
@@ -21,475 +20,491 @@ results of this test:
 186/113 after remove filter/length call to detect whether depencies are stable. 300 times faster. w00t.
 
 */
-test('one observes ten thousand that observe one', function (t) {
-    gc();
-    var a = observable(2);
+test("one observes ten thousand that observe one", function(t) {
+    gc()
+    var a = observable(2)
 
     // many observers that listen to one..
-    var observers = [];
+    var observers = []
     for (var i = 0; i < 10000; i++) {
-        (function(idx) {
-            observers.push(computed(function() {
-                return a.get() * idx;
-            }))
-        })(i);
+        ;(function(idx) {
+            observers.push(
+                computed(function() {
+                    return a.get() * idx
+                })
+            )
+        })(i)
     }
 
-    var bCalcs = 0;
+    var bCalcs = 0
     // one observers that listens to many..
     var b = computed(function() {
-        var res = 0;
-        for(var i = 0; i < observers.length; i++)
-        	res += observers[i].get();
-        bCalcs += 1;
-        return res;
+        var res = 0
+        for (var i = 0; i < observers.length; i++) res += observers[i].get()
+        bCalcs += 1
+        return res
     })
 
-    var start = now();
+    var start = now()
 
-    mobx.observe(b, voidObserver, true); // start observers
-    t.equal(99990000, b.get());
-    var initial = now();
+    mobx.observe(b, voidObserver, true) // start observers
+    t.equal(99990000, b.get())
+    var initial = now()
 
-    a.set(3);
-    t.equal(149985000, b.get()); // yes, I verified ;-).
+    a.set(3)
+    t.equal(149985000, b.get()) // yes, I verified ;-).
     //t.equal(2, bCalcs);
-    var end = now();
+    var end = now()
 
-    log("One observers many observes one - Started/Updated in " + (initial - start) + "/" + (end - initial) + " ms.");
-    t.end();
+    log(
+        "One observers many observes one - Started/Updated in " +
+            (initial - start) +
+            "/" +
+            (end - initial) +
+            " ms."
+    )
+    t.end()
 })
 
-test('five hundrend properties that observe their sibling', function (t) {
-    gc();
-    var observables = [observable(1)];
-    for(var i = 0; i < 500; i++) {
-        (function(idx) {
-            observables.push(computed(function() { return observables[idx].get() + 1 }));
-        })(i);
+test("five hundrend properties that observe their sibling", function(t) {
+    gc()
+    var observables = [observable(1)]
+    for (var i = 0; i < 500; i++) {
+        ;(function(idx) {
+            observables.push(
+                computed(function() {
+                    return observables[idx].get() + 1
+                })
+            )
+        })(i)
     }
 
-    var start = now();
+    var start = now()
 
-    var last = observables[observables.length -1];
-    mobx.observe(last, voidObserver);
-    t.equal(501, last.get());
-    var initial = now();
+    var last = observables[observables.length - 1]
+    mobx.observe(last, voidObserver)
+    t.equal(501, last.get())
+    var initial = now()
 
-    observables[0].set(2);
-    t.equal(502, last.get());
-    var end = now();
+    observables[0].set(2)
+    t.equal(502, last.get())
+    var end = now()
 
-    log("500 props observing sibling -  Started/Updated in " + (initial - start) + "/" + (end - initial) + " ms.");
-    t.end();
+    log(
+        "500 props observing sibling -  Started/Updated in " +
+            (initial - start) +
+            "/" +
+            (end - initial) +
+            " ms."
+    )
+    t.end()
 })
 
-test('late dependency change', function(t) {
-    gc();
-    var values = [];
-	for(var i = 0; i < 100; i++)
-		values.push(observable(0))
+test("late dependency change", function(t) {
+    gc()
+    var values = []
+    for (var i = 0; i < 100; i++) values.push(observable(0))
 
     var sum = computed(function() {
-        var sum = 0;
-        for(var i = 0; i < 100; i++)
-    	    sum += values[i].get();
-        return sum;
+        var sum = 0
+        for (var i = 0; i < 100; i++) sum += values[i].get()
+        return sum
     })
 
-    mobx.observe(sum, voidObserver, true);
+    mobx.observe(sum, voidObserver, true)
 
-    var start = new Date();
+    var start = new Date()
 
-    for(var i = 0; i < 10000; i++)
-	    values[99].set(i);
+    for (var i = 0; i < 10000; i++) values[99].set(i)
 
-    t.equal(sum.get(), 9999);
-    log("Late dependency change - Updated in " + ((new Date) - start) + "ms.");
-    t.end();
+    t.equal(sum.get(), 9999)
+    log("Late dependency change - Updated in " + (new Date() - start) + "ms.")
+    t.end()
 })
 
-test('lots of unused computables', function(t) {
-    gc();
-    var a = observable(1);
+test("lots of unused computables", function(t) {
+    gc()
+    var a = observable(1)
 
     // many observers that listen to one..
-    var observers = [];
+    var observers = []
     for (var i = 0; i < 10000; i++) {
-        (function(idx) {
-            observers.push(computed(function() {
-                return a.get() * idx;
-            }))
-        })(i);
+        ;(function(idx) {
+            observers.push(
+                computed(function() {
+                    return a.get() * idx
+                })
+            )
+        })(i)
     }
 
     // one observers that listens to many..
     var b = computed(function() {
-        var res = 0;
-        for(var i = 0; i < observers.length; i++)
-        	res += observers[i].get();
-        return res;
-    });
+        var res = 0
+        for (var i = 0; i < observers.length; i++) res += observers[i].get()
+        return res
+    })
 
-    var sum = 0;
-    var subscription = mobx.observe(b, function(e) {
-        sum = e.newValue;
-    }, true);
+    var sum = 0
+    var subscription = mobx.observe(
+        b,
+        function(e) {
+            sum = e.newValue
+        },
+        true
+    )
 
-    t.equal(sum, 49995000);
+    t.equal(sum, 49995000)
 
     // unsubscribe, nobody should listen to a() now!
-    subscription();
+    subscription()
 
-    var start = now();
+    var start = now()
 
-    a.set(3);
-    t.equal(sum, 49995000); // unchanged!
+    a.set(3)
+    t.equal(sum, 49995000) // unchanged!
 
-    var end = now();
+    var end = now()
 
-    log("Unused computables -   Updated in " + (end - start) + " ms.");
-    t.end();
+    log("Unused computables -   Updated in " + (end - start) + " ms.")
+    t.end()
 })
 
-test('many unreferenced observables', function(t) {
-    gc();
-    var a = observable(3);
-    var b = observable(6);
-    var c = observable(7);
-    var d = computed(function() { return a.get() * b.get() * c.get() });
-    t.equal(d.get(), 126);
-    t.equal(d.dependenciesState, -1);
-    var start = now();
-    for(var i = 0; i < 10000; i++) {
-        c.set(i);
-        d.get();
+test("many unreferenced observables", function(t) {
+    gc()
+    var a = observable(3)
+    var b = observable(6)
+    var c = observable(7)
+    var d = computed(function() {
+        return a.get() * b.get() * c.get()
+    })
+    t.equal(d.get(), 126)
+    t.equal(d.dependenciesState, -1)
+    var start = now()
+    for (var i = 0; i < 10000; i++) {
+        c.set(i)
+        d.get()
     }
-    var end = now();
+    var end = now()
 
-    log("Unused observables -  Updated in " + (end - start) + " ms.");
+    log("Unused observables -  Updated in " + (end - start) + " ms.")
 
-    t.end();
+    t.end()
 })
 
-test('array reduce', function(t) {
-    gc();
-    var aCalc = 0;
-    var ar = observable([]);
-    var b = observable(1);
+test("array reduce", function(t) {
+    gc()
+    var aCalc = 0
+    var ar = observable([])
+    var b = observable(1)
 
     var sum = computed(function() {
-        aCalc++;
+        aCalc++
         return ar.reduce(function(a, c) {
-            return a + c * b.get();
-        }, 0);
-    });
-    mobx.observe(sum, voidObserver);
+            return a + c * b.get()
+        }, 0)
+    })
+    mobx.observe(sum, voidObserver)
 
-    var start = now();
+    var start = now()
 
-    for(var i = 0; i < 1000; i++)
-        ar.push(i);
+    for (var i = 0; i < 1000; i++) ar.push(i)
 
-    t.equal(499500, sum.get());
-    t.equal(1001, aCalc);
-    aCalc = 0;
+    t.equal(499500, sum.get())
+    t.equal(1001, aCalc)
+    aCalc = 0
 
-    var initial = now();
+    var initial = now()
 
-    for(var i = 0; i < 1000; i++)
-    ar[i] = ar[i] * 2;
-    b.set(2);
+    for (var i = 0; i < 1000; i++) ar[i] = ar[i] * 2
+    b.set(2)
 
-    t.equal(1998000, sum.get());
-    t.equal(1000, aCalc);
+    t.equal(1998000, sum.get())
+    t.equal(1000, aCalc)
 
-    var end = now();
+    var end = now()
 
-    log("Array reduce -  Started/Updated in " + (initial - start) + "/" + (end - initial) + " ms.");
-    t.end();
+    log("Array reduce -  Started/Updated in " + (initial - start) + "/" + (end - initial) + " ms.")
+    t.end()
 })
 
-test('array classic loop', function(t) {
-    gc();
-    var ar = observable([]);
-    var aCalc = 0;
-    var b = observable(1);
+test("array classic loop", function(t) {
+    gc()
+    var ar = observable([])
+    var aCalc = 0
+    var b = observable(1)
     var sum = computed(function() {
-        var s = 0;
-        aCalc++;
-        for(var i = 0; i < ar.length; i++)
-            s+=ar[i] * b.get();
-        return s;
-    });
-    mobx.observe(sum, voidObserver, true); // calculate
+        var s = 0
+        aCalc++
+        for (var i = 0; i < ar.length; i++) s += ar[i] * b.get()
+        return s
+    })
+    mobx.observe(sum, voidObserver, true) // calculate
 
-    var start = now();
+    var start = now()
 
-    t.equal(1, aCalc);
-    for(var i = 0; i < 1000; i++)
-    	ar.push(i);
+    t.equal(1, aCalc)
+    for (var i = 0; i < 1000; i++) ar.push(i)
 
-    t.equal(499500, sum.get());
-    t.equal(1001, aCalc);
+    t.equal(499500, sum.get())
+    t.equal(1001, aCalc)
 
-    var initial = now();
-    aCalc = 0;
+    var initial = now()
+    aCalc = 0
 
-    for(var i = 0; i < 1000; i++)
-    	ar[i] = ar[i] * 2;
-    b.set(2);
+    for (var i = 0; i < 1000; i++) ar[i] = ar[i] * 2
+    b.set(2)
 
-    t.equal(1998000, sum.get());
-    t.equal(1000, aCalc);
+    t.equal(1998000, sum.get())
+    t.equal(1000, aCalc)
 
-    var end = now();
+    var end = now()
 
-    log("Array loop -  Started/Updated in " + (initial - start) + "/" + (end - initial) + " ms.");
-    t.end();
+    log("Array loop -  Started/Updated in " + (initial - start) + "/" + (end - initial) + " ms.")
+    t.end()
 })
 
 function order_system_helper(t, usebatch, keepObserving) {
-    gc();
-    t.equal(mobx.extras.isComputingDerivation(), false);
-    var orders = observable([]);
-    var vat = observable(2);
+    gc()
+    t.equal(mobx.extras.isComputingDerivation(), false)
+    var orders = observable([])
+    var vat = observable(2)
 
     var totalAmount = computed(function() {
-        var sum = 0, l = orders.length;
-        for(var i = 0; i < l; i++)
-        	sum += orders[i].total.get();
-        return sum;
-    });
+        var sum = 0,
+            l = orders.length
+        for (var i = 0; i < l; i++) sum += orders[i].total.get()
+        return sum
+    })
 
     function OrderLine(order, price, amount) {
-        this.price = observable(price);
-        this.amount = observable(amount);
-        this.total = computed(function() {
-            return order.vat.get() * this.price.get() * this.amount.get();
-        }, { context: this });
+        this.price = observable(price)
+        this.amount = observable(amount)
+        this.total = computed(
+            function() {
+                return order.vat.get() * this.price.get() * this.amount.get()
+            },
+            { context: this }
+        )
     }
 
     function Order(includeVat) {
-        this.includeVat = observable(includeVat);
-        this.lines = observable([]);
+        this.includeVat = observable(includeVat)
+        this.lines = observable([])
 
-        this.vat = computed(function() {
-            if (this.includeVat.get())
-            	return vat.get();
-            return 1;
-        }, { context: this });
+        this.vat = computed(
+            function() {
+                if (this.includeVat.get()) return vat.get()
+                return 1
+            },
+            { context: this }
+        )
 
-        this.total = computed(function() {
-            return this.lines.reduce(function(acc, order) {
-                return acc + order.total.get();
-            }, 0);
-        }, { context: this });
+        this.total = computed(
+            function() {
+                return this.lines.reduce(function(acc, order) {
+                    return acc + order.total.get()
+                }, 0)
+            },
+            { context: this }
+        )
     }
 
-    var disp;
-    if (keepObserving)
-        disp = mobx.observe(totalAmount, voidObserver);
+    var disp
+    if (keepObserving) disp = mobx.observe(totalAmount, voidObserver)
 
-    var start = now();
+    var start = now()
 
     function setup() {
-        for(var i = 0; i < 100; i++) {
-            var c = new Order(i % 2 == 0);
-            orders.push(c);
-            for(var j = 0; j < 100; j++)
-                c.lines.unshift(new OrderLine(c, 5, 5))
+        for (var i = 0; i < 100; i++) {
+            var c = new Order(i % 2 == 0)
+            orders.push(c)
+            for (var j = 0; j < 100; j++) c.lines.unshift(new OrderLine(c, 5, 5))
         }
     }
 
-    if (usebatch)
-        mobx.transaction(setup);
-    else
-        setup();
+    if (usebatch) mobx.transaction(setup)
+    else setup()
 
-    t.equal(totalAmount.get(), 375000);
+    t.equal(totalAmount.get(), 375000)
 
-    var initial = now();
+    var initial = now()
 
     function update() {
-        for(var i = 0; i < 50; i++)
-            orders[i].includeVat.set(!orders[i].includeVat.get());
-        vat.set(3);
+        for (var i = 0; i < 50; i++) orders[i].includeVat.set(!orders[i].includeVat.get())
+        vat.set(3)
     }
 
-    if (usebatch)
-        mobx.transaction(update)
-    else
-        update();
+    if (usebatch) mobx.transaction(update)
+    else update()
 
-    t.equal(totalAmount.get(), 500000);
+    t.equal(totalAmount.get(), 500000)
 
-    if (keepObserving)
-        disp();
+    if (keepObserving) disp()
 
     var end = now()
-    log("Order system batched: " + usebatch + " tracked: " + keepObserving + "  Started/Updated in " + (initial - start) + "/" + (end - initial) + " ms.");
+    log(
+        "Order system batched: " +
+            usebatch +
+            " tracked: " +
+            keepObserving +
+            "  Started/Updated in " +
+            (initial - start) +
+            "/" +
+            (end - initial) +
+            " ms."
+    )
 
-    t.end();
-};
+    t.end()
+}
 
-test('order system observed', function(t) {
-    order_system_helper(t, false, true);
+test("order system observed", function(t) {
+    order_system_helper(t, false, true)
 })
 
-test('order system batched observed', function(t) {
-    order_system_helper(t, true, true);
+test("order system batched observed", function(t) {
+    order_system_helper(t, true, true)
 })
 
-test('order system lazy', function(t) {
-    order_system_helper(t, false, false);
+test("order system lazy", function(t) {
+    order_system_helper(t, false, false)
 })
 
-test('order system batched lazy', function(t) {
-    order_system_helper(t, true, false);
+test("order system batched lazy", function(t) {
+    order_system_helper(t, true, false)
 })
 
-test('create array', function(t) {
-    gc();
-    var a = [];
-    for(var i = 0; i < 1000; i++)
-        a.push(i);
-    var start = now();
-    for(var i = 0; i < 1000; i++)
-        observable(a);
-    log('\nCreate array -  Created in ' + (now() - start) + 'ms.');
-    t.end();
+test("create array", function(t) {
+    gc()
+    var a = []
+    for (var i = 0; i < 1000; i++) a.push(i)
+    var start = now()
+    for (var i = 0; i < 1000; i++) observable(a)
+    log("\nCreate array -  Created in " + (now() - start) + "ms.")
+    t.end()
 })
 
-test('create array (fast)', function(t) {
-    gc();
-    var a = [];
-    for(var i = 0; i < 1000; i++)
-        a.push(i);
-    var start = now();
-    for(var i = 0; i < 1000; i++)
-        mobx.observable.shallowArray(a);
-    log('\nCreate array (non-recursive)  Created in ' + (now() - start) + 'ms.');
-    t.end();
+test("create array (fast)", function(t) {
+    gc()
+    var a = []
+    for (var i = 0; i < 1000; i++) a.push(i)
+    var start = now()
+    for (var i = 0; i < 1000; i++) mobx.observable.shallowArray(a)
+    log("\nCreate array (non-recursive)  Created in " + (now() - start) + "ms.")
+    t.end()
 })
 
-test('observe and dispose', t => {
-	gc()
+test("observe and dispose", t => {
+    gc()
 
-	var start = now();
-	var a = mobx.observable(1)
-	var observers = []
-	var MAX = 50000;
+    var start = now()
+    var a = mobx.observable(1)
+    var observers = []
+    var MAX = 50000
 
-	for(var i = 0; i < MAX * 2; i++)
-		observers.push(mobx.autorun(() => a.get()));
-	a.set(2);
-	// favorable order
-	// + unfavorable order
-	for(var i = 0; i < MAX; i++) {
-		observers[i]()
-		observers[observers.length - 1 - i]()
-	}
+    for (var i = 0; i < MAX * 2; i++) observers.push(mobx.autorun(() => a.get()))
+    a.set(2)
+    // favorable order
+    // + unfavorable order
+    for (var i = 0; i < MAX; i++) {
+        observers[i]()
+        observers[observers.length - 1 - i]()
+    }
 
-	log("Observable with many observers  + dispose: " + (now() - start) + "ms")
-	t.end()
+    log("Observable with many observers  + dispose: " + (now() - start) + "ms")
+    t.end()
 })
 
-test('sort', t => {
-	gc()
+test("sort", t => {
+    gc()
 
-	function Item(a, b, c) {
-		mobx.extendObservable(this, {
-			a: a, b: b, c: c, get d() {
-				return this.a + this.b + this.c;
-			}
-		})
-	}
-	var items = mobx.observable([])
+    function Item(a, b, c) {
+        mobx.extendObservable(this, {
+            a: a,
+            b: b,
+            c: c,
+            get d() {
+                return this.a + this.b + this.c
+            }
+        })
+    }
+    var items = mobx.observable([])
 
-	function sortFn (l, r) {
-		items.length; // screw all optimizations!
-		l.d;
-		r.d;
-		if (l.a > r.a)
-			return 1
-		if (l.a < r.a)
-			return -1;
-		if (l.b > r.b)
-			return 1;
-		if (l.b < r.b)
-			return -1;
-		if (l.c > r.c)
-			return 1;
-		if (l.c < r.c)
-			return -1;
-		return 0;
-	}
+    function sortFn(l, r) {
+        items.length // screw all optimizations!
+        l.d
+        r.d
+        if (l.a > r.a) return 1
+        if (l.a < r.a) return -1
+        if (l.b > r.b) return 1
+        if (l.b < r.b) return -1
+        if (l.c > r.c) return 1
+        if (l.c < r.c) return -1
+        return 0
+    }
 
-	var sorted = mobx.computed(() => {
-		items.sort(sortFn)
-	})
+    var sorted = mobx.computed(() => {
+        items.sort(sortFn)
+    })
 
+    var start = now()
+    var MAX = 100000
 
-	var start = now();
-	var MAX = 100000;
+    var ar = mobx.autorun(() => sorted.get())
 
-	var ar = mobx.autorun(() => sorted.get())
+    mobx.transaction(() => {
+        for (var i = 0; i < MAX; i++) items.push(new Item(i % 10, i % 3, i % 7))
+    })
 
-	mobx.transaction(() => {
-		for (var i = 0; i < MAX; i++)
-			items.push(new Item(i % 10, i % 3, i %7))
-	})
+    log("expensive sort: created " + (now() - start))
+    var start = now()
 
-	log("expensive sort: created " + (now() - start))
-	var start = now();
+    for (var i = 0; i < 5; i++) {
+        items[i * 1000].a = 7
+        items[i * 1100].b = 5
+        items[i * 1200].c = 9
+    }
 
-	for (var i = 0; i < 5; i++) {
-		items[i * 1000].a = 7;
-		items[i * 1100].b = 5;
-		items[i * 1200].c = 9;
-	}
+    log("expensive sort: updated " + (now() - start))
+    var start = now()
 
-	log("expensive sort: updated " + (now() - start))
-	var start = now();
+    ar()
 
-	ar();
+    log("expensive sort: disposed" + (now() - start))
 
-	log("expensive sort: disposed" + (now() - start))
+    var plain = mobx.toJS(items, false)
+    t.equal(plain.length, MAX)
 
-	var plain = mobx.toJS(items, false);
-	t.equal(plain.length, MAX)
+    var start = now()
+    for (var i = 0; i < 5; i++) {
+        plain[i * 1000].a = 7
+        plain.sort(sortFn)
+        plain[i * 1100].b = 5
+        plain.sort(sortFn)
+        plain[i * 1200].c = 9
+        plain.sort(sortFn)
+    }
+    log("native plain sort: updated " + (now() - start))
 
-	var start = now();
-	for (var i = 0; i <5; i++) {
-		plain[i * 1000].a = 7;
-		plain.sort(sortFn);
-		plain[i * 1100].b = 5;
-		plain.sort(sortFn);
-		plain[i * 1200].c = 9;
-		plain.sort(sortFn);
-	}
-	log("native plain sort: updated " + (now() - start))
-
-	t.end()
+    t.end()
 })
 
-test('computed temporary memoization', t => {
-  "use strict";
-  gc()
-  var computeds = []
-  for(let i = 0; i < 40; i++) {
-    computeds.push(mobx.computed(() =>
-      i ? computeds[i - 1].get() + computeds[i - 1].get() : 1
-    ))
-  }
-  var start = now()
-  t.equal(computeds[27].get(), 134217728)
+test("computed temporary memoization", t => {
+    "use strict"
+    gc()
+    var computeds = []
+    for (let i = 0; i < 40; i++) {
+        computeds.push(
+            mobx.computed(() => (i ? computeds[i - 1].get() + computeds[i - 1].get() : 1))
+        )
+    }
+    var start = now()
+    t.equal(computeds[27].get(), 134217728)
 
-  log("computed memoization " + (now() - start) + 'ms')
-  t.end()
+    log("computed memoization " + (now() - start) + "ms")
+    t.end()
 })
 
 function now() {
-    return + new Date();
+    return +new Date()
 }

--- a/test/perf/transform-perf.js
+++ b/test/perf/transform-perf.js
@@ -1,10 +1,9 @@
-var m = require('../../');
-var test = require('tape');
-var log = require('./index.js').logMeasurement;
+var m = require("../../")
+var test = require("tape")
+var log = require("./index.js").logMeasurement
 
 function gc() {
-    if (typeof global.gc === "function")
-        global.gc();
+    if (typeof global.gc === "function") global.gc()
 }
 
 /**
@@ -16,308 +15,333 @@ function gc() {
  */
 
 function measure(title, func) {
-	var start = Date.now();
-	var res = func();
-	log(title + " " + (Date.now() - start) + "ms.");
-	return res;
+    var start = Date.now()
+    var res = func()
+    log(title + " " + (Date.now() - start) + "ms.")
+    return res
 }
 
 function flatten() {
-	var res = [];
-	for(var i = 0, l = arguments.length; i < l; i++)
-		for(var j = 0, l2 = arguments[i].length; j < l2; j++)
-			res.push(arguments[i][j]);
-	return res;
+    var res = []
+    for (var i = 0, l = arguments.length; i < l; i++)
+        for (var j = 0, l2 = arguments[i].length; j < l2; j++) res.push(arguments[i][j])
+    return res
 }
 
-test('non-reactive folder tree', function(t) {
-	gc();
-	function Folder(parent, name) {
-		this.parent = parent;
-		this.name = "" + name;
-		this.children = [];
-	}
+test("non-reactive folder tree", function(t) {
+    gc()
+    function Folder(parent, name) {
+        this.parent = parent
+        this.name = "" + name
+        this.children = []
+    }
 
-	function DisplayFolder(folder, state) {
-		this.state = state;
-		this.folder = folder;
-		this.collapsed = false;
-		this._children = folder.children.map(transformFolder);
-	}
+    function DisplayFolder(folder, state) {
+        this.state = state
+        this.folder = folder
+        this.collapsed = false
+        this._children = folder.children.map(transformFolder)
+    }
 
-	Object.defineProperties(DisplayFolder.prototype, {
-		name: { get: function() {
-			return this.folder.name;
-		} },
-		isVisible: { get: function() {
-			return !this.state.filter || this.name.indexOf(this.state.filter) !== -1 || this.children.some(child => child.isVisible);
-		} },
-		children: { get: function() {
-			if (this.collapsed)
-				return [];
-			return this._children.filter(function(child) {
-				return child.isVisible;
-			});
-		} },
-		path: { get: function() {
-			return this.folder.parent === null ? this.name : transformFolder(this.folder.parent).path + "/" + this.name;
-		} }
-	});
+    Object.defineProperties(DisplayFolder.prototype, {
+        name: {
+            get: function() {
+                return this.folder.name
+            }
+        },
+        isVisible: {
+            get: function() {
+                return (
+                    !this.state.filter ||
+                    this.name.indexOf(this.state.filter) !== -1 ||
+                    this.children.some(child => child.isVisible)
+                )
+            }
+        },
+        children: {
+            get: function() {
+                if (this.collapsed) return []
+                return this._children.filter(function(child) {
+                    return child.isVisible
+                })
+            }
+        },
+        path: {
+            get: function() {
+                return this.folder.parent === null
+                    ? this.name
+                    : transformFolder(this.folder.parent).path + "/" + this.name
+            }
+        }
+    })
 
-	var state = {
-		root: new Folder(null, "root"),
-		filter: null,
-		displayRoot: null
-	};
+    var state = {
+        root: new Folder(null, "root"),
+        filter: null,
+        displayRoot: null
+    }
 
-	var transformFolder = function (folder) {
-		return new DisplayFolder(folder, state);
-	};
+    var transformFolder = function(folder) {
+        return new DisplayFolder(folder, state)
+    }
 
-	// returns list of strings per folder
-	DisplayFolder.prototype.rebuild = function () {
-		var path = this.path;
-		this.asText = path + "\n" +
-			this.children.filter(function(child) {
-				return child.isVisible;
-			}).map(child => child.asText).join('');
-	};
+    // returns list of strings per folder
+    DisplayFolder.prototype.rebuild = function() {
+        var path = this.path
+        this.asText =
+            path +
+            "\n" +
+            this.children
+                .filter(function(child) {
+                    return child.isVisible
+                })
+                .map(child => child.asText)
+                .join("")
+    }
 
-	DisplayFolder.prototype.rebuildAll = function() {
-		this.children.forEach(child => child.rebuildAll());
-		this.rebuild();
-	}
+    DisplayFolder.prototype.rebuildAll = function() {
+        this.children.forEach(child => child.rebuildAll())
+        this.rebuild()
+    }
 
-	function createFolders(parent, recursion) {
-		if (recursion === 0)
-			return;
-		for (var i = 0; i < 10; i++) {
-			var folder = new Folder(parent, i);
-			parent.children.push(folder);
-			createFolders(folder, recursion - 1);
-		}
-	}
+    function createFolders(parent, recursion) {
+        if (recursion === 0) return
+        for (var i = 0; i < 10; i++) {
+            var folder = new Folder(parent, i)
+            parent.children.push(folder)
+            createFolders(folder, recursion - 1)
+        }
+    }
 
-	measure("reactive folder tree [total]\n", () => {
-		measure("create folders", () => createFolders(state.root, 3)); // 10^3
-		measure("create displayfolders", () => state.displayRoot = transformFolder(state.root));
-		measure("create text", () => {
-			state.displayRoot.rebuildAll();
-			state.text = state.displayRoot.asText.split("\n");
-			t.equal(state.text.length, 1112);
-			t.equal(state.text[0], "root");
-			t.equal(state.text[state.text.length - 2], "root/9/9/9");
-		});
+    measure("reactive folder tree [total]\n", () => {
+        measure("create folders", () => createFolders(state.root, 3)) // 10^3
+        measure("create displayfolders", () => (state.displayRoot = transformFolder(state.root)))
+        measure("create text", () => {
+            state.displayRoot.rebuildAll()
+            state.text = state.displayRoot.asText.split("\n")
+            t.equal(state.text.length, 1112)
+            t.equal(state.text[0], "root")
+            t.equal(state.text[state.text.length - 2], "root/9/9/9")
+        })
 
-		measure("collapse folder", () => {
-			state.displayRoot.children[9].collapsed = true;
-			state.displayRoot.children[9].rebuild();
-			state.displayRoot.rebuild();
-			state.text = state.displayRoot.asText.split("\n");
-			t.equal(state.text.length, 1002);
-			t.equal(state.text[state.text.length - 3], "root/8/9/9");
-			t.equal(state.text[state.text.length - 2], "root/9");
-		});
+        measure("collapse folder", () => {
+            state.displayRoot.children[9].collapsed = true
+            state.displayRoot.children[9].rebuild()
+            state.displayRoot.rebuild()
+            state.text = state.displayRoot.asText.split("\n")
+            t.equal(state.text.length, 1002)
+            t.equal(state.text[state.text.length - 3], "root/8/9/9")
+            t.equal(state.text[state.text.length - 2], "root/9")
+        })
 
-		measure("uncollapse folder", () => {
-			state.displayRoot.children[9].collapsed = false;
-			state.displayRoot.children[9].rebuild();
-			state.displayRoot.rebuild();
-			state.text = state.displayRoot.asText.split("\n");
-			t.equal(state.text.length, 1112);
-			t.equal(state.text[state.text.length - 2], "root/9/9/9");
-		});
+        measure("uncollapse folder", () => {
+            state.displayRoot.children[9].collapsed = false
+            state.displayRoot.children[9].rebuild()
+            state.displayRoot.rebuild()
+            state.text = state.displayRoot.asText.split("\n")
+            t.equal(state.text.length, 1112)
+            t.equal(state.text[state.text.length - 2], "root/9/9/9")
+        })
 
-		measure("change name of folder", () => {
-			state.root.name = "wow";
-			state.displayRoot.rebuildAll();
-			state.text = state.displayRoot.asText.split("\n");
-			t.equal(state.text.length, 1112);
-			t.equal(state.text[state.text.length - 2], "wow/9/9/9");
-		});
+        measure("change name of folder", () => {
+            state.root.name = "wow"
+            state.displayRoot.rebuildAll()
+            state.text = state.displayRoot.asText.split("\n")
+            t.equal(state.text.length, 1112)
+            t.equal(state.text[state.text.length - 2], "wow/9/9/9")
+        })
 
-		measure("search", () => {
-			state.filter = "8";
-			state.displayRoot.rebuildAll();
-			state.text = state.displayRoot.asText.split("\n");
-			t.deepEqual(state.text.slice(0, 4), [ 'wow', 'wow/0', 'wow/0/0', 'wow/0/0/8' ]);
-			t.deepEqual(state.text.slice(-5), [ 'wow/9/8', 'wow/9/8/8', 'wow/9/9', 'wow/9/9/8', '' ]);
-			t.equal(state.text.length, 212);
-		});
+        measure("search", () => {
+            state.filter = "8"
+            state.displayRoot.rebuildAll()
+            state.text = state.displayRoot.asText.split("\n")
+            t.deepEqual(state.text.slice(0, 4), ["wow", "wow/0", "wow/0/0", "wow/0/0/8"])
+            t.deepEqual(state.text.slice(-5), ["wow/9/8", "wow/9/8/8", "wow/9/9", "wow/9/9/8", ""])
+            t.equal(state.text.length, 212)
+        })
 
-		measure("unsearch", () => {
-			state.filter = null;
-			state.displayRoot.rebuildAll();
-			state.text = state.displayRoot.asText.split("\n");
-			t.equal(state.text.length, 1112);
-		});
-	});
+        measure("unsearch", () => {
+            state.filter = null
+            state.displayRoot.rebuildAll()
+            state.text = state.displayRoot.asText.split("\n")
+            t.equal(state.text.length, 1112)
+        })
+    })
 
-	t.end();
-});
+    t.end()
+})
 
-test('reactive folder tree', function(t) {
-	gc();
-	function Folder(parent, name) {
-		this.parent = parent;
-		m.extendObservable(this, {
-			name: "" + name,
-			children: m.observable([]),
-		});
-	}
+test("reactive folder tree", function(t) {
+    gc()
+    function Folder(parent, name) {
+        this.parent = parent
+        m.extendObservable(this, {
+            name: "" + name,
+            children: m.observable([])
+        })
+    }
 
-	function DisplayFolder(folder, state) {
-		this.state = state;
-		this.folder = folder;
-		m.extendObservable(this, {
-			collapsed: false,
-			get name() {
-				return this.folder.name;
-			},
-			get isVisible() {
-				return !this.state.filter || this.name.indexOf(this.state.filter) !== -1 || this.children.some(child => child.isVisible);
-			},
-			get children() {
-				if (this.collapsed)
-					return [];
-				return this.folder.children.map(transformFolder).filter(function(child) {
-					return child.isVisible;
-				})
-			},
-			get path() {
-				return this.folder.parent === null ? this.name : transformFolder(this.folder.parent).path + "/" + this.name;
-			}
-		});
-	}
+    function DisplayFolder(folder, state) {
+        this.state = state
+        this.folder = folder
+        m.extendObservable(this, {
+            collapsed: false,
+            get name() {
+                return this.folder.name
+            },
+            get isVisible() {
+                return (
+                    !this.state.filter ||
+                    this.name.indexOf(this.state.filter) !== -1 ||
+                    this.children.some(child => child.isVisible)
+                )
+            },
+            get children() {
+                if (this.collapsed) return []
+                return this.folder.children.map(transformFolder).filter(function(child) {
+                    return child.isVisible
+                })
+            },
+            get path() {
+                return this.folder.parent === null
+                    ? this.name
+                    : transformFolder(this.folder.parent).path + "/" + this.name
+            }
+        })
+    }
 
-	var state = m.observable({
-		root: new Folder(null, "root"),
-		filter: null,
-		displayRoot: null
-	});
+    var state = m.observable({
+        root: new Folder(null, "root"),
+        filter: null,
+        displayRoot: null
+    })
 
-	var transformFolder = m.createTransformer(function (folder) {
-		return new DisplayFolder(folder, state);
-	});
+    var transformFolder = m.createTransformer(function(folder) {
+        return new DisplayFolder(folder, state)
+    })
 
-	// returns list of strings per folder
-	var stringTransformer = m.createTransformer(function (displayFolder) {
-		var path = displayFolder.path;
-		return path + "\n" +
-			displayFolder.children.filter(function(child) {
-				return child.isVisible;
-			}).map(stringTransformer).join('');
-	});
+    // returns list of strings per folder
+    var stringTransformer = m.createTransformer(function(displayFolder) {
+        var path = displayFolder.path
+        return (
+            path +
+            "\n" +
+            displayFolder.children
+                .filter(function(child) {
+                    return child.isVisible
+                })
+                .map(stringTransformer)
+                .join("")
+        )
+    })
 
-	function createFolders(parent, recursion) {
-		if (recursion === 0)
-			return;
-		for (var i = 0; i < 10; i++) {
-			var folder = new Folder(parent, i);
-			parent.children.push(folder);
-			createFolders(folder, recursion - 1);
-		}
-	}
+    function createFolders(parent, recursion) {
+        if (recursion === 0) return
+        for (var i = 0; i < 10; i++) {
+            var folder = new Folder(parent, i)
+            parent.children.push(folder)
+            createFolders(folder, recursion - 1)
+        }
+    }
 
-	measure("reactive folder tree [total]\n", () => {
-		measure("create folders", () => createFolders(state.root, 3)); // 10^3
-		measure("create displayfolders", () => state.displayRoot = transformFolder(state.root));
-		measure("create text", () => {
-			m.autorun(function() {
-				state.text = stringTransformer(state.displayRoot).split("\n");
-			});
-			t.equal(state.text.length, 1112);
-			t.equal(state.text[0], "root");
-			t.equal(state.text[state.text.length - 2], "root/9/9/9");
-		});
+    measure("reactive folder tree [total]\n", () => {
+        measure("create folders", () => createFolders(state.root, 3)) // 10^3
+        measure("create displayfolders", () => (state.displayRoot = transformFolder(state.root)))
+        measure("create text", () => {
+            m.autorun(function() {
+                state.text = stringTransformer(state.displayRoot).split("\n")
+            })
+            t.equal(state.text.length, 1112)
+            t.equal(state.text[0], "root")
+            t.equal(state.text[state.text.length - 2], "root/9/9/9")
+        })
 
-		measure("collapse folder", () => {
-			state.displayRoot.children[9].collapsed = true;
-			t.equal(state.text.length, 1002);
-			t.equal(state.text[state.text.length - 3], "root/8/9/9");
-			t.equal(state.text[state.text.length - 2], "root/9");
-		});
+        measure("collapse folder", () => {
+            state.displayRoot.children[9].collapsed = true
+            t.equal(state.text.length, 1002)
+            t.equal(state.text[state.text.length - 3], "root/8/9/9")
+            t.equal(state.text[state.text.length - 2], "root/9")
+        })
 
-		measure("uncollapse folder", () => {
-			state.displayRoot.children[9].collapsed = false;
-			t.equal(state.text.length, 1112);
-			t.equal(state.text[state.text.length - 2], "root/9/9/9");
-		});
+        measure("uncollapse folder", () => {
+            state.displayRoot.children[9].collapsed = false
+            t.equal(state.text.length, 1112)
+            t.equal(state.text[state.text.length - 2], "root/9/9/9")
+        })
 
-		measure("change name of folder", () => {
-			state.root.name = "wow";
-			t.equal(state.text.length, 1112);
-			t.equal(state.text[state.text.length - 2], "wow/9/9/9");
-		});
+        measure("change name of folder", () => {
+            state.root.name = "wow"
+            t.equal(state.text.length, 1112)
+            t.equal(state.text[state.text.length - 2], "wow/9/9/9")
+        })
 
-		measure("search", () => {
-			state.filter = "8";
-			t.deepEqual(state.text.slice(0, 4), [ 'wow', 'wow/0', 'wow/0/0', 'wow/0/0/8' ]);
-			t.deepEqual(state.text.slice(-5), [ 'wow/9/8', 'wow/9/8/8', 'wow/9/9', 'wow/9/9/8', '' ]);
-			t.equal(state.text.length, 212);
-		});
+        measure("search", () => {
+            state.filter = "8"
+            t.deepEqual(state.text.slice(0, 4), ["wow", "wow/0", "wow/0/0", "wow/0/0/8"])
+            t.deepEqual(state.text.slice(-5), ["wow/9/8", "wow/9/8/8", "wow/9/9", "wow/9/9/8", ""])
+            t.equal(state.text.length, 212)
+        })
 
-		measure("unsearch", () => {
-			state.filter = null;
-			t.equal(state.text.length, 1112);
-		});
-	});
+        measure("unsearch", () => {
+            state.filter = null
+            t.equal(state.text.length, 1112)
+        })
+    })
 
-	t.end();
-});
+    t.end()
+})
 
-var BOX_COUNT = 10000;
-var BOX_MUTATIONS = 100;
+var BOX_COUNT = 10000
+var BOX_MUTATIONS = 100
 
-test('non-reactive state serialization', function(t) {
-	gc();
-	serializationTester(t, x => x);
-});
+test("non-reactive state serialization", function(t) {
+    gc()
+    serializationTester(t, x => x)
+})
 
-test('reactive state serialization', function(t) {
-	gc();
-	serializationTester(t, m.createTransformer);
-});
+test("reactive state serialization", function(t) {
+    gc()
+    serializationTester(t, m.createTransformer)
+})
 
 function serializationTester(t, transformerFactory) {
-	function Box(x, y) {
-		m.extendObservable(this, {
-			x: x,
-			y: y
-		});
-	}
+    function Box(x, y) {
+        m.extendObservable(this, {
+            x: x,
+            y: y
+        })
+    }
 
-	var boxes = m.observable([]);
-	var states = [];
+    var boxes = m.observable([])
+    var states = []
 
-	var serializeBox = transformerFactory(box => {
-		return { x: box.x, y: box.y };
-	});
+    var serializeBox = transformerFactory(box => {
+        return { x: box.x, y: box.y }
+    })
 
-	var serializeBoxes = transformerFactory(boxes => {
-		// NB. would be a lot faster if partitioning or liveMap would be applied..!
-		return boxes.map(serializeBox);
-	})
+    var serializeBoxes = transformerFactory(boxes => {
+        // NB. would be a lot faster if partitioning or liveMap would be applied..!
+        return boxes.map(serializeBox)
+    })
 
-	measure("total", () => {
-		measure("create boxes", () => {
-			for(var i = 0; i < BOX_COUNT; i++)
-				boxes.push(new Box(i, i));
-		});
+    measure("total", () => {
+        measure("create boxes", () => {
+            for (var i = 0; i < BOX_COUNT; i++) boxes.push(new Box(i, i))
+        })
 
-		m.autorun(() => {
-			states.push(serializeBoxes(boxes));
-		});
+        m.autorun(() => {
+            states.push(serializeBoxes(boxes))
+        })
 
-		measure("mutations", () => {
-			for(var i = 0; i < BOX_MUTATIONS; i++)
-				boxes[boxes.length -1 - BOX_MUTATIONS][i % 2 === 0 ? "x" : "y"] = i * 3;
-		});
+        measure("mutations", () => {
+            for (var i = 0; i < BOX_MUTATIONS; i++)
+                boxes[boxes.length - 1 - BOX_MUTATIONS][i % 2 === 0 ? "x" : "y"] = i * 3
+        })
 
-		t.equal(boxes.length, BOX_COUNT);
-		t.equal(states.length, BOX_MUTATIONS + 1);
-		t.equal(states[states.length -1].length, BOX_COUNT);
-	});
+        t.equal(boxes.length, BOX_COUNT)
+        t.equal(states.length, BOX_MUTATIONS + 1)
+        t.equal(states[states.length - 1].length, BOX_COUNT)
+    })
 
-	t.end();
+    t.end()
 }

--- a/test/reaction.js
+++ b/test/reaction.js
@@ -1,356 +1,407 @@
-var test = require('tape')
-var mobx = require('..')
+var test = require("tape")
+var mobx = require("..")
 var reaction = mobx.reaction
 
-test('basic', t => {
-	var a = mobx.observable(1);
-	var values = [];
+test("basic", t => {
+    var a = mobx.observable(1)
+    var values = []
 
-	var d = reaction(() => a.get(), newValue => {
-		values.push(newValue);
-	})
+    var d = reaction(
+        () => a.get(),
+        newValue => {
+            values.push(newValue)
+        }
+    )
 
-	a.set(2);
-	a.set(3);
-	d();
-	a.set(4);
+    a.set(2)
+    a.set(3)
+    d()
+    a.set(4)
 
-	t.deepEqual(values, [2, 3]);
-	t.end();
+    t.deepEqual(values, [2, 3])
+    t.end()
 })
 
-test('effect fireImmediately is honored', t => {
-	var a = mobx.observable(1);
-	var values = [];
+test("effect fireImmediately is honored", t => {
+    var a = mobx.observable(1)
+    var values = []
 
-	var d = reaction(() => a.get(), newValue => {
-		values.push(newValue);
-	}, true)
+    var d = reaction(
+        () => a.get(),
+        newValue => {
+            values.push(newValue)
+        },
+        true
+    )
 
-	a.set(2);
-	a.set(3);
-	d();
-	a.set(4);
+    a.set(2)
+    a.set(3)
+    d()
+    a.set(4)
 
-	t.deepEqual(values, [1, 2, 3]);
-	t.end()
+    t.deepEqual(values, [1, 2, 3])
+    t.end()
 })
 
-test('effect is untracked', t => {
-	var a = mobx.observable(1);
-	var b =  mobx.observable(2);
-	var values = [];
+test("effect is untracked", t => {
+    var a = mobx.observable(1)
+    var b = mobx.observable(2)
+    var values = []
 
-	var d = reaction(() => a.get(), newValue => {
-		values.push(newValue * b.get());
-	}, true)
+    var d = reaction(
+        () => a.get(),
+        newValue => {
+            values.push(newValue * b.get())
+        },
+        true
+    )
 
-	a.set(2);
-	b.set(7); // shoudn't trigger a new change
-	a.set(3);
-	d();
-	a.set(4);
+    a.set(2)
+    b.set(7) // shoudn't trigger a new change
+    a.set(3)
+    d()
+    a.set(4)
 
-	t.deepEqual(values, [2, 4, 21]);
-	t.end()
+    t.deepEqual(values, [2, 4, 21])
+    t.end()
 })
 
-test('effect debounce is honored', t => {
-	t.plan(2)
+test("effect debounce is honored", t => {
+    t.plan(2)
 
-	var a = mobx.observable(1);
-	var values = [];
-	var exprCount = 0;
+    var a = mobx.observable(1)
+    var values = []
+    var exprCount = 0
 
-	var d = reaction(() => {
-		exprCount ++;
-		return a.get()
-	}, newValue => {
-		values.push(newValue);
-	}, {
-		delay: 100
-	})
+    var d = reaction(
+        () => {
+            exprCount++
+            return a.get()
+        },
+        newValue => {
+            values.push(newValue)
+        },
+        {
+            delay: 100
+        }
+    )
 
-	setTimeout(() => a.set(2), 30);
-	setTimeout(() => a.set(3), 150); // should not be visible, combined with the next
-	setTimeout(() => a.set(4), 160);
-	setTimeout(() => a.set(5), 300);
-	setTimeout(() => d(), 500);
-	setTimeout(() => a.set(6), 700);
+    setTimeout(() => a.set(2), 30)
+    setTimeout(() => a.set(3), 150) // should not be visible, combined with the next
+    setTimeout(() => a.set(4), 160)
+    setTimeout(() => a.set(5), 300)
+    setTimeout(() => d(), 500)
+    setTimeout(() => a.set(6), 700)
 
-	setTimeout(() => {
-		t.deepEqual(values, [2, 4, 5])
-		t.equal(exprCount, 4)
-	}, 900)
+    setTimeout(() => {
+        t.deepEqual(values, [2, 4, 5])
+        t.equal(exprCount, 4)
+    }, 900)
 })
 
-test('effect debounce + fire immediately is honored', t => {
-	t.plan(2)
+test("effect debounce + fire immediately is honored", t => {
+    t.plan(2)
 
-	var a = mobx.observable(1);
-	var values = [];
-	var exprCount = 0;
+    var a = mobx.observable(1)
+    var values = []
+    var exprCount = 0
 
-	var d = reaction(() => {
-		exprCount ++;
-		return a.get()
-	}, newValue => {
-		values.push(newValue);
-	}, {
-		fireImmediately: true,
-		delay: 100
-	})
+    var d = reaction(
+        () => {
+            exprCount++
+            return a.get()
+        },
+        newValue => {
+            values.push(newValue)
+        },
+        {
+            fireImmediately: true,
+            delay: 100
+        }
+    )
 
-	setTimeout(() => a.set(3), 150);
-	setTimeout(() => a.set(4), 300);
+    setTimeout(() => a.set(3), 150)
+    setTimeout(() => a.set(4), 300)
 
-	setTimeout(() => {
-		d();
-		t.deepEqual(values, [1, 3, 4]);
-		t.equal(exprCount, 3)
-	}, 500)
+    setTimeout(() => {
+        d()
+        t.deepEqual(values, [1, 3, 4])
+        t.equal(exprCount, 3)
+    }, 500)
 })
 
-test('passes Reaction as an argument to expression function', t => {
-	var a = mobx.observable(1);
-	var values = [];
+test("passes Reaction as an argument to expression function", t => {
+    var a = mobx.observable(1)
+    var values = []
 
-	reaction(r => {
-		if (a.get() === 'pleaseDispose') r.dispose();
-		return a.get();
-	}, newValue => {
-		values.push(newValue);
-	}, true);
+    reaction(
+        r => {
+            if (a.get() === "pleaseDispose") r.dispose()
+            return a.get()
+        },
+        newValue => {
+            values.push(newValue)
+        },
+        true
+    )
 
-	a.set(2);
-	a.set(2);
-	a.set('pleaseDispose');
-	a.set(3);
-	a.set(4);
+    a.set(2)
+    a.set(2)
+    a.set("pleaseDispose")
+    a.set(3)
+    a.set(4)
 
-	t.deepEqual(values, [1, 2, 'pleaseDispose']);
-	t.end();
-});
+    t.deepEqual(values, [1, 2, "pleaseDispose"])
+    t.end()
+})
 
-test('passes Reaction as an argument to effect function', t => {
-	var a = mobx.observable(1);
-	var values = [];
+test("passes Reaction as an argument to effect function", t => {
+    var a = mobx.observable(1)
+    var values = []
 
-	reaction(() => a.get(), (newValue, r) => {
-		if (a.get() === 'pleaseDispose') r.dispose();
-		values.push(newValue);
-	}, true);
+    reaction(
+        () => a.get(),
+        (newValue, r) => {
+            if (a.get() === "pleaseDispose") r.dispose()
+            values.push(newValue)
+        },
+        true
+    )
 
-	a.set(2);
-	a.set(2);
-	a.set('pleaseDispose');
-	a.set(3);
-	a.set(4);
+    a.set(2)
+    a.set(2)
+    a.set("pleaseDispose")
+    a.set(3)
+    a.set(4)
 
-	t.deepEqual(values, [1, 2, 'pleaseDispose']);
-	t.end();
-});
+    t.deepEqual(values, [1, 2, "pleaseDispose"])
+    t.end()
+})
 
-test('can dispose reaction on first run', t => {
-	var a = mobx.observable(1);
+test("can dispose reaction on first run", t => {
+    var a = mobx.observable(1)
 
-	var valuesExpr1st = [];
-	reaction(() => a.get(), (newValue, r) => {
-		r.dispose();
-		valuesExpr1st.push(newValue);
-	}, true);
+    var valuesExpr1st = []
+    reaction(
+        () => a.get(),
+        (newValue, r) => {
+            r.dispose()
+            valuesExpr1st.push(newValue)
+        },
+        true
+    )
 
-	var valuesEffect1st = [];
-	reaction(r => {
-		r.dispose();
-		return a.get();
-	}, newValue => {
-		valuesEffect1st.push(newValue);
-	}, true);
+    var valuesEffect1st = []
+    reaction(
+        r => {
+            r.dispose()
+            return a.get()
+        },
+        newValue => {
+            valuesEffect1st.push(newValue)
+        },
+        true
+    )
 
-	var valuesExpr = [];
-	reaction(() => a.get(), (newValue, r) => {
-		r.dispose();
-		valuesExpr.push(newValue);
-	});
+    var valuesExpr = []
+    reaction(
+        () => a.get(),
+        (newValue, r) => {
+            r.dispose()
+            valuesExpr.push(newValue)
+        }
+    )
 
-	var valuesEffect = [];
-	reaction(r => {
-		r.dispose();
-		return a.get();
-	}, newValue => {
-		valuesEffect.push(newValue);
-	});
+    var valuesEffect = []
+    reaction(
+        r => {
+            r.dispose()
+            return a.get()
+        },
+        newValue => {
+            valuesEffect.push(newValue)
+        }
+    )
 
-	a.set(2);
-	a.set(3);
+    a.set(2)
+    a.set(3)
 
-	t.deepEqual(valuesExpr1st, [1]);
-	t.deepEqual(valuesEffect1st, [1]);
-	t.deepEqual(valuesExpr, [2]);
-	t.deepEqual(valuesEffect, []);
-	t.end();
-});
+    t.deepEqual(valuesExpr1st, [1])
+    t.deepEqual(valuesEffect1st, [1])
+    t.deepEqual(valuesExpr, [2])
+    t.deepEqual(valuesEffect, [])
+    t.end()
+})
 
 test("#278 do not rerun if expr output doesn't change", t => {
-	var a = mobx.observable(1);
-	var values = [];
+    var a = mobx.observable(1)
+    var values = []
 
-	var d = reaction(() => a.get() < 10 ? a.get() : 11, newValue => {
-		values.push(newValue);
-	})
+    var d = reaction(
+        () => (a.get() < 10 ? a.get() : 11),
+        newValue => {
+            values.push(newValue)
+        }
+    )
 
-	a.set(2);
-	a.set(3);
-	a.set(10);
-	a.set(11);
-	a.set(12);
-	a.set(4);
-	a.set(5);
-	a.set(13);
+    a.set(2)
+    a.set(3)
+    a.set(10)
+    a.set(11)
+    a.set(12)
+    a.set(4)
+    a.set(5)
+    a.set(13)
 
-	d();
-	a.set(4);
+    d()
+    a.set(4)
 
-	t.deepEqual(values, [2, 3, 11, 4, 5, 11]);
-	t.end();
+    t.deepEqual(values, [2, 3, 11, 4, 5, 11])
+    t.end()
 })
 
 test("#278 do not rerun if expr output doesn't change structurally", t => {
-	var users = mobx.observable([
-		{
-			name: "jan",
-			get uppername() { return this.name.toUpperCase() }
-		},
-		{
-			name: "piet",
-			get uppername() { return this.name.toUpperCase() }
-		}
-	]);
-	var values = [];
+    var users = mobx.observable([
+        {
+            name: "jan",
+            get uppername() {
+                return this.name.toUpperCase()
+            }
+        },
+        {
+            name: "piet",
+            get uppername() {
+                return this.name.toUpperCase()
+            }
+        }
+    ])
+    var values = []
 
-	var d = reaction(
-		() => users.map(user => user.uppername),
-		newValue => {
-			values.push(newValue);
-		},
-		{
-			fireImmediately: true,
-			compareStructural: true
-		}
-	)
+    var d = reaction(
+        () => users.map(user => user.uppername),
+        newValue => {
+            values.push(newValue)
+        },
+        {
+            fireImmediately: true,
+            compareStructural: true
+        }
+    )
 
-	users[0].name = "john";
-	users[0].name = "JoHn";
-	users[0].name = "jOHN";
-	users[1].name = "johan";
+    users[0].name = "john"
+    users[0].name = "JoHn"
+    users[0].name = "jOHN"
+    users[1].name = "johan"
 
-	d();
-	users[1].name = "w00t";
+    d()
+    users[1].name = "w00t"
 
-	t.deepEqual(values, [
-		["JAN", "PIET"],
-		["JOHN", "PIET"],
-		["JOHN", "JOHAN"]
-	]);
-	t.end();
+    t.deepEqual(values, [["JAN", "PIET"], ["JOHN", "PIET"], ["JOHN", "JOHAN"]])
+    t.end()
 })
 
 test("do not rerun if prev & next expr output is NaN", t => {
-	var v = mobx.observable('a');
-	var values = [];
-	var valuesS = [];
+    var v = mobx.observable("a")
+    var values = []
+    var valuesS = []
 
-	var d = reaction(
-		() => v.get(),
-		newValue => { values.push(String(newValue)); },
-		{ fireImmediately: true, }
-	);
-	var dd = reaction(
-		() => v.get(),
-		newValue => { valuesS.push(String(newValue)); },
-		{ fireImmediately: true, compareStructural: true }
-	);
+    var d = reaction(
+        () => v.get(),
+        newValue => {
+            values.push(String(newValue))
+        },
+        { fireImmediately: true }
+    )
+    var dd = reaction(
+        () => v.get(),
+        newValue => {
+            valuesS.push(String(newValue))
+        },
+        { fireImmediately: true, compareStructural: true }
+    )
 
-	v.set(NaN);
-	v.set(NaN);
-	v.set(NaN);
-	v.set('b');
+    v.set(NaN)
+    v.set(NaN)
+    v.set(NaN)
+    v.set("b")
 
-	d();
-	dd();
+    d()
+    dd()
 
-	t.deepEqual(values, [ 'a', 'NaN', 'b']);
-	t.deepEqual(valuesS, [ 'a', 'NaN', 'b']);
-	t.end();
+    t.deepEqual(values, ["a", "NaN", "b"])
+    t.deepEqual(valuesS, ["a", "NaN", "b"])
+    t.end()
 })
 
 test("reaction uses equals", t => {
-	const o = mobx.observable("a");
-	const values = [];
-	const disposeReaction = mobx.reaction(
-		() => o.get(),
-		(value) => values.push(value.toLowerCase()),
-		{ equals: (from, to) => from.toUpperCase() === to.toUpperCase(), fireImmediately: true }
-	);
-	t.deepEqual(values, ["a"]);
-	o.set("A");
-	t.deepEqual(values, ["a"]);
-	o.set("B");
-	t.deepEqual(values, ["a", "b"]);
-	o.set("A");
-	t.deepEqual(values, ["a", "b", "a"]);
+    const o = mobx.observable("a")
+    const values = []
+    const disposeReaction = mobx.reaction(
+        () => o.get(),
+        value => values.push(value.toLowerCase()),
+        { equals: (from, to) => from.toUpperCase() === to.toUpperCase(), fireImmediately: true }
+    )
+    t.deepEqual(values, ["a"])
+    o.set("A")
+    t.deepEqual(values, ["a"])
+    o.set("B")
+    t.deepEqual(values, ["a", "b"])
+    o.set("A")
+    t.deepEqual(values, ["a", "b", "a"])
 
-	disposeReaction();
+    disposeReaction()
 
-	t.end();
-});
-
+    t.end()
+})
 
 test("reaction equals function only invoked when necessary", t => {
-	const comparisons = [];
-	const loggingComparer = (from, to) => {
-		comparisons.push({ from, to });
-		return from === to;
-	};
+    const comparisons = []
+    const loggingComparer = (from, to) => {
+        comparisons.push({ from, to })
+        return from === to
+    }
 
-	const left = mobx.observable("A");
-	const right = mobx.observable("B");
+    const left = mobx.observable("A")
+    const right = mobx.observable("B")
 
-	const values = [];
-	const disposeReaction = mobx.reaction(
-		() => left.get().toLowerCase() + right.get().toLowerCase(),
-		(value) => values.push(value),
-		{ equals: loggingComparer, fireImmediately: true }
-	);
+    const values = []
+    const disposeReaction = mobx.reaction(
+        () => left.get().toLowerCase() + right.get().toLowerCase(),
+        value => values.push(value),
+        { equals: loggingComparer, fireImmediately: true }
+    )
 
-	// No comparison should be made on the first value
-	t.deepEqual(comparisons, []);
+    // No comparison should be made on the first value
+    t.deepEqual(comparisons, [])
 
-	// First change will cause a comparison
-	left.set("C");
-	t.deepEqual(comparisons, [{ from: "ab", to: "cb" }]);
+    // First change will cause a comparison
+    left.set("C")
+    t.deepEqual(comparisons, [{ from: "ab", to: "cb" }])
 
-	// Exception in the reaction expression won't cause a comparison
-	left.set(null);
-	t.deepEqual(comparisons, [{ from: "ab", to: "cb" }]);
+    // Exception in the reaction expression won't cause a comparison
+    left.set(null)
+    t.deepEqual(comparisons, [{ from: "ab", to: "cb" }])
 
-	// Another exception in the reaction expression won't cause a comparison
-	right.set(null);
-	t.deepEqual(comparisons, [{ from: "ab", to: "cb" }]);
+    // Another exception in the reaction expression won't cause a comparison
+    right.set(null)
+    t.deepEqual(comparisons, [{ from: "ab", to: "cb" }])
 
-	// Transition from exception in the expression will cause a comparison with the last valid value
-	left.set("D");
-	right.set("E");
-	t.deepEqual(comparisons, [{ from: "ab", to: "cb" }, { from: 'cb', to: 'de' }]);
+    // Transition from exception in the expression will cause a comparison with the last valid value
+    left.set("D")
+    right.set("E")
+    t.deepEqual(comparisons, [{ from: "ab", to: "cb" }, { from: "cb", to: "de" }])
 
-	// Another value change will cause a comparison
-	right.set("F");
-	t.deepEqual(comparisons, [{ from: "ab", to: "cb" }, { from: 'cb', to: 'de' }, { from: "de", to: "df" }]);
+    // Another value change will cause a comparison
+    right.set("F")
+    t.deepEqual(comparisons, [
+        { from: "ab", to: "cb" },
+        { from: "cb", to: "de" },
+        { from: "de", to: "df" }
+    ])
 
-	t.deepEqual(values, ["ab", "cb", "de", "df"]);
+    t.deepEqual(values, ["ab", "cb", "de", "df"])
 
-	disposeReaction();
+    disposeReaction()
 
-	t.end();
-});
+    t.end()
+})

--- a/test/spy.js
+++ b/test/spy.js
@@ -1,172 +1,205 @@
 "use strict"
-var test = require('tape');
-var mobx = require('..');
+var test = require("tape")
+var mobx = require("..")
 
-test('spy output', t => {
-	var events = [];
+test("spy output", t => {
+    var events = []
 
-	var stop = mobx.spy(c => events.push(c));
+    var stop = mobx.spy(c => events.push(c))
 
-	doStuff();
+    doStuff()
 
-	stop();
+    stop()
 
-	doStuff();
+    doStuff()
 
-	events.forEach(ev => { delete ev.object; delete ev.fn; delete ev.time; });
+    events.forEach(ev => {
+        delete ev.object
+        delete ev.fn
+        delete ev.time
+    })
 
-	t.equal(events.length, doStuffEvents.length, "amount of events doesn't match");
-	//t.deepEqual(events, doStuffEvents);
+    t.equal(events.length, doStuffEvents.length, "amount of events doesn't match")
+    //t.deepEqual(events, doStuffEvents);
 
-	events.forEach((ev, idx) => {
-		t.deepEqual(ev, doStuffEvents[idx], "expected event #" + (1 + idx) + " to be equal");
-	});
+    events.forEach((ev, idx) => {
+        t.deepEqual(ev, doStuffEvents[idx], "expected event #" + (1 + idx) + " to be equal")
+    })
 
-	t.ok(events.filter(ev => ev.spyReportStart === true).length > 0, "spy report start count should be larger then zero");
+    t.ok(
+        events.filter(ev => ev.spyReportStart === true).length > 0,
+        "spy report start count should be larger then zero"
+    )
 
-	t.equal(
-		events.filter(ev => ev.spyReportStart === true).length,
-		events.filter(ev => ev.spyReportEnd === true).length,
-		"amount of start and end events differs"
-	);
+    t.equal(
+        events.filter(ev => ev.spyReportStart === true).length,
+        events.filter(ev => ev.spyReportEnd === true).length,
+        "amount of start and end events differs"
+    )
 
-	t.end();
+    t.end()
 })
 
 function doStuff() {
-	var a = mobx.observable(2);
-	a.set(3);
+    var a = mobx.observable(2)
+    a.set(3)
 
-	var b = mobx.observable({
-		c: 4
-	});
-	b.c = 5;
-	mobx.extendObservable(b, { d: 6 });
-	b.d =  7;
+    var b = mobx.observable({
+        c: 4
+    })
+    b.c = 5
+    mobx.extendObservable(b, { d: 6 })
+    b.d = 7
 
-	var e = mobx.observable([1, 2]);
-	e.push(3, 4);
-	e.shift();
-	e[2] = 5;
+    var e = mobx.observable([1, 2])
+    e.push(3, 4)
+    e.shift()
+    e[2] = 5
 
-	var f = mobx.map({ g: 1 });
-	f.delete("h");
-	f.delete("g");
-	f.set("i", 5);
-	f.set("i", 6);
+    var f = mobx.map({ g: 1 })
+    f.delete("h")
+    f.delete("g")
+    f.set("i", 5)
+    f.set("i", 6)
 
-	var j = mobx.computed(() => a.get() * 2);
+    var j = mobx.computed(() => a.get() * 2)
 
-	var stop = mobx.autorun(() => { j.get() });
+    var stop = mobx.autorun(() => {
+        j.get()
+    })
 
-	a.set(4);
+    a.set(4)
 
-	mobx.transaction(function myTransaction() {
-		a.set(5);
-		a.set(6);
-	});
+    mobx.transaction(function myTransaction() {
+        a.set(5)
+        a.set(6)
+    })
 
-	mobx.action("myTestAction", (newValue) => {
-		a.set(newValue)
-	}).call({}, 7);
+    mobx
+        .action("myTestAction", newValue => {
+            a.set(newValue)
+        })
+        .call({}, 7)
 }
 
-
-
-
-
-
-
 const doStuffEvents = [
-	{ newValue: 2, type: 'create' },
-	{ newValue: 3, oldValue: 2, type: 'update', spyReportStart: true },
-	{ spyReportEnd: true },
-	{ name: 'c', newValue: 4, spyReportStart: true, type: 'add' },
-	{ spyReportEnd: true },
-	{ name: 'c', newValue: 5, oldValue: 4, spyReportStart: true, type: 'update' },
-	{ spyReportEnd: true },
-	{ name: 'd', newValue: 6, spyReportStart: true, type: 'add' },
-	{ spyReportEnd: true },
-	{ name: 'd', newValue: 7, oldValue: 6, spyReportStart: true, type: 'update' },
-	{ spyReportEnd: true },
-	{ added: [ 1, 2 ], addedCount: 2, index: 0, removed: [], removedCount: 0, spyReportStart: true, type: 'splice' },
-	{ spyReportEnd: true },
-	{ added: [ 3, 4 ], addedCount: 2, index: 2, removed: [], removedCount: 0, spyReportStart: true, type: 'splice' },
-	{ spyReportEnd: true },
-	{ added: [], addedCount: 0, index: 0, removed: [ 1 ], removedCount: 1, spyReportStart: true, type: 'splice' },
-	{ spyReportEnd: true },
-	{ index: 2, newValue: 5, oldValue: 4, spyReportStart: true, type: 'update' },
-	{ spyReportEnd: true },
-	{ name: 'g', newValue: 1, spyReportStart: true, type: 'add' },
-	{ spyReportEnd: true },
-	{ name: 'g', oldValue: 1, spyReportStart: true, type: 'delete' },
-	{ spyReportEnd: true },
-	{ name: 'i', newValue: 5, spyReportStart: true, type: 'add' },
-	{ spyReportEnd: true },
-	{ name: 'i', newValue: 6, oldValue: 5, spyReportStart: true, type: 'update' },
-	{ spyReportEnd: true },
-	{ spyReportStart: true, type: 'reaction' },
-	{ type: 'compute' },
-	{ spyReportEnd: true },
-	{ newValue: 4, oldValue: 3, spyReportStart: true, type: 'update' },
-	{ type: 'compute' },
-	{ spyReportStart: true, type: 'reaction' },
-	{ spyReportEnd: true },
-	{ spyReportEnd: true },
-	{ newValue: 5, oldValue: 4, spyReportStart: true, type: 'update' },
-	{ spyReportEnd: true },
-	{ newValue: 6, oldValue: 5, spyReportStart: true, type: 'update' },
-	{ spyReportEnd: true },
-	{ type: 'compute' },
-	{ spyReportStart: true, type: 'reaction' },
-	{ spyReportEnd: true },
-	{ name: 'myTestAction', spyReportStart: true, arguments: [7], type: 'action' },
-	{ newValue: 7, oldValue: 6, spyReportStart: true, type: 'update' },
-	{ spyReportEnd: true },
-	{ type: 'compute' },
-	{ spyReportStart: true, type: 'reaction' },
-	{ spyReportEnd: true },
-	{ spyReportEnd: true }
+    { newValue: 2, type: "create" },
+    { newValue: 3, oldValue: 2, type: "update", spyReportStart: true },
+    { spyReportEnd: true },
+    { name: "c", newValue: 4, spyReportStart: true, type: "add" },
+    { spyReportEnd: true },
+    { name: "c", newValue: 5, oldValue: 4, spyReportStart: true, type: "update" },
+    { spyReportEnd: true },
+    { name: "d", newValue: 6, spyReportStart: true, type: "add" },
+    { spyReportEnd: true },
+    { name: "d", newValue: 7, oldValue: 6, spyReportStart: true, type: "update" },
+    { spyReportEnd: true },
+    {
+        added: [1, 2],
+        addedCount: 2,
+        index: 0,
+        removed: [],
+        removedCount: 0,
+        spyReportStart: true,
+        type: "splice"
+    },
+    { spyReportEnd: true },
+    {
+        added: [3, 4],
+        addedCount: 2,
+        index: 2,
+        removed: [],
+        removedCount: 0,
+        spyReportStart: true,
+        type: "splice"
+    },
+    { spyReportEnd: true },
+    {
+        added: [],
+        addedCount: 0,
+        index: 0,
+        removed: [1],
+        removedCount: 1,
+        spyReportStart: true,
+        type: "splice"
+    },
+    { spyReportEnd: true },
+    { index: 2, newValue: 5, oldValue: 4, spyReportStart: true, type: "update" },
+    { spyReportEnd: true },
+    { name: "g", newValue: 1, spyReportStart: true, type: "add" },
+    { spyReportEnd: true },
+    { name: "g", oldValue: 1, spyReportStart: true, type: "delete" },
+    { spyReportEnd: true },
+    { name: "i", newValue: 5, spyReportStart: true, type: "add" },
+    { spyReportEnd: true },
+    { name: "i", newValue: 6, oldValue: 5, spyReportStart: true, type: "update" },
+    { spyReportEnd: true },
+    { spyReportStart: true, type: "reaction" },
+    { type: "compute" },
+    { spyReportEnd: true },
+    { newValue: 4, oldValue: 3, spyReportStart: true, type: "update" },
+    { type: "compute" },
+    { spyReportStart: true, type: "reaction" },
+    { spyReportEnd: true },
+    { spyReportEnd: true },
+    { newValue: 5, oldValue: 4, spyReportStart: true, type: "update" },
+    { spyReportEnd: true },
+    { newValue: 6, oldValue: 5, spyReportStart: true, type: "update" },
+    { spyReportEnd: true },
+    { type: "compute" },
+    { spyReportStart: true, type: "reaction" },
+    { spyReportEnd: true },
+    { name: "myTestAction", spyReportStart: true, arguments: [7], type: "action" },
+    { newValue: 7, oldValue: 6, spyReportStart: true, type: "update" },
+    { spyReportEnd: true },
+    { type: "compute" },
+    { spyReportStart: true, type: "reaction" },
+    { spyReportEnd: true },
+    { spyReportEnd: true }
 ]
 
 test("spy error", t => {
-	mobx.extras.getGlobalState().mobxGuid = 0;
+    mobx.extras.getGlobalState().mobxGuid = 0
 
-	const a = mobx.observable({
-		x: 2,
-		get y() {
-			if (this.x === 3)
-				throw "Oops";
-			return this.x * 2;
-		}
-	})
+    const a = mobx.observable({
+        x: 2,
+        get y() {
+            if (this.x === 3) throw "Oops"
+            return this.x * 2
+        }
+    })
 
-	var events = [];
-	var stop = mobx.spy(c => events.push(c));
+    var events = []
+    var stop = mobx.spy(c => events.push(c))
 
-	var d = mobx.autorun("autorun", () => a.y)
+    var d = mobx.autorun("autorun", () => a.y)
 
-	a.x = 3;
+    a.x = 3
 
-	events.forEach(x => {
-		delete x.fn
-		delete x.object
-		delete x.time
-	})
+    events.forEach(x => {
+        delete x.fn
+        delete x.object
+        delete x.time
+    })
 
-	t.deepEqual(events, [
-		{ spyReportStart: true, type: 'reaction' },
-			{ type: 'compute' },
-		{ spyReportEnd: true },
-		{ name: 'x', newValue: 3, oldValue: 2, spyReportStart: true, type: 'update' },
-			{ type: 'compute' },
-			{ spyReportStart: true, type: 'reaction' },
-				{ error: 'Oops', message: '[mobx] Encountered an uncaught exception that was thrown by a reaction or observer component, in: \'Reaction[autorun]', type: 'error' },
-			{ spyReportEnd: true },
-		{ spyReportEnd: true }
-	]);
+    t.deepEqual(events, [
+        { spyReportStart: true, type: "reaction" },
+        { type: "compute" },
+        { spyReportEnd: true },
+        { name: "x", newValue: 3, oldValue: 2, spyReportStart: true, type: "update" },
+        { type: "compute" },
+        { spyReportStart: true, type: "reaction" },
+        {
+            error: "Oops",
+            message:
+                "[mobx] Encountered an uncaught exception that was thrown by a reaction or observer component, in: 'Reaction[autorun]",
+            type: "error"
+        },
+        { spyReportEnd: true },
+        { spyReportEnd: true }
+    ])
 
-	d();
-	stop();
-	t.end();
+    d()
+    stop()
+    t.end()
 })

--- a/test/state-sharing.js
+++ b/test/state-sharing.js
@@ -1,42 +1,48 @@
 "use strict"
-const test = require('tape');
+const test = require("tape")
 const child_process = require("child_process")
 
 function testOutput(t, cmd, expected) {
-	test("Global state sharing: " + cmd, t => {
-		const output = child_process.exec(
-			'node -e \'' + cmd + '\'',
-			{ cwd: __dirname },
-			(e, stdout, stderr) => {
-				if (e)
-					t.fail(e)
-				else {
-					t.equal(stdout.toString(), '')
-					t.equal(stderr.toString(), expected)
-					t.end()
-				}
-			}
-		);
-	})
+    test("Global state sharing: " + cmd, t => {
+        const output = child_process.exec(
+            "node -e '" + cmd + "'",
+            { cwd: __dirname },
+            (e, stdout, stderr) => {
+                if (e) t.fail(e)
+                else {
+                    t.equal(stdout.toString(), "")
+                    t.equal(stderr.toString(), expected)
+                    t.end()
+                }
+            }
+        )
+    })
 }
 
 test("it should handle multiple instances with the correct warnings", t => {
-	testOutput(t,
-		'require("..");require("../lib/mobx.umd.js")',
-		'[mobx] Warning: there are multiple mobx instances active. This might lead to unexpected results. See https://github.com/mobxjs/mobx/issues/1082 for details.\n'
-	);
-	testOutput(t,
-		'require("..").extras.shareGlobalState();require("../lib/mobx.umd.js")',
-		'[mobx] Deprecated: Using `shareGlobalState` is not recommended, use peer dependencies instead. See https://github.com/mobxjs/mobx/issues/1082 for details.' +
-		'\n[mobx] Warning: there are multiple mobx instances active. This might lead to unexpected results. See https://github.com/mobxjs/mobx/issues/1082 for details.\n'
-	);
-	testOutput(t,
-		'require("..").extras.shareGlobalState();require("../lib/mobx.umd.js").extras.shareGlobalState()',
-		'[mobx] Deprecated: Using `shareGlobalState` is not recommended, use peer dependencies instead. See https://github.com/mobxjs/mobx/issues/1082 for details.'+
-		'\n[mobx] Deprecated: Using `shareGlobalState` is not recommended, use peer dependencies instead. See https://github.com/mobxjs/mobx/issues/1082 for details.\n'
-	);
-	testOutput(t, 'require("..").extras.isolateGlobalState();require("../lib/mobx.umd.js").extras.isolateGlobalState()', '');
-	testOutput(t, 'require("..");require("../lib/mobx.umd.js").extras.isolateGlobalState()', '');
-	testOutput(t, 'require("..").extras.isolateGlobalState();require("../lib/mobx.umd.js")', '');
-	t.end();
+    testOutput(
+        t,
+        'require("..");require("../lib/mobx.umd.js")',
+        "[mobx] Warning: there are multiple mobx instances active. This might lead to unexpected results. See https://github.com/mobxjs/mobx/issues/1082 for details.\n"
+    )
+    testOutput(
+        t,
+        'require("..").extras.shareGlobalState();require("../lib/mobx.umd.js")',
+        "[mobx] Deprecated: Using `shareGlobalState` is not recommended, use peer dependencies instead. See https://github.com/mobxjs/mobx/issues/1082 for details." +
+            "\n[mobx] Warning: there are multiple mobx instances active. This might lead to unexpected results. See https://github.com/mobxjs/mobx/issues/1082 for details.\n"
+    )
+    testOutput(
+        t,
+        'require("..").extras.shareGlobalState();require("../lib/mobx.umd.js").extras.shareGlobalState()',
+        "[mobx] Deprecated: Using `shareGlobalState` is not recommended, use peer dependencies instead. See https://github.com/mobxjs/mobx/issues/1082 for details." +
+            "\n[mobx] Deprecated: Using `shareGlobalState` is not recommended, use peer dependencies instead. See https://github.com/mobxjs/mobx/issues/1082 for details.\n"
+    )
+    testOutput(
+        t,
+        'require("..").extras.isolateGlobalState();require("../lib/mobx.umd.js").extras.isolateGlobalState()',
+        ""
+    )
+    testOutput(t, 'require("..");require("../lib/mobx.umd.js").extras.isolateGlobalState()', "")
+    testOutput(t, 'require("..").extras.isolateGlobalState();require("../lib/mobx.umd.js")', "")
+    t.end()
 })

--- a/test/strict-mode.js
+++ b/test/strict-mode.js
@@ -1,197 +1,199 @@
-var test = require('tape');
-var mobx = require('../');
+var test = require("tape")
+var mobx = require("../")
 
-var strictError = /Since strict-mode is enabled, changing observed observable values outside actions is not allowed. Please wrap the code in an `action` if this change is intended. Tried to modify: /;
+var strictError = /Since strict-mode is enabled, changing observed observable values outside actions is not allowed. Please wrap the code in an `action` if this change is intended. Tried to modify: /
 
-test('strict mode should not allow changes outside action', t => {
-	var a = mobx.observable(2);
-	t.equal(mobx.isStrictModeEnabled(), false)
-	mobx.useStrict(true);
-	t.equal(mobx.isStrictModeEnabled(), true)
+test("strict mode should not allow changes outside action", t => {
+    var a = mobx.observable(2)
+    t.equal(mobx.isStrictModeEnabled(), false)
+    mobx.useStrict(true)
+    t.equal(mobx.isStrictModeEnabled(), true)
 
-	// allowed, a is not observed
-	t.doesNotThrow(() => a.set(3), strictError);
+    // allowed, a is not observed
+    t.doesNotThrow(() => a.set(3), strictError)
 
-	var d = mobx.autorun(() => a.get())
-	// not-allowed, a is observed
-	t.throws(() => a.set(3), strictError);
-	d()
+    var d = mobx.autorun(() => a.get())
+    // not-allowed, a is observed
+    t.throws(() => a.set(3), strictError)
+    d()
 
-	mobx.useStrict(false);
-	t.equal(mobx.isStrictModeEnabled(), false)
-	a.set(4);
-	t.equal(a.get(), 4);
-	t.end();
-});
-
-test('actions can modify observed state in strict mode', t => {
-	var a = mobx.observable(2);
-	var d = mobx.autorun(() => a.get())
-
-	mobx.useStrict(true);
-	mobx.action(() => {
-		a.set(3);
-		var b = mobx.observable(4);
-	})();
-
-	mobx.useStrict(false);
-	d()
-	t.end();
-});
-
-test('actions can modify non-observed state in strict mode', t => {
-	var a = mobx.observable(2);
-
-	mobx.useStrict(true);
-	mobx.action(() => {
-		a.set(3);
-		var b = mobx.observable(4);
-	})();
-
-	mobx.useStrict(false);
-	t.end();
-});
-
-test('reactions cannot modify state in strict mode', t => {
-	var a = mobx.observable(3);
-	var b = mobx.observable(4);
-	mobx.useStrict(true);
-	mobx.extras.resetGlobalState(); // should preserve strict mode
-
-	var bd = mobx.autorun(() => {
-		b.get(); // make sure it is observed
-	})
-
-	var d = mobx.autorun(() => {
-		t.throws(() => {
-			a.get();
-			b.set(3)
-		}, strictError);
-	});
-
-	d = mobx.autorun(() => {
-		if (a.get() > 5)
-			b.set(7);
-	});
-
-	mobx.action(() => a.set(4))(); // ok
-
-	t.throws(() => a.set(5), strictError);
-
-	mobx.useStrict(false);
-	d()
-	bd()
-	t.end();
-});
-
-
-test('action inside reaction in strict mode can modify state', t => {
-	var a = mobx.observable(1);
-	var b = mobx.observable(2);
-
-	var bd = mobx.autorun(() => {
-		b.get(); // make sure it is observed
-	})
-
-	mobx.useStrict(true);
-	var act = mobx.action(() => b.set(b.get() + 1));
-
-	var d = mobx.autorun(() => {
-		if (a.get() % 2 === 0)
-			act();
-		if (a.get() == 16) {
-			t.throws(() => b.set(55), strictError, "finishing act should restore strict mode again");
-		}
-	});
-
-	var setA = mobx.action(val => a.set(val));
-	t.equal(b.get(), 2);
-	setA(4);
-	t.equal(b.get(), 3);
-	setA(5);
-	t.equal(b.get(), 3);
-	setA(16);
-	t.equal(b.get(), 4, "b should not be 55");
-
-	mobx.useStrict(false);
-	bd()
-	d()
-	t.end();
-});
-
-test('cannot create or modify objects in strict mode without action', t => {
-	var obj = mobx.observable({a: 2});
-	var ar = mobx.observable([1]);
-	var map = mobx.map({ a: 2});
-
-	mobx.useStrict(true);
-
-	// introducing new observables is ok!
-	// mobx.observable({ a: 2, b: function() { return this.a }});
-	// mobx.observable({ b: function() { return this.a } });
-	// mobx.map({ a: 2});
-	// mobx.observable([1, 2, 3]);
-	// mobx.extendObservable(obj, { b: 4});
-
-	// t.throws(() => obj.a = 3, strictError);
-	// t.throws(() => ar[0] = 2, strictError);
-	// t.throws(() => ar.push(3), strictError);
-	// t.throws(() => map.set("a", 3), strictError);
-	// t.throws(() => map.set("b", 4), strictError);
-	// t.throws(() => map.delete("a"), strictError);
-
-	mobx.useStrict(false);
-
-	// can modify again
-	obj.a  = 42;
-
-	t.end();
+    mobx.useStrict(false)
+    t.equal(mobx.isStrictModeEnabled(), false)
+    a.set(4)
+    t.equal(a.get(), 4)
+    t.end()
 })
 
-test('can create objects in strict mode with action', t => {
-	var obj = mobx.observable({a: 2});
-	var ar = mobx.observable([1]);
-	var map = mobx.map({ a: 2});
+test("actions can modify observed state in strict mode", t => {
+    var a = mobx.observable(2)
+    var d = mobx.autorun(() => a.get())
 
-	mobx.useStrict(true);
+    mobx.useStrict(true)
+    mobx.action(() => {
+        a.set(3)
+        var b = mobx.observable(4)
+    })()
 
-	mobx.action(() => {
-		mobx.observable({ a: 2, b: function() { return this.a }});
-		mobx.map({ a: 2});
-		mobx.observable([1, 2, 3]);
-
-		obj.a = 3;
-		mobx.extendObservable(obj, { b: 4});
-		ar[0] = 2;
-		ar.push(3);
-		map.set("a", 3);
-		map.set("b", 4);
-		map.delete("a");
-	})();
-
-	mobx.useStrict(false);
-	t.end();
+    mobx.useStrict(false)
+    d()
+    t.end()
 })
 
-test('strict mode checks', function(t) {
-    var x = mobx.observable(3);
-	var d = mobx.autorun(() => x.get())
+test("actions can modify non-observed state in strict mode", t => {
+    var a = mobx.observable(2)
+
+    mobx.useStrict(true)
+    mobx.action(() => {
+        a.set(3)
+        var b = mobx.observable(4)
+    })()
+
+    mobx.useStrict(false)
+    t.end()
+})
+
+test("reactions cannot modify state in strict mode", t => {
+    var a = mobx.observable(3)
+    var b = mobx.observable(4)
+    mobx.useStrict(true)
+    mobx.extras.resetGlobalState() // should preserve strict mode
+
+    var bd = mobx.autorun(() => {
+        b.get() // make sure it is observed
+    })
+
+    var d = mobx.autorun(() => {
+        t.throws(() => {
+            a.get()
+            b.set(3)
+        }, strictError)
+    })
+
+    d = mobx.autorun(() => {
+        if (a.get() > 5) b.set(7)
+    })
+
+    mobx.action(() => a.set(4))() // ok
+
+    t.throws(() => a.set(5), strictError)
+
+    mobx.useStrict(false)
+    d()
+    bd()
+    t.end()
+})
+
+test("action inside reaction in strict mode can modify state", t => {
+    var a = mobx.observable(1)
+    var b = mobx.observable(2)
+
+    var bd = mobx.autorun(() => {
+        b.get() // make sure it is observed
+    })
+
+    mobx.useStrict(true)
+    var act = mobx.action(() => b.set(b.get() + 1))
+
+    var d = mobx.autorun(() => {
+        if (a.get() % 2 === 0) act()
+        if (a.get() == 16) {
+            t.throws(() => b.set(55), strictError, "finishing act should restore strict mode again")
+        }
+    })
+
+    var setA = mobx.action(val => a.set(val))
+    t.equal(b.get(), 2)
+    setA(4)
+    t.equal(b.get(), 3)
+    setA(5)
+    t.equal(b.get(), 3)
+    setA(16)
+    t.equal(b.get(), 4, "b should not be 55")
+
+    mobx.useStrict(false)
+    bd()
+    d()
+    t.end()
+})
+
+test("cannot create or modify objects in strict mode without action", t => {
+    var obj = mobx.observable({ a: 2 })
+    var ar = mobx.observable([1])
+    var map = mobx.map({ a: 2 })
+
+    mobx.useStrict(true)
+
+    // introducing new observables is ok!
+    // mobx.observable({ a: 2, b: function() { return this.a }});
+    // mobx.observable({ b: function() { return this.a } });
+    // mobx.map({ a: 2});
+    // mobx.observable([1, 2, 3]);
+    // mobx.extendObservable(obj, { b: 4});
+
+    // t.throws(() => obj.a = 3, strictError);
+    // t.throws(() => ar[0] = 2, strictError);
+    // t.throws(() => ar.push(3), strictError);
+    // t.throws(() => map.set("a", 3), strictError);
+    // t.throws(() => map.set("b", 4), strictError);
+    // t.throws(() => map.delete("a"), strictError);
+
+    mobx.useStrict(false)
+
+    // can modify again
+    obj.a = 42
+
+    t.end()
+})
+
+test("can create objects in strict mode with action", t => {
+    var obj = mobx.observable({ a: 2 })
+    var ar = mobx.observable([1])
+    var map = mobx.map({ a: 2 })
+
+    mobx.useStrict(true)
+
+    mobx.action(() => {
+        mobx.observable({
+            a: 2,
+            b: function() {
+                return this.a
+            }
+        })
+        mobx.map({ a: 2 })
+        mobx.observable([1, 2, 3])
+
+        obj.a = 3
+        mobx.extendObservable(obj, { b: 4 })
+        ar[0] = 2
+        ar.push(3)
+        map.set("a", 3)
+        map.set("b", 4)
+        map.delete("a")
+    })()
+
+    mobx.useStrict(false)
+    t.end()
+})
+
+test("strict mode checks", function(t) {
+    var x = mobx.observable(3)
+    var d = mobx.autorun(() => x.get())
 
     mobx.extras.allowStateChanges(false, function() {
-        x.get();
-    });
+        x.get()
+    })
 
     mobx.extras.allowStateChanges(true, function() {
-        x.set(7);
-    });
+        x.set(7)
+    })
 
     t.throws(function() {
         mobx.extras.allowStateChanges(false, function() {
-            x.set(4);
-        });
-    }, /Side effects like changing state are not allowed at this point/);
+            x.set(4)
+        })
+    }, /Side effects like changing state are not allowed at this point/)
 
-	mobx.extras.resetGlobalState();
-	d()
-    t.end();
-});
+    mobx.extras.resetGlobalState()
+    d()
+    t.end()
+})

--- a/test/tojs.js
+++ b/test/tojs.js
@@ -1,14 +1,13 @@
 "use strict"
 
-var test = require('tape');
-var mobx = require('..');
-var m = mobx;
-var observable = mobx.observable;
-var transaction = mobx.transaction;
+var test = require("tape")
+var mobx = require("..")
+var m = mobx
+var observable = mobx.observable
+var transaction = mobx.transaction
 
-
-test('json1', function(t) {
-	mobx.extras.resetGlobalState()
+test("json1", function(t) {
+    mobx.extras.resetGlobalState()
 
     var todos = observable([
         {
@@ -17,27 +16,31 @@ test('json1', function(t) {
         {
             title: "improve coverge"
         }
-    ]);
+    ])
 
-    var output;
+    var output
     mobx.autorun(function() {
-        output = todos.map(function(todo) { return todo.title; }).join(", ");
-    });
+        output = todos
+            .map(function(todo) {
+                return todo.title
+            })
+            .join(", ")
+    })
 
-    todos[1].title = "improve coverage"; // prints: write blog, improve coverage
-    t.equal(output, "write blog, improve coverage");
-    todos.push({ title: "take a nap" }); // prints: write blog, improve coverage, take a nap
-    t.equal(output, "write blog, improve coverage, take a nap");
+    todos[1].title = "improve coverage" // prints: write blog, improve coverage
+    t.equal(output, "write blog, improve coverage")
+    todos.push({ title: "take a nap" }) // prints: write blog, improve coverage, take a nap
+    t.equal(output, "write blog, improve coverage, take a nap")
 
-    t.end();
+    t.end()
 })
 
-test('json2', function(t) {
+test("json2", function(t) {
     var source = {
         todos: [
             {
                 title: "write blog",
-                tags: ["react","frp"],
+                tags: ["react", "frp"],
                 details: {
                     url: "somewhere"
                 }
@@ -50,88 +53,91 @@ test('json2', function(t) {
                 }
             }
         ]
-    };
+    }
 
-    var o = mobx.observable(JSON.parse(JSON.stringify(source)));
+    var o = mobx.observable(JSON.parse(JSON.stringify(source)))
 
-    t.deepEqual(mobx.toJS(o), source);
+    t.deepEqual(mobx.toJS(o), source)
 
     var analyze = mobx.computed(function() {
-        return [
-            o.todos.length,
-            o.todos[1].details.url
-        ]
-    });
+        return [o.todos.length, o.todos[1].details.url]
+    })
 
     var alltags = mobx.computed(function() {
-        return o.todos.map(function(todo) {
-            return todo.tags.join(",");
-        }).join(",");
-    });
+        return o.todos
+            .map(function(todo) {
+                return todo.tags.join(",")
+            })
+            .join(",")
+    })
 
-    var ab = [];
-    var tb = [];
+    var ab = []
+    var tb = []
 
-    m.observe(analyze, function(d) { ab.push(d.newValue); }, true);
-    m.observe(alltags, function(d) { tb.push(d.newValue); }, true);
+    m.observe(
+        analyze,
+        function(d) {
+            ab.push(d.newValue)
+        },
+        true
+    )
+    m.observe(
+        alltags,
+        function(d) {
+            tb.push(d.newValue)
+        },
+        true
+    )
 
-    o.todos[0].details.url = "boe";
-    o.todos[1].details.url = "ba";
-    o.todos[0].tags[0] = "reactjs";
-    o.todos[1].tags.push("pff");
+    o.todos[0].details.url = "boe"
+    o.todos[1].details.url = "ba"
+    o.todos[0].tags[0] = "reactjs"
+    o.todos[1].tags.push("pff")
 
     t.deepEqual(mobx.toJS(o), {
-        "todos": [
+        todos: [
             {
-                "title": "write blog",
-                "tags": [
-                    "reactjs",
-                    "frp"
-                ],
-                "details": {
-                    "url": "boe"
+                title: "write blog",
+                tags: ["reactjs", "frp"],
+                details: {
+                    url: "boe"
                 }
             },
             {
-                "title": "do the dishes",
-                "tags": [
-                    "mweh", "pff"
-                ],
-                "details": {
-                    "url": "ba"
+                title: "do the dishes",
+                tags: ["mweh", "pff"],
+                details: {
+                    url: "ba"
                 }
             }
         ]
-    });
-    t.deepEqual(ab, [ [ 2, 'here' ], [ 2, 'ba' ] ]);
-    t.deepEqual(tb,  [ 'react,frp,mweh', 'reactjs,frp,mweh', 'reactjs,frp,mweh,pff' ]);
-    ab = [];
-    tb = [];
+    })
+    t.deepEqual(ab, [[2, "here"], [2, "ba"]])
+    t.deepEqual(tb, ["react,frp,mweh", "reactjs,frp,mweh", "reactjs,frp,mweh,pff"])
+    ab = []
+    tb = []
 
-    o.todos.push(mobx.observable({
-        title: "test",
-        tags: ["x"]
-    }));
+    o.todos.push(
+        mobx.observable({
+            title: "test",
+            tags: ["x"]
+        })
+    )
 
     t.deepEqual(mobx.toJS(o), {
-        "todos": [
+        todos: [
             {
-                "title": "write blog",
-                "tags": [
-                    "reactjs",
-                    "frp"
-                ],
-                "details": {
-                    "url": "boe"
+                title: "write blog",
+                tags: ["reactjs", "frp"],
+                details: {
+                    url: "boe"
                 }
             },
             {
-                "title": "do the dishes",
-                "tags": [
-                    "mweh", "pff"
-                ],
-                "details": {
-                    "url": "ba"
+                title: "do the dishes",
+                tags: ["mweh", "pff"],
+                details: {
+                    url: "ba"
                 }
             },
             {
@@ -139,11 +145,11 @@ test('json2', function(t) {
                 tags: ["x"]
             }
         ]
-    });
-    t.deepEqual(ab, [[3, "ba"]]);
-    t.deepEqual(tb, ["reactjs,frp,mweh,pff,x"]);
-    ab = [];
-    tb = [];
+    })
+    t.deepEqual(ab, [[3, "ba"]])
+    t.deepEqual(tb, ["reactjs,frp,mweh,pff,x"])
+    ab = []
+    tb = []
 
     o.todos[1] = mobx.observable({
         title: "clean the attic",
@@ -151,26 +157,21 @@ test('json2', function(t) {
         details: {
             url: "booking.com"
         }
-    });
+    })
     t.deepEqual(JSON.parse(JSON.stringify(o)), {
-        "todos": [
+        todos: [
             {
-                "title": "write blog",
-                "tags": [
-                    "reactjs",
-                    "frp"
-                ],
-                "details": {
-                    "url": "boe"
+                title: "write blog",
+                tags: ["reactjs", "frp"],
+                details: {
+                    url: "boe"
                 }
             },
             {
-                "title": "clean the attic",
-                "tags": [
-                    "needs sabbatical"
-                ],
-                "details": {
-                    "url": "booking.com"
+                title: "clean the attic",
+                tags: ["needs sabbatical"],
+                details: {
+                    url: "booking.com"
                 }
             },
             {
@@ -178,33 +179,28 @@ test('json2', function(t) {
                 tags: ["x"]
             }
         ]
-    });
-    t.deepEqual(ab, [[3, "booking.com"]]);
-    t.deepEqual(tb, ["reactjs,frp,needs sabbatical,x"]);
-    ab = [];
-    tb = [];
+    })
+    t.deepEqual(ab, [[3, "booking.com"]])
+    t.deepEqual(tb, ["reactjs,frp,needs sabbatical,x"])
+    ab = []
+    tb = []
 
-    o.todos[1].details = mobx.observable({ url: "google" });
-    o.todos[1].tags = ["foo", "bar"];
+    o.todos[1].details = mobx.observable({ url: "google" })
+    o.todos[1].tags = ["foo", "bar"]
     t.deepEqual(mobx.toJS(o, false), {
-         "todos": [
+        todos: [
             {
-                "title": "write blog",
-                "tags": [
-                    "reactjs",
-                    "frp"
-                ],
-                "details": {
-                    "url": "boe"
+                title: "write blog",
+                tags: ["reactjs", "frp"],
+                details: {
+                    url: "boe"
                 }
             },
             {
-                "title": "clean the attic",
-                "tags": [
-                    "foo", "bar"
-                ],
-                "details": {
-                    "url": "google"
+                title: "clean the attic",
+                tags: ["foo", "bar"],
+                details: {
+                    url: "google"
                 }
             },
             {
@@ -212,122 +208,122 @@ test('json2', function(t) {
                 tags: ["x"]
             }
         ]
-    });
-    t.deepEqual(mobx.toJS(o, true), mobx.toJS(o, false));
-    t.deepEqual(ab, [[3, "google"]]);
-    t.deepEqual(tb, ["reactjs,frp,foo,bar,x"]);
+    })
+    t.deepEqual(mobx.toJS(o, true), mobx.toJS(o, false))
+    t.deepEqual(ab, [[3, "google"]])
+    t.deepEqual(tb, ["reactjs,frp,foo,bar,x"])
 
-    t.end();
+    t.end()
 })
 
-test('toJS handles dates', t => {
-	var a = observable({
-		d: new Date()
-	});
+test("toJS handles dates", t => {
+    var a = observable({
+        d: new Date()
+    })
 
-	var b = mobx.toJS(a);
-	t.equal(b.d instanceof Date, true)
-	t.equal(a.d === b.d, true)
-	t.end()
+    var b = mobx.toJS(a)
+    t.equal(b.d instanceof Date, true)
+    t.equal(a.d === b.d, true)
+    t.end()
 })
 
-test('json cycles', function(t) {
+test("json cycles", function(t) {
     var a = observable({
         b: 1,
         c: [2],
         d: mobx.map(),
         e: a
-    });
+    })
 
-    a.e = a;
-    a.c.push(a, a.d);
-    a.d.set("f", a);
-    a.d.set("d", a.d);
-    a.d.set("c", a.c);
+    a.e = a
+    a.c.push(a, a.d)
+    a.d.set("f", a)
+    a.d.set("d", a.d)
+    a.d.set("c", a.c)
 
-    var cloneA = mobx.toJS(a, true);
-    var cloneC = cloneA.c;
-    var cloneD = cloneA.d;
+    var cloneA = mobx.toJS(a, true)
+    var cloneC = cloneA.c
+    var cloneD = cloneA.d
 
-    t.equal(cloneA.b, 1);
-    t.equal(cloneA.c[0], 2);
-    t.equal(cloneA.c[1], cloneA);
-    t.equal(cloneA.c[2], cloneD);
-    t.equal(cloneD.f, cloneA);
-    t.equal(cloneD.d, cloneD);
-    t.equal(cloneD.c, cloneC);
-    t.equal(cloneA.e, cloneA);
+    t.equal(cloneA.b, 1)
+    t.equal(cloneA.c[0], 2)
+    t.equal(cloneA.c[1], cloneA)
+    t.equal(cloneA.c[2], cloneD)
+    t.equal(cloneD.f, cloneA)
+    t.equal(cloneD.d, cloneD)
+    t.equal(cloneD.c, cloneC)
+    t.equal(cloneA.e, cloneA)
 
-    t.end();
+    t.end()
 })
 
-test('#285 class instances with toJS', t => {
-	function Person() {
-		this.firstName = "michel";
-		mobx.extendObservable(this, {
-			lastName: "weststrate",
-			tags: ["user", "mobx-member"],
-			get fullName() {
-				return this.firstName + this.lastName
-			}
-		})
-	}
+test("#285 class instances with toJS", t => {
+    function Person() {
+        this.firstName = "michel"
+        mobx.extendObservable(this, {
+            lastName: "weststrate",
+            tags: ["user", "mobx-member"],
+            get fullName() {
+                return this.firstName + this.lastName
+            }
+        })
+    }
 
-	const p1 = new Person();
-	// check before lazy initialization
-	t.deepEqual(mobx.toJS(p1), {
-		firstName: "michel",
-		lastName: "weststrate",
-		tags: ["user", "mobx-member"]
-	});
+    const p1 = new Person()
+    // check before lazy initialization
+    t.deepEqual(mobx.toJS(p1), {
+        firstName: "michel",
+        lastName: "weststrate",
+        tags: ["user", "mobx-member"]
+    })
 
-	// check after lazy initialization
-	t.deepEqual(mobx.toJS(p1), {
-		firstName: "michel",
-		lastName: "weststrate",
-		tags: ["user", "mobx-member"]
-	});
+    // check after lazy initialization
+    t.deepEqual(mobx.toJS(p1), {
+        firstName: "michel",
+        lastName: "weststrate",
+        tags: ["user", "mobx-member"]
+    })
 
-	t.end()
+    t.end()
 })
 
-test('#285 non-mobx class instances with toJS', t => {
-	const nameObservable = mobx.observable("weststrate");
-	function Person() {
-		this.firstName = "michel";
-		this.lastName = nameObservable;
-	}
+test("#285 non-mobx class instances with toJS", t => {
+    const nameObservable = mobx.observable("weststrate")
+    function Person() {
+        this.firstName = "michel"
+        this.lastName = nameObservable
+    }
 
-	const p1 = new Person();
-	// check before lazy initialization
-	t.deepEqual(mobx.toJS(p1), {
-		firstName: "michel",
-		lastName: nameObservable // toJS doesn't recurse into non observable objects!
-	});
+    const p1 = new Person()
+    // check before lazy initialization
+    t.deepEqual(mobx.toJS(p1), {
+        firstName: "michel",
+        lastName: nameObservable // toJS doesn't recurse into non observable objects!
+    })
 
-	t.end()
+    t.end()
 })
 
 test("verify #566 solution", t => {
-	function MyClass() {}
-	const a = new MyClass()
-	const b = mobx.observable({ x: 3 })
-	const c = mobx.observable({ a: a, b: b })
+    function MyClass() {}
+    const a = new MyClass()
+    const b = mobx.observable({ x: 3 })
+    const c = mobx.observable({ a: a, b: b })
 
-	t.ok(mobx.toJS(c).a === a) // true
-	t.ok(mobx.toJS(c).b !== b) // false, cloned
-	t.ok(mobx.toJS(c).b.x === b.x) // true, both 3
+    t.ok(mobx.toJS(c).a === a) // true
+    t.ok(mobx.toJS(c).b !== b) // false, cloned
+    t.ok(mobx.toJS(c).b.x === b.x) // true, both 3
 
-	t.end()
+    t.end()
 })
 
 test("verify already seen", t => {
-	const a = mobx.observable({ x: null, y: 3 })
-	a.x = a;
+    const a = mobx.observable({ x: null, y: 3 })
+    a.x = a
 
-	const res = mobx.toJS(a);
-	t.equal(res.y, 3);
-	t.ok(res.x === res)
-	t.notOk(res.x === a);
-	t.end();
+    const res = mobx.toJS(a)
+    t.equal(res.y, 3)
+    t.ok(res.x === res)
+    t.notOk(res.x === a)
+    t.end()
 })

--- a/test/transform.js
+++ b/test/transform.js
@@ -1,1055 +1,1246 @@
-var m = require('../');
-var test = require('tape');
-var TransformUtils = require('./utils/transform');
+var m = require("../")
+var test = require("tape")
+var TransformUtils = require("./utils/transform")
 
-test('transform1', function(t) {
-	m.extras.resetGlobalState();
-	var todoCalc = 0;
-	var stateCalc = 0;
-	var state = m.observable({
-		todos: [{
-			title: "coffee"
-		}],
-		name: "michel"
-	});
+test("transform1", function(t) {
+    m.extras.resetGlobalState()
+    var todoCalc = 0
+    var stateCalc = 0
+    var state = m.observable({
+        todos: [
+            {
+                title: "coffee"
+            }
+        ],
+        name: "michel"
+    })
 
-	var mapped;
-	var unloaded = [];
+    var mapped
+    var unloaded = []
 
-	var transformState = m.createTransformer(function(state) {
-		stateCalc++;
-		return state.name + state.todos.map(transformTodo).join(",");
-	})
+    var transformState = m.createTransformer(function(state) {
+        stateCalc++
+        return state.name + state.todos.map(transformTodo).join(",")
+    })
 
-	var transformTodo = m.createTransformer(function(todo) {
-		todoCalc++;
-		return todo.title.toUpperCase();
-	}, function cleanup(text, todo) {
-		unloaded.push([todo, text]);
-	});
+    var transformTodo = m.createTransformer(
+        function(todo) {
+            todoCalc++
+            return todo.title.toUpperCase()
+        },
+        function cleanup(text, todo) {
+            unloaded.push([todo, text])
+        }
+    )
 
-	m.autorun(function() {
-		mapped = transformState(state);
-	});
+    m.autorun(function() {
+        mapped = transformState(state)
+    })
 
-	t.equal(mapped, "michelCOFFEE");
-	t.equal(stateCalc, 1);
-	t.equal(todoCalc, 1);
+    t.equal(mapped, "michelCOFFEE")
+    t.equal(stateCalc, 1)
+    t.equal(todoCalc, 1)
 
-	state.name = "john";
-	t.equal(mapped, "johnCOFFEE");
-	t.equal(stateCalc, 2);
-	t.equal(todoCalc, 1);
+    state.name = "john"
+    t.equal(mapped, "johnCOFFEE")
+    t.equal(stateCalc, 2)
+    t.equal(todoCalc, 1)
 
-	state.todos[0].title = "TEA";
-	t.equal(mapped, "johnTEA");
-	t.equal(stateCalc, 3);
-	t.equal(todoCalc, 2);
+    state.todos[0].title = "TEA"
+    t.equal(mapped, "johnTEA")
+    t.equal(stateCalc, 3)
+    t.equal(todoCalc, 2)
 
-	state.todos.push({ title: "BISCUIT" });
-	t.equal(mapped, "johnTEA,BISCUIT");
-	t.equal(stateCalc, 4);
-	t.equal(todoCalc, 3);
+    state.todos.push({ title: "BISCUIT" })
+    t.equal(mapped, "johnTEA,BISCUIT")
+    t.equal(stateCalc, 4)
+    t.equal(todoCalc, 3)
 
-	var tea = state.todos.shift();
-	t.equal(mapped, "johnBISCUIT");
-	t.equal(stateCalc, 5);
-	t.equal(todoCalc, 3);
+    var tea = state.todos.shift()
+    t.equal(mapped, "johnBISCUIT")
+    t.equal(stateCalc, 5)
+    t.equal(todoCalc, 3)
 
-	t.equal(unloaded.length, 1);
-	t.equal(unloaded[0][0], tea);
-	t.equal(unloaded[0][1], "TEA");
-	t.equal(tea.$mobx.values.title.observers.length, 0);
-	t.equal(state.todos[0].$mobx.values.title.observers.length, 1);
+    t.equal(unloaded.length, 1)
+    t.equal(unloaded[0][0], tea)
+    t.equal(unloaded[0][1], "TEA")
+    t.equal(tea.$mobx.values.title.observers.length, 0)
+    t.equal(state.todos[0].$mobx.values.title.observers.length, 1)
 
+    tea.title = "mint"
+    t.equal(mapped, "johnBISCUIT")
+    t.equal(stateCalc, 5)
+    t.equal(todoCalc, 3)
 
-	tea.title = "mint";
-	t.equal(mapped, "johnBISCUIT");
-	t.equal(stateCalc, 5);
-	t.equal(todoCalc, 3);
+    t.deepEqual(Object.keys(state.todos[0]), ["title"])
 
-	t.deepEqual(Object.keys(state.todos[0]), ["title"]);
+    t.end()
+})
 
+test("createTransformer as off-instance computed", t => {
+    var runs = 0
 
-	t.end();
-});
+    // observable in closure
+    var capitalize = m.observable(false)
 
-test('createTransformer as off-instance computed', t => {
-	var runs = 0;
+    var _computeDisplayName = person => {
+        runs++ // count the runs
+        var res = person.firstName + " " + person.lastName
+        if (capitalize.get()) return res.toUpperCase()
+        return res
+    }
 
-	// observable in closure
-	var capitalize = m.observable(false);
+    // transformer creates a computed but reuses it for every time the same object is passed in
+    var displayName = m.createTransformer(_computeDisplayName)
 
-	var _computeDisplayName = person => {
-		runs++; // count the runs
-		var res = person.firstName + " "  + person.lastName;
-		if (capitalize.get())
-			return res.toUpperCase();
-		return res;
-	};
+    var person1 = m.observable({
+        firstName: "Mickey",
+        lastName: "Mouse"
+    })
 
-	// transformer creates a computed but reuses it for every time the same object is passed in
-	var displayName = m.createTransformer(_computeDisplayName);
+    var person2 = m.observable({
+        firstName: "Donald",
+        lastName: "Duck"
+    })
 
-	var person1 = m.observable({
-		firstName: "Mickey",
-		lastName: "Mouse"
-	});
+    var persons = m.observable([])
+    var displayNames = []
 
-	var person2 = m.observable({
-		firstName: "Donald",
-		lastName: "Duck"
-	});
+    var disposer = m.autorun(() => {
+        displayNames = persons.map(p => displayName(p))
+    })
 
-	var persons = m.observable([]);
-	var displayNames = [];
+    t.equal(runs, 0)
+    t.deepEqual(displayNames, [])
 
-	var disposer = m.autorun(() => {
-		displayNames = persons.map(p => displayName(p));
-	});
+    persons.push(person1)
+    t.equal(runs, 1)
+    t.deepEqual(displayNames, ["Mickey Mouse"])
 
-	t.equal(runs, 0);
-	t.deepEqual(displayNames, []);
+    t.equal(displayName(person1), "Mickey Mouse")
+    t.equal(runs, 1, "No new run needed; behaves like a normal computes")
 
-	persons.push(person1);
-	t.equal(runs, 1);
-	t.deepEqual(displayNames, ["Mickey Mouse"]);
+    persons.push(person2)
+    t.equal(runs, 2, "person 2 calculated")
+    t.deepEqual(displayNames, ["Mickey Mouse", "Donald Duck"])
 
-	t.equal(displayName(person1), "Mickey Mouse");
-	t.equal(runs, 1, "No new run needed; behaves like a normal computes");
+    persons.push(person1)
+    t.equal(runs, 2, "person 1 not recalculated")
+    t.deepEqual(displayNames, ["Mickey Mouse", "Donald Duck", "Mickey Mouse"])
 
-	persons.push(person2);
-	t.equal(runs, 2, "person 2 calculated");
-	t.deepEqual(displayNames, ["Mickey Mouse", "Donald Duck"]);
+    person1.firstName = "Minnie"
+    t.equal(runs, 3, "computed run only one other time")
+    t.deepEqual(displayNames, ["Minnie Mouse", "Donald Duck", "Minnie Mouse"])
 
-	persons.push(person1);
-	t.equal(runs, 2, "person 1 not recalculated");
-	t.deepEqual(displayNames, ["Mickey Mouse", "Donald Duck", "Mickey Mouse"]);
+    capitalize.set(true)
+    t.equal(runs, 5, "both computeds were invalidated")
+    t.deepEqual(displayNames, ["MINNIE MOUSE", "DONALD DUCK", "MINNIE MOUSE"])
 
-	person1.firstName = "Minnie";
-	t.equal(runs, 3, "computed run only one other time");
-	t.deepEqual(displayNames, ["Minnie Mouse", "Donald Duck", "Minnie Mouse"]);
+    persons.splice(1, 1)
+    t.deepEqual(displayNames, ["MINNIE MOUSE", "MINNIE MOUSE"])
 
-	capitalize.set(true);
-	t.equal(runs, 5, "both computeds were invalidated")
-	t.deepEqual(displayNames, ["MINNIE MOUSE", "DONALD DUCK", "MINNIE MOUSE"]);
+    person2.firstName = "Dagobert"
+    t.equal(runs, 5, "No re-run for person2; not observed anymore")
 
-	persons.splice(1, 1);
-	t.deepEqual(displayNames, ["MINNIE MOUSE", "MINNIE MOUSE"]);
+    disposer()
+    person1.lastName = "Maxi"
+    t.equal(runs, 5, "No re-run for person1; not observed anymore")
 
-	person2.firstName = "Dagobert";
-	t.equal(runs, 5, "No re-run for person2; not observed anymore");
+    t.equal(displayName(person1), "MINNIE MAXI", "display name still consistent")
+    t.equal(runs, 6, "Re-run was needed because lazy mode")
 
-	disposer();
-	person1.lastName = "Maxi";
-	t.equal(runs, 5, "No re-run for person1; not observed anymore");
+    t.end()
+})
 
-	t.equal(displayName(person1), "MINNIE MAXI", "display name still consistent");
-	t.equal(runs, 6, "Re-run was needed because lazy mode");
+test("163 - resetGlobalState should clear cache", function(t) {
+    var runs = 0
+    function doubler(x) {
+        runs++
+        return { value: x.value * 2 }
+    }
 
-	t.end();
-});
+    var doubleTransformer = m.createTransformer(doubler)
+    var a = { value: 2 }
 
-test('163 - resetGlobalState should clear cache', function(t) {
-	var runs = 0;
-	function doubler(x) {
-		runs++;
-		return { value: x.value * 2 };
-	}
+    var autorunTrigger = m.observable(1)
+    var transformOutputs = []
 
-	var doubleTransformer = m.createTransformer(doubler);
-	var a = { value: 2 };
+    m.autorun(function() {
+        autorunTrigger.get()
+        transformOutputs.push(doubleTransformer(a))
+    })
+    t.equal(runs, 1)
 
-	var autorunTrigger = m.observable(1);
-	var transformOutputs = [];
+    autorunTrigger.set(2)
+    t.equal(runs, 1)
+    t.equal(transformOutputs.length, 2)
+    t.equal(transformOutputs[1], transformOutputs[0], "transformer should have returned from cache")
 
-	m.autorun(function() {
-		autorunTrigger.get();
-		transformOutputs.push(doubleTransformer(a));
-	});
-	t.equal(runs, 1);
+    m.extras.resetGlobalState()
 
-	autorunTrigger.set(2);
-	t.equal(runs, 1);
-	t.equal(transformOutputs.length, 2);
-	t.equal(transformOutputs[1], transformOutputs[0], "transformer should have returned from cache");
+    autorunTrigger.set(3)
+    t.equal(runs, 2)
+    t.equal(transformOutputs.length, 3)
+    t.notEqual(
+        transformOutputs[2],
+        transformOutputs[1],
+        "transformer should NOT have returned from cache"
+    )
 
-	m.extras.resetGlobalState();
+    t.end()
+})
 
-	autorunTrigger.set(3);
-	t.equal(runs, 2);
-	t.equal(transformOutputs.length, 3);
-	t.notEqual(transformOutputs[2], transformOutputs[1], "transformer should NOT have returned from cache");
+test("transform into reactive graph", function(t) {
+    function Folder(name) {
+        m.extendObservable(this, {
+            name: name,
+            children: []
+        })
+    }
 
-	t.end();
-});
+    var _childrenRecalc = 0
+    function DerivedFolder(state, baseFolder) {
+        this.state = state
+        this.baseFolder = baseFolder
+        m.extendObservable(this, {
+            get name() {
+                return this.baseFolder.name
+            },
+            get isVisible() {
+                return (
+                    !this.state.filter ||
+                    this.name.indexOf(this.state.filter) !== -1 ||
+                    this.children.length > 0
+                )
+            },
+            get children() {
+                _childrenRecalc++
+                return this.baseFolder.children.map(transformFolder).filter(function(folder) {
+                    return folder.isVisible === true
+                })
+            }
+        })
+    }
 
-test('transform into reactive graph', function(t) {
+    var state = m.observable({
+        filter: null
+    })
 
-	function Folder(name) {
-		m.extendObservable(this, {
-			name: name,
-			children: []
-		});
-	}
+    var _transformCount = 0
+    var transformFolder = m.createTransformer(function(folder) {
+        _transformCount++
+        console.log("Transform", folder.name)
+        return new DerivedFolder(state, folder)
+    })
 
-	var _childrenRecalc = 0;
-	function DerivedFolder(state, baseFolder) {
-		this.state = state;
-		this.baseFolder = baseFolder;
-		m.extendObservable(this, {
-			get name() {
-				return this.baseFolder.name;
-			},
-			get isVisible() {
-				return !this.state.filter || this.name.indexOf(this.state.filter) !== -1 || this.children.length > 0;
-			},
-			get children() {
-				_childrenRecalc++;
-				return this.baseFolder.children.map(transformFolder).filter(function(folder) {
-					return folder.isVisible === true;
-				});
-			}
-		})
-	}
+    state.root = new Folder("/")
+    m.autorun(function() {
+        state.derived = transformFolder(state.root)
+        state.derived.children
+    })
 
-	var state = m.observable({
-		filter: null,
-	});
+    /** test convience */
+    function childrenRecalcs() {
+        var a = _childrenRecalc
+        _childrenRecalc = 0
+        return a
+    }
 
-	var _transformCount = 0;
-	var transformFolder = m.createTransformer(function(folder) {
-		_transformCount++;
-		console.log("Transform", folder.name);
-		return new DerivedFolder(state, folder);
-	});
+    function transformCount() {
+        var a = _transformCount
+        _transformCount = 0
+        return a
+    }
 
-	state.root = new Folder("/");
-	m.autorun(function() {
-		state.derived = transformFolder(state.root);
-		state.derived.children;
-	});
+    t.equal(state.derived.name, "/")
+    t.equal(state.derived.children.length, 0)
+    t.equal(transformCount(), 1)
+    t.equal(childrenRecalcs(), 1)
 
-	/** test convience */
-	function childrenRecalcs() {
-		var  a = _childrenRecalc;
-		_childrenRecalc = 0;
-		return a;
-	}
+    state.root.children.push(new Folder("hoi"))
+    t.equal(state.derived.name, "/")
+    t.equal(state.derived.children.length, 1)
+    t.equal(state.derived.children[0].name, "hoi")
+    t.equal(transformCount(), 1)
+    t.equal(childrenRecalcs(), 1)
 
-	function transformCount() {
-		var  a = _transformCount;
-		_transformCount = 0;
-		return a;
-	}
+    state.filter = "boe"
+    t.equal(state.derived.name, "/")
+    t.equal(state.derived.isVisible, false)
+    t.equal(state.derived.children.length, 0)
+    t.equal(transformCount(), 0)
+    t.equal(childrenRecalcs(), 2)
 
-	t.equal(state.derived.name, "/");
-	t.equal(state.derived.children.length, 0);
-	t.equal(transformCount(), 1);
-	t.equal(childrenRecalcs(), 1);
+    state.filter = "oi"
+    t.equal(state.derived.name, "/")
+    t.equal(state.derived.isVisible, true)
+    t.equal(state.derived.children.length, 1)
+    t.equal(state.derived.children[0].name, "hoi")
+    t.equal(transformCount(), 0)
+    t.equal(childrenRecalcs(), 1)
 
-	state.root.children.push(new Folder("hoi"));
-	t.equal(state.derived.name, "/");
-	t.equal(state.derived.children.length, 1);
-	t.equal(state.derived.children[0].name, "hoi");
-	t.equal(transformCount(), 1);
-	t.equal(childrenRecalcs(), 1);
-
-	state.filter = "boe";
-	t.equal(state.derived.name, "/");
-	t.equal(state.derived.isVisible, false);
-	t.equal(state.derived.children.length, 0);
-	t.equal(transformCount(), 0);
-	t.equal(childrenRecalcs(), 2);
-
-	state.filter = "oi";
-	t.equal(state.derived.name, "/");
-	t.equal(state.derived.isVisible, true);
-	t.equal(state.derived.children.length, 1);
-	t.equal(state.derived.children[0].name, "hoi");
-	t.equal(transformCount(), 0);
-	t.equal(childrenRecalcs(), 1);
-
-	t.end();
-
-});
+    t.end()
+})
 
 // testing: https://github.com/mobxjs/mobx/issues/67
-test('transform tree (modifying tree incrementally)', function(t) {
-	var pluckFn = TransformUtils.pluckFn;
-	var identity = TransformUtils.identity;
-	var testSet = TransformUtils.testSet();
-	var state = testSet.state;
-	var stats = testSet.stats;
-	var TreeNode = testSet.TreeNode;
-	var DisplayNode = testSet.DisplayNode;
-
-	var nodeCreateCount = 0;
-	var renderCount = 0;
-	var renderNodeCount = 0;
-
-	var transformNode = m.createTransformer(function(node) {
-		nodeCreateCount++;
-		return new DisplayNode(node);
-	}, function cleanup(displayNode, node) { displayNode.destroy(); });
-
-	// transform nodes to renderedNodes
-	m.autorun(function() {
-		// KM: ideally, I would like to do an assignment here, but it creates a cycle and would need to preserve ms.modifiers.structure:
-		//
-		// state.renderedNodes = state.root ? state.root.map(transformNode) : [];
-		//
-
-		var renderedNodes = state.root ? state.root.map(transformNode) : [];
-		state.renderedNodes.replace(renderedNodes);
-	});
-
-	// render
-	m.autorun(function() {
-		renderCount++;
-		renderNodeCount += state.renderedNodes.length;
-	});
-
-	t.equal(nodeCreateCount,	0);
-	t.equal(stats.refCount,	0);
-	t.equal(renderCount, 			1);
-	t.equal(renderNodeCount, 	0);
-	t.deepEqual(state.renderedNodes.length, 0);
-
-	////////////////////////////////////
-	// Incremental Tree
-	////////////////////////////////////
-
-	// initialize root
-	var node = new TreeNode('root');
-	state.root = node;
-	t.equal(nodeCreateCount,	1);
-	t.equal(stats.refCount,	1);
-	t.equal(renderCount, 			2);
-	t.equal(renderNodeCount, 	1);
-	t.deepEqual(state.renderedNodes.length, 1);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root']);
-
-	// add first child
-	state.root.addChild(new TreeNode('root-child-1'));
-	t.equal(nodeCreateCount,	1 + 1);
-	t.equal(stats.refCount,	1 + 1);
-	t.equal(renderCount, 			2 + 1);
-	t.equal(renderNodeCount, 	1 + 2);
-	t.deepEqual(state.renderedNodes.length, 2);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1']);
-
-	// add second child
-	state.root.addChild(new TreeNode('root-child-2'));
-	t.equal(nodeCreateCount,	1 + 1 + 1);
-	t.equal(stats.refCount,	1 + 1 + 1);
-	t.equal(renderCount, 			2 + 1 + 1);
-	t.equal(renderNodeCount, 	1 + 2 + 3);
-	t.deepEqual(state.renderedNodes.length, 3);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-2']);
-
-	// add first child to second child
-	node = state.root.find(function(node) { return node.name === 'root-child-2'; });
-	node.addChild(new TreeNode('root-child-2-child-1'));
-	t.equal(nodeCreateCount,	1 + 1 + 1 + 1);
-	t.equal(stats.refCount,	1 + 1 + 1 + 1);
-	t.equal(renderCount, 			2 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	1 + 2 + 3 + 4);
-	t.deepEqual(state.renderedNodes.length, 4);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// add first child to first child
-	node = state.root.find(function(node) { return node.name === 'root-child-1'; });
-	node.addChild(new TreeNode('root-child-1-child-1'));
-	t.equal(nodeCreateCount,	1 + 1 + 1 + 1 + 1);
-	t.equal(stats.refCount, 	1 + 1 + 1 + 1 + 1);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	1 + 2 + 3 + 4 + 5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// remove children from first child
-	node = state.root.find(function(node) { return node.name === 'root-child-1'; });
-	node.children.splice(0);
-	t.equal(nodeCreateCount,	1 + 1 + 1 + 1 + 1 + 0);
-	t.equal(stats.refCount, 	1 + 1 + 1 + 1 + 1 - 1);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	1 + 2 + 3 + 4 + 5 + 4);
-	t.deepEqual(state.renderedNodes.length, 4);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// remove children from first child with no children should be a no-op
-	node = state.root.find(function(node) { return node.name === 'root-child-1'; });
-	node.children.splice(0);
-	t.equal(nodeCreateCount,	1 + 1 + 1 + 1 + 1 + 0 + 0);
-	t.equal(stats.refCount, 	1 + 1 + 1 + 1 + 1 - 1 + 0);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 1 + 1 + 0);
-	t.equal(renderNodeCount, 	1 + 2 + 3 + 4 + 5 + 4 + 0);
-	t.deepEqual(state.renderedNodes.length, 4);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// remove children from root
-	state.root.children.splice(0);
-	t.equal(nodeCreateCount,	1 + 1 + 1 + 1 + 1 + 0 + 0 + 0);
-	t.equal(stats.refCount, 	1 + 1 + 1 + 1 + 1 - 1 + 0 - 3);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 1 + 1 + 0 + 1);
-	t.equal(renderNodeCount, 	1 + 2 + 3 + 4 + 5 + 4 + 0 + 1);
-	t.deepEqual(state.renderedNodes.length, 1);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root']);
-
-	// teardown
-	state.root = null;
-	t.equal(nodeCreateCount,	1 + 1 + 1 + 1 + 1 + 0 + 0 + 0 + 0);
-	t.equal(stats.refCount, 	0);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 1 + 1 + 0 + 1 + 1);
-	t.equal(renderNodeCount, 	1 + 2 + 3 + 4 + 5 + 4 + 0 + 1 + 0);
-	t.deepEqual(state.renderedNodes.length, 0);
-
-	t.end();
-});
-
-test('transform tree (modifying tree incrementally)', function(t) {
-	var pluckFn = TransformUtils.pluckFn;
-	var identity = TransformUtils.identity;
-	var testSet = TransformUtils.testSet();
-	var state = testSet.state;
-	var stats = testSet.stats;
-	var TreeNode = testSet.TreeNode;
-	var DisplayNode = testSet.DisplayNode;
-
-	var nodeCreateCount = 0;
-	var renderCount = 0;
-	var renderNodeCount = 0;
-
-	var transformNode = m.createTransformer(function(node) {
-		nodeCreateCount++;
-		return new DisplayNode(node);
-	}, function cleanup(displayNode, node) { displayNode.destroy(); });
-
-	// transform nodes to renderedNodes
-	m.autorun(function() {
-		var renderedNodes = state.root ? state.root.map(transformNode) : [];
-		state.renderedNodes.replace(renderedNodes);
-	});
-
-	// render
-	m.autorun(function() {
-		renderCount++;
-		renderNodeCount += state.renderedNodes.length;
-	});
-
-	// setup
-	var node = new TreeNode('root-1');
-	state.root = node;
-	t.equal(nodeCreateCount,	1);
-	t.equal(stats.refCount, 	1);
-	t.equal(renderCount, 			2);
-	t.equal(renderNodeCount, 	1);
-	t.deepEqual(state.renderedNodes.length, 1);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root-1']);
-
-	////////////////////////////////////
-	// Batch Tree (Partial)
-	////////////////////////////////////
-
-	// add partial tree as a batch
-	var children = [];
-	children.push(new TreeNode('root-1-child-1b'));
-	children[0].addChild(new TreeNode('root-1-child-1b-child-1'))
-	children.push(new TreeNode('root-1-child-2b'));
-	children[1].addChild(new TreeNode('root-1-child-2b-child-1'))
-	state.root.addChildren(children);
-	t.equal(nodeCreateCount,	1 + 4);
-	t.equal(stats.refCount, 	1 + 4);
-	t.equal(renderCount, 			2 + 1);
-	t.equal(renderNodeCount, 	1 + 5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root-1', 'root-1-child-1b', 'root-1-child-1b-child-1', 'root-1-child-2b', 'root-1-child-2b-child-1']);
-
-	// remove root-1
-	state.root = null;
-	t.equal(nodeCreateCount,	1 + 4 + 0);
-	t.equal(stats.refCount, 	1 + 4 - 5);
-	t.equal(renderCount, 			2 + 1 + 1);
-	t.equal(renderNodeCount, 	1 + 5 + 0);
-	t.deepEqual(state.renderedNodes.length, 0);
-
-	////////////////////////////////////
-	// Batch Tree (Full)
-	////////////////////////////////////
-
-	// add full tree as a batch
-	node = new TreeNode('root-2')
-	node.addChild(new TreeNode('root-2-child-1'));
-	node.children[0].addChild(new TreeNode('root-2-child-1-child-1'))
-	node.addChild(new TreeNode('root-2-child-2'));
-	node.children[1].addChild(new TreeNode('root-2-child-2-child-1'))
-	state.root = node;
-	t.equal(nodeCreateCount,	1 + 4 + 0 + 5);
-	t.equal(stats.refCount, 	1 + 4 - 5 + 5);
-	t.equal(renderCount, 			2 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	1 + 5 + 0 + 5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root-2', 'root-2-child-1', 'root-2-child-1-child-1', 'root-2-child-2', 'root-2-child-2-child-1']);
-
-	// teardown
-	state.root = null;
-	t.equal(nodeCreateCount,	1 + 4 + 0 + 5 + 0);
-	t.equal(stats.refCount, 	0);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	1 + 5 + 0 + 5 + 0);
-	t.deepEqual(state.renderedNodes.length, 0);
-
-	t.end();
-});
-
-test('transform tree (modifying expanded)', function(t) {
-	var pluckFn = TransformUtils.pluckFn;
-	var identity = TransformUtils.identity;
-	var testSet = TransformUtils.testSet();
-	var state = testSet.state;
-	var stats = testSet.stats;
-	var TreeNode = testSet.TreeNode;
-	var DisplayNode = testSet.DisplayNode;
-
-	var nodeCreateCount = 0;
-	var renderCount = 0;
-	var renderNodeCount = 0;
-
-	var transformNode = m.createTransformer(function(node) {
-		nodeCreateCount++;
-		return new DisplayNode(node);
-	}, function cleanup(displayNode, node) { displayNode.destroy(); });
-
-	// transform nodes to renderedNodes
-	m.autorun(function() {
-		var renderedNodes = state.root ? state.root.transform(transformNode) : [];
-		state.renderedNodes.replace(renderedNodes);
-	});
-
-	// render
-	m.autorun(function() {
-		renderCount++;
-		renderNodeCount += state.renderedNodes.length;
-	});
-
-	// patch for collapsed
-	TreeNode.prototype.transform = function(iteratee, results) {
-		if (this.parent && state.collapsed.has(this.parent.path())) return results || []; // not visible
-
-		results = results || [];
-		results.push(iteratee(this));
-		this.children.forEach(function(child) { child.transform(iteratee, results); });
-		return results;
-	}
-
-	// setup
-	var node = new TreeNode('root')
-	node.addChild(new TreeNode('root-child-1'));
-	node.children[0].addChild(new TreeNode('root-child-1-child-1'))
-	node.addChild(new TreeNode('root-child-2'));
-	node.children[1].addChild(new TreeNode('root-child-2-child-1'))
-	state.root = node;
-	t.equal(nodeCreateCount,	5);
-	t.equal(stats.refCount, 	5);
-	t.equal(renderCount, 			2);
-	t.equal(renderNodeCount, 	5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	////////////////////////////////////
-	// Expanded
-	////////////////////////////////////
-
-	// toggle root to collapsed
-	state.renderedNodes[0].toggleCollapsed();
-	t.equal(nodeCreateCount,	5 + 0);
-	t.equal(stats.refCount, 	5 - 4);
-	t.equal(renderCount, 			2 + 1);
-	t.equal(renderNodeCount, 	5 + 1);
-	t.deepEqual(state.renderedNodes.length, 1);
-	t.notDeepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity)); // not a direct map of the tree nodes
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root']);
-
-	// toggle root to expanded
-	state.renderedNodes[0].toggleCollapsed();
-	t.equal(nodeCreateCount,	5 + 0 + 4);
-	t.equal(stats.refCount, 	5 - 4 + 4);
-	t.equal(renderCount, 			2 + 1 + 1);
-	t.equal(renderNodeCount, 	5 + 1 + 5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// toggle child-1 collapsed
-	state.renderedNodes[1].toggleCollapsed();
-	t.equal(nodeCreateCount,	5 + 0 + 4 + 0);
-	t.equal(stats.refCount, 	5 - 4 + 4 - 1);
-	t.equal(renderCount, 			2 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	5 + 1 + 5 + 4);
-	t.deepEqual(state.renderedNodes.length, 4);
-	t.notDeepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity)); // not a direct map of the tree nodes
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// toggle child-2-child-1 collapsed should be a no-op
-	state.renderedNodes[state.renderedNodes.length-1].toggleCollapsed();
-	t.equal(nodeCreateCount,	5 + 0 + 4 + 0 + 0);
-	t.equal(stats.refCount, 	5 - 4 + 4 - 1 + 0);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 0);
-	t.equal(renderNodeCount, 	5 + 1 + 5 + 4 + 0);
-	t.deepEqual(state.renderedNodes.length, 4);
-	t.notDeepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity)); // not a direct map of the tree nodes
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// teardown
-	state.root = null;
-	t.equal(nodeCreateCount,	5 + 0 + 4 + 0 + 0 + 0);
-	t.equal(stats.refCount, 	0);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 0 + 1);
-	t.equal(renderNodeCount, 	5 + 1 + 5 + 4 + 0 + 0);
-	t.deepEqual(state.renderedNodes.length, 0);
-
-	t.end();
-});
-
-test('transform tree (modifying render observable)', function(t) {
-	var pluckFn = TransformUtils.pluckFn;
-	var identity = TransformUtils.identity;
-	var testSet = TransformUtils.testSet();
-	var state = testSet.state;
-	var stats = testSet.stats;
-	var TreeNode = testSet.TreeNode;
-	var DisplayNode = testSet.DisplayNode;
-
-	var nodeCreateCount = 0;
-	var renderCount = 0;
-	var renderNodeCount = 0;
-	var renderIconCalc = 0;
-
-	var transformNode = m.createTransformer(function(node) {
-		nodeCreateCount++;
-		return new DisplayNode(node);
-	}, function cleanup(displayNode, node) { displayNode.destroy(); });
-
-	// transform nodes to renderedNodes
-	m.autorun(function() {
-		var renderedNodes = state.root ? state.root.transform(transformNode) : [];
-		state.renderedNodes.replace(renderedNodes);
-	});
-
-	// render
-	m.autorun(function() {
-		renderCount++;
-		renderNodeCount += state.renderedNodes.length;
-	});
-
-	// custom transform
-	TreeNode.prototype.transform = function(iteratee, results) {
-		node.icon.get();  // icon dependency
-
-		results = results || [];
-		results.push(iteratee(this));
-		this.children.forEach(function(child) { child.transform(iteratee, results); });
-		return results;
-	}
-
-	// setup
-	var node = new TreeNode('root')
-	node.addChild(new TreeNode('root-child-1'));
-	node.children[0].addChild(new TreeNode('root-child-1-child-1'))
-	node.addChild(new TreeNode('root-child-2'));
-	node.children[1].addChild(new TreeNode('root-child-2-child-1'))
-	state.root = node;
-	t.equal(nodeCreateCount,	5);
-	t.equal(stats.refCount, 	5);
-	t.equal(renderCount, 			2);
-	t.equal(renderNodeCount, 	5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	////////////////////////////////////
-	// Icon
-	////////////////////////////////////
-
-	// update root icon
-	state.root.icon.set('file');
-	t.equal(nodeCreateCount,	5 + 0);
-	t.equal(stats.refCount, 	5 + 0);
-	t.equal(renderCount, 			2 + 1);
-	t.equal(renderNodeCount, 	5 + 5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// teardown
-	state.root = null;
-	t.equal(nodeCreateCount,	5 + 0 + 0);
-	t.equal(stats.refCount, 	0);
-	t.equal(renderCount, 			2 + 1 + 1);
-	t.equal(renderNodeCount, 	5 + 5 + 0);
-	t.deepEqual(state.renderedNodes.length, 0);
-
-	t.end();
-});
-
-test('transform tree (modifying render-only observable)', function(t) {
-	var pluckFn = TransformUtils.pluckFn;
-	var identity = TransformUtils.identity;
-	var testSet = TransformUtils.testSet();
-	var state = testSet.state;
-	var stats = testSet.stats;
-	var TreeNode = testSet.TreeNode;
-	var DisplayNode = testSet.DisplayNode;
-
-	var nodeCreateCount = 0;
-	var renderCount = 0;
-	var renderNodeCount = 0;
-	var renderIconCalc = 0;
-
-	var transformNode = m.createTransformer(function(node) {
-		nodeCreateCount++;
-		return new DisplayNode(node);
-	}, function cleanup(displayNode, node) { displayNode.destroy(); });
-
-	// transform nodes to renderedNodes
-	m.autorun(function() {
-		var renderedNodes = state.root ? state.root.map(transformNode) : [];
-		state.renderedNodes.replace(renderedNodes);
-	});
-
-	// render
-	m.autorun(function() {
-		renderCount++;
-		renderNodeCount += state.renderedNodes.length;
-
-		state.renderedNodes.forEach(function(renderedNode) {
-			m.autorun(function() {
-				renderIconCalc++;
-				renderedNode.node.icon.get();  // icon dependency
-			});
-		});
-	});
-
-	// setup
-	var node = new TreeNode('root')
-	node.addChild(new TreeNode('root-child-1'));
-	node.children[0].addChild(new TreeNode('root-child-1-child-1'))
-	node.addChild(new TreeNode('root-child-2'));
-	node.children[1].addChild(new TreeNode('root-child-2-child-1'))
-	state.root = node;
-	t.equal(nodeCreateCount,	5);
-	t.equal(stats.refCount, 	5);
-	t.equal(renderCount, 			2);
-	t.equal(renderNodeCount, 	5);
-	t.equal(renderIconCalc, 	5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	////////////////////////////////////
-	// Icon
-	////////////////////////////////////
-
-	// update root icon
-	state.root.icon.set('file');
-	t.equal(nodeCreateCount,	5 + 0);
-	t.equal(stats.refCount, 	5 + 0);
-	t.equal(renderCount, 			2 + 0);
-	t.equal(renderNodeCount, 	5 + 0);
-	t.equal(renderIconCalc, 	5 + 1);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// teardown
-	state.root = null;
-	t.equal(nodeCreateCount,	5 + 0 + 0);
-	t.equal(stats.refCount, 	0);
-	t.equal(renderCount, 			2 + 0 + 1);
-	t.equal(renderNodeCount, 	5 + 0 + 0);
-	t.equal(renderIconCalc, 	5 + 1 + 0);
-	t.deepEqual(state.renderedNodes.length, 0);
-
-	t.end();
-});
-
-test('transform tree (static tags / global filter only)', function(t) {
-	var intersection = TransformUtils.intersection;
-	var pluckFn = TransformUtils.pluckFn;
-	var identity = TransformUtils.identity;
-	var testSet = TransformUtils.testSet();
-	var state = testSet.state;
-	var stats = testSet.stats;
-	var TreeNode = testSet.TreeNode;
-	var DisplayNode = testSet.DisplayNode;
-
-	var nodeCreateCount = 0;
-	var renderCount = 0;
-	var renderNodeCount = 0;
-
-	var transformNode = m.createTransformer(function(node) {
-		nodeCreateCount++;
-		return new DisplayNode(node);
-	}, function cleanup(displayNode, node) { displayNode.destroy(); });
-
-	// transform nodes to renderedNodes
-	m.autorun(function() {
-		var renderedNodes = state.root ? state.root.transform(transformNode) : [];
-		state.renderedNodes.replace(renderedNodes);
-	});
-
-	// render
-	m.autorun(function() {
-		renderCount++;
-		renderNodeCount += state.renderedNodes.length;
-	});
-
-	// no tags
-	state.tags = m.observable.array([])
-
-	// custom transform
-	TreeNode.prototype.transform = function(iteratee, results) {
-		results = results || [];
-		if (!state.tags.length || intersection(state.tags, this.tags).length) results.push(iteratee(this));
-		this.children.forEach(function(child) { child.transform(iteratee, results); });
-		return results;
-	}
-
-	// setup
-	var node = new TreeNode('root', {tags: [1]});
-	node.addChild(new TreeNode('root-child-1', {tags: [2]}));
-	node.children[0].addChild(new TreeNode('root-child-1-child-1', {tags: [3]}));
-	node.addChild(new TreeNode('root-child-2', {tags: [2]}));
-	node.children[1].addChild(new TreeNode('root-child-2-child-1', {tags: [3]}));
-	state.root = node;
-	t.equal(nodeCreateCount,	5);
-	t.equal(stats.refCount, 	5);
-	t.equal(renderCount, 			2);
-	t.equal(renderNodeCount, 	5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	////////////////////////////////////
-	// Tags
-	////////////////////////////////////
-
-	// add search tag
-	state.tags.push(2);
-	t.equal(nodeCreateCount,	5 + 0);
-	t.equal(stats.refCount, 	5 - 3);
-	t.equal(renderCount, 			2 + 1);
-	t.equal(renderNodeCount, 	5 + 2);
-	t.deepEqual(state.renderedNodes.length, 2);
-	t.notDeepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root-child-1', 'root-child-2']);
-
-	// add search tag
-	state.tags.push(3);
-	t.equal(nodeCreateCount,	5 + 0 + 2);
-	t.equal(stats.refCount, 	5 - 3 + 2);
-	t.equal(renderCount, 			2 + 1 + 1);
-	t.equal(renderNodeCount, 	5 + 2 + 4);
-	t.deepEqual(state.renderedNodes.length, 4);
-	t.notDeepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// add search tag
-	state.tags.push(1);
-	t.equal(nodeCreateCount,	5 + 0 + 2 + 1);
-	t.equal(stats.refCount, 	5 - 3 + 2 + 1);
-	t.equal(renderCount, 			2 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	5 + 2 + 4 + 5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// remove search tags
-	state.tags.splice(0, 2);
-	t.equal(nodeCreateCount,	5 + 0 + 2 + 1 + 0);
-	t.equal(stats.refCount, 	5 - 3 + 2 + 1 - 4);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	5 + 2 + 4 + 5 + 1);
-	t.deepEqual(state.renderedNodes.length, 1);
-	t.notDeepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root']);
-
-	// teardown
-	state.root = null;
-	t.equal(nodeCreateCount,	5 + 0 + 2 + 1 + 0 + 0);
-	t.equal(stats.refCount, 	0);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	5 + 2 + 4 + 5 + 1 + 0);
-	t.deepEqual(state.renderedNodes.length, 0);
-
-	t.end();
-});
-
-test('transform tree (dynamic tags - peek / rebuild)', function(t) {
-	var intersection = TransformUtils.intersection;
-	var pluckFn = TransformUtils.pluckFn;
-	var identity = TransformUtils.identity;
-	var testSet = TransformUtils.testSet();
-	var state = testSet.state;
-	var stats = testSet.stats;
-	var TreeNode = testSet.TreeNode;
-	var DisplayNode = testSet.DisplayNode;
-
-	var nodeCreateCount = 0;
-	var renderCount = 0;
-	var renderNodeCount = 0;
-
-	var transformNode = m.createTransformer(function(node) {
-		nodeCreateCount++;
-		return new DisplayNode(node);
-	}, function cleanup(displayNode, node) { displayNode.destroy(); });
-
-	// transform nodes to renderedNodes
-	m.autorun(function() {
-		var renderedNodes = state.root ? state.root.transform(transformNode) : [];
-		state.renderedNodes.replace(renderedNodes);
-	});
-
-	// render
-	m.autorun(function() {
-		renderCount++;
-		renderNodeCount += state.renderedNodes.length;
-	});
-
-	// no tags
-	state.tags = m.observable.array([])
-
-	// custom transform
-	TreeNode.prototype.transform = function(iteratee, results) {
-		results = results || [];
-		if (!state.tags.length || intersection(state.tags, this.tags).length) results.push(iteratee(this));
-		this.children.forEach(function(child) { child.transform(iteratee, results); });
-		return results;
-	}
-
-	// setup
-	var node = new TreeNode('root', {tags: m.observable.array([1]	)});
-	node.addChild(new TreeNode('root-child-1', {tags: m.observable.array([2])}));
-	node.children[0].addChild(new TreeNode('root-child-1-child-1', {tags: m.observable.array([3])}));
-	node.addChild(new TreeNode('root-child-2', {tags: m.observable.array([2])}));
-	node.children[1].addChild(new TreeNode('root-child-2-child-1', {tags: m.observable.array([3])}));
-	state.root = node;
-	t.equal(nodeCreateCount,	5);
-	t.equal(stats.refCount, 	5);
-	t.equal(renderCount, 			2);
-	t.equal(renderNodeCount, 	5);
-	t.deepEqual(state.renderedNodes.length, 5);
-	t.deepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	////////////////////////////////////
-	// Tags
-	////////////////////////////////////
-
-	// add search tag
-	state.tags.push(2);
-	t.equal(nodeCreateCount,	5 + 0);
-	t.equal(stats.refCount, 	5 - 3);
-	t.equal(renderCount, 			2 + 1);
-	t.equal(renderNodeCount, 	5 + 2);
-	t.deepEqual(state.renderedNodes.length, 2);
-	t.notDeepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root-child-1', 'root-child-2']);
-
-	// modify search tag
-	state.root.tags.push(2);
-	t.equal(nodeCreateCount,	5 + 0 + 1);
-	t.equal(stats.refCount, 	5 - 3 + 1);
-	t.equal(renderCount, 			2 + 1 + 1);
-	t.equal(renderNodeCount, 	5 + 2 + 3);
-	t.deepEqual(state.renderedNodes.length, 3);
-	t.notDeepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1', 'root-child-2']);
-
-	// perform multiple search tag operations
-	m.transaction(function() {
-		state.root.tags.shift(); // no-op
-		state.root.find(function(node) { return node.name === 'root-child-1'; }).tags.splice(0);
-		state.root.find(function(node) { return node.name === 'root-child-1-child-1'; }).tags.push(2);
-		state.root.find(function(node) { return node.name === 'root-child-2-child-1'; }).tags.push(2);
-	});
-	t.equal(nodeCreateCount,	5 + 0 + 1 + 2);
-	t.equal(stats.refCount, 	5 - 3 + 1 + 1);
-	t.equal(renderCount, 			2 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	5 + 2 + 3 + 4);
-	t.deepEqual(state.renderedNodes.length, 4);
-	t.notDeepEqual(state.renderedNodes.map(pluckFn('node')), state.root.map(identity));
-	t.deepEqual(state.renderedNodes.map(pluckFn('node.name')), ['root', 'root-child-1-child-1', 'root-child-2', 'root-child-2-child-1']);
-
-	// teardown
-	state.root = null;
-	t.equal(nodeCreateCount,	5 + 0 + 1 + 2 + 0);
-	t.equal(stats.refCount, 	0);
-	t.equal(renderCount, 			2 + 1 + 1 + 1 + 1);
-	t.equal(renderNodeCount, 	5 + 2 + 3 + 4 + 0);
-	t.deepEqual(state.renderedNodes.length, 0);
-
-	t.end();
-});
+test("transform tree (modifying tree incrementally)", function(t) {
+    var pluckFn = TransformUtils.pluckFn
+    var identity = TransformUtils.identity
+    var testSet = TransformUtils.testSet()
+    var state = testSet.state
+    var stats = testSet.stats
+    var TreeNode = testSet.TreeNode
+    var DisplayNode = testSet.DisplayNode
+
+    var nodeCreateCount = 0
+    var renderCount = 0
+    var renderNodeCount = 0
+
+    var transformNode = m.createTransformer(
+        function(node) {
+            nodeCreateCount++
+            return new DisplayNode(node)
+        },
+        function cleanup(displayNode, node) {
+            displayNode.destroy()
+        }
+    )
+
+    // transform nodes to renderedNodes
+    m.autorun(function() {
+        // KM: ideally, I would like to do an assignment here, but it creates a cycle and would need to preserve ms.modifiers.structure:
+        //
+        // state.renderedNodes = state.root ? state.root.map(transformNode) : [];
+        //
+
+        var renderedNodes = state.root ? state.root.map(transformNode) : []
+        state.renderedNodes.replace(renderedNodes)
+    })
+
+    // render
+    m.autorun(function() {
+        renderCount++
+        renderNodeCount += state.renderedNodes.length
+    })
+
+    t.equal(nodeCreateCount, 0)
+    t.equal(stats.refCount, 0)
+    t.equal(renderCount, 1)
+    t.equal(renderNodeCount, 0)
+    t.deepEqual(state.renderedNodes.length, 0)
+
+    ////////////////////////////////////
+    // Incremental Tree
+    ////////////////////////////////////
+
+    // initialize root
+    var node = new TreeNode("root")
+    state.root = node
+    t.equal(nodeCreateCount, 1)
+    t.equal(stats.refCount, 1)
+    t.equal(renderCount, 2)
+    t.equal(renderNodeCount, 1)
+    t.deepEqual(state.renderedNodes.length, 1)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), ["root"])
+
+    // add first child
+    state.root.addChild(new TreeNode("root-child-1"))
+    t.equal(nodeCreateCount, 1 + 1)
+    t.equal(stats.refCount, 1 + 1)
+    t.equal(renderCount, 2 + 1)
+    t.equal(renderNodeCount, 1 + 2)
+    t.deepEqual(state.renderedNodes.length, 2)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), ["root", "root-child-1"])
+
+    // add second child
+    state.root.addChild(new TreeNode("root-child-2"))
+    t.equal(nodeCreateCount, 1 + 1 + 1)
+    t.equal(stats.refCount, 1 + 1 + 1)
+    t.equal(renderCount, 2 + 1 + 1)
+    t.equal(renderNodeCount, 1 + 2 + 3)
+    t.deepEqual(state.renderedNodes.length, 3)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-2"
+    ])
+
+    // add first child to second child
+    node = state.root.find(function(node) {
+        return node.name === "root-child-2"
+    })
+    node.addChild(new TreeNode("root-child-2-child-1"))
+    t.equal(nodeCreateCount, 1 + 1 + 1 + 1)
+    t.equal(stats.refCount, 1 + 1 + 1 + 1)
+    t.equal(renderCount, 2 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 1 + 2 + 3 + 4)
+    t.deepEqual(state.renderedNodes.length, 4)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // add first child to first child
+    node = state.root.find(function(node) {
+        return node.name === "root-child-1"
+    })
+    node.addChild(new TreeNode("root-child-1-child-1"))
+    t.equal(nodeCreateCount, 1 + 1 + 1 + 1 + 1)
+    t.equal(stats.refCount, 1 + 1 + 1 + 1 + 1)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 1 + 2 + 3 + 4 + 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // remove children from first child
+    node = state.root.find(function(node) {
+        return node.name === "root-child-1"
+    })
+    node.children.splice(0)
+    t.equal(nodeCreateCount, 1 + 1 + 1 + 1 + 1 + 0)
+    t.equal(stats.refCount, 1 + 1 + 1 + 1 + 1 - 1)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 1 + 2 + 3 + 4 + 5 + 4)
+    t.deepEqual(state.renderedNodes.length, 4)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // remove children from first child with no children should be a no-op
+    node = state.root.find(function(node) {
+        return node.name === "root-child-1"
+    })
+    node.children.splice(0)
+    t.equal(nodeCreateCount, 1 + 1 + 1 + 1 + 1 + 0 + 0)
+    t.equal(stats.refCount, 1 + 1 + 1 + 1 + 1 - 1 + 0)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 1 + 1 + 0)
+    t.equal(renderNodeCount, 1 + 2 + 3 + 4 + 5 + 4 + 0)
+    t.deepEqual(state.renderedNodes.length, 4)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // remove children from root
+    state.root.children.splice(0)
+    t.equal(nodeCreateCount, 1 + 1 + 1 + 1 + 1 + 0 + 0 + 0)
+    t.equal(stats.refCount, 1 + 1 + 1 + 1 + 1 - 1 + 0 - 3)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 1 + 1 + 0 + 1)
+    t.equal(renderNodeCount, 1 + 2 + 3 + 4 + 5 + 4 + 0 + 1)
+    t.deepEqual(state.renderedNodes.length, 1)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), ["root"])
+
+    // teardown
+    state.root = null
+    t.equal(nodeCreateCount, 1 + 1 + 1 + 1 + 1 + 0 + 0 + 0 + 0)
+    t.equal(stats.refCount, 0)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 1 + 1 + 0 + 1 + 1)
+    t.equal(renderNodeCount, 1 + 2 + 3 + 4 + 5 + 4 + 0 + 1 + 0)
+    t.deepEqual(state.renderedNodes.length, 0)
+
+    t.end()
+})
+
+test("transform tree (modifying tree incrementally)", function(t) {
+    var pluckFn = TransformUtils.pluckFn
+    var identity = TransformUtils.identity
+    var testSet = TransformUtils.testSet()
+    var state = testSet.state
+    var stats = testSet.stats
+    var TreeNode = testSet.TreeNode
+    var DisplayNode = testSet.DisplayNode
+
+    var nodeCreateCount = 0
+    var renderCount = 0
+    var renderNodeCount = 0
+
+    var transformNode = m.createTransformer(
+        function(node) {
+            nodeCreateCount++
+            return new DisplayNode(node)
+        },
+        function cleanup(displayNode, node) {
+            displayNode.destroy()
+        }
+    )
+
+    // transform nodes to renderedNodes
+    m.autorun(function() {
+        var renderedNodes = state.root ? state.root.map(transformNode) : []
+        state.renderedNodes.replace(renderedNodes)
+    })
+
+    // render
+    m.autorun(function() {
+        renderCount++
+        renderNodeCount += state.renderedNodes.length
+    })
+
+    // setup
+    var node = new TreeNode("root-1")
+    state.root = node
+    t.equal(nodeCreateCount, 1)
+    t.equal(stats.refCount, 1)
+    t.equal(renderCount, 2)
+    t.equal(renderNodeCount, 1)
+    t.deepEqual(state.renderedNodes.length, 1)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), ["root-1"])
+
+    ////////////////////////////////////
+    // Batch Tree (Partial)
+    ////////////////////////////////////
+
+    // add partial tree as a batch
+    var children = []
+    children.push(new TreeNode("root-1-child-1b"))
+    children[0].addChild(new TreeNode("root-1-child-1b-child-1"))
+    children.push(new TreeNode("root-1-child-2b"))
+    children[1].addChild(new TreeNode("root-1-child-2b-child-1"))
+    state.root.addChildren(children)
+    t.equal(nodeCreateCount, 1 + 4)
+    t.equal(stats.refCount, 1 + 4)
+    t.equal(renderCount, 2 + 1)
+    t.equal(renderNodeCount, 1 + 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root-1",
+        "root-1-child-1b",
+        "root-1-child-1b-child-1",
+        "root-1-child-2b",
+        "root-1-child-2b-child-1"
+    ])
+
+    // remove root-1
+    state.root = null
+    t.equal(nodeCreateCount, 1 + 4 + 0)
+    t.equal(stats.refCount, 1 + 4 - 5)
+    t.equal(renderCount, 2 + 1 + 1)
+    t.equal(renderNodeCount, 1 + 5 + 0)
+    t.deepEqual(state.renderedNodes.length, 0)
+
+    ////////////////////////////////////
+    // Batch Tree (Full)
+    ////////////////////////////////////
+
+    // add full tree as a batch
+    node = new TreeNode("root-2")
+    node.addChild(new TreeNode("root-2-child-1"))
+    node.children[0].addChild(new TreeNode("root-2-child-1-child-1"))
+    node.addChild(new TreeNode("root-2-child-2"))
+    node.children[1].addChild(new TreeNode("root-2-child-2-child-1"))
+    state.root = node
+    t.equal(nodeCreateCount, 1 + 4 + 0 + 5)
+    t.equal(stats.refCount, 1 + 4 - 5 + 5)
+    t.equal(renderCount, 2 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 1 + 5 + 0 + 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root-2",
+        "root-2-child-1",
+        "root-2-child-1-child-1",
+        "root-2-child-2",
+        "root-2-child-2-child-1"
+    ])
+
+    // teardown
+    state.root = null
+    t.equal(nodeCreateCount, 1 + 4 + 0 + 5 + 0)
+    t.equal(stats.refCount, 0)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 1 + 5 + 0 + 5 + 0)
+    t.deepEqual(state.renderedNodes.length, 0)
+
+    t.end()
+})
+
+test("transform tree (modifying expanded)", function(t) {
+    var pluckFn = TransformUtils.pluckFn
+    var identity = TransformUtils.identity
+    var testSet = TransformUtils.testSet()
+    var state = testSet.state
+    var stats = testSet.stats
+    var TreeNode = testSet.TreeNode
+    var DisplayNode = testSet.DisplayNode
+
+    var nodeCreateCount = 0
+    var renderCount = 0
+    var renderNodeCount = 0
+
+    var transformNode = m.createTransformer(
+        function(node) {
+            nodeCreateCount++
+            return new DisplayNode(node)
+        },
+        function cleanup(displayNode, node) {
+            displayNode.destroy()
+        }
+    )
+
+    // transform nodes to renderedNodes
+    m.autorun(function() {
+        var renderedNodes = state.root ? state.root.transform(transformNode) : []
+        state.renderedNodes.replace(renderedNodes)
+    })
+
+    // render
+    m.autorun(function() {
+        renderCount++
+        renderNodeCount += state.renderedNodes.length
+    })
+
+    // patch for collapsed
+    TreeNode.prototype.transform = function(iteratee, results) {
+        if (this.parent && state.collapsed.has(this.parent.path())) return results || [] // not visible
+
+        results = results || []
+        results.push(iteratee(this))
+        this.children.forEach(function(child) {
+            child.transform(iteratee, results)
+        })
+        return results
+    }
+
+    // setup
+    var node = new TreeNode("root")
+    node.addChild(new TreeNode("root-child-1"))
+    node.children[0].addChild(new TreeNode("root-child-1-child-1"))
+    node.addChild(new TreeNode("root-child-2"))
+    node.children[1].addChild(new TreeNode("root-child-2-child-1"))
+    state.root = node
+    t.equal(nodeCreateCount, 5)
+    t.equal(stats.refCount, 5)
+    t.equal(renderCount, 2)
+    t.equal(renderNodeCount, 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    ////////////////////////////////////
+    // Expanded
+    ////////////////////////////////////
+
+    // toggle root to collapsed
+    state.renderedNodes[0].toggleCollapsed()
+    t.equal(nodeCreateCount, 5 + 0)
+    t.equal(stats.refCount, 5 - 4)
+    t.equal(renderCount, 2 + 1)
+    t.equal(renderNodeCount, 5 + 1)
+    t.deepEqual(state.renderedNodes.length, 1)
+    t.notDeepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity)) // not a direct map of the tree nodes
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), ["root"])
+
+    // toggle root to expanded
+    state.renderedNodes[0].toggleCollapsed()
+    t.equal(nodeCreateCount, 5 + 0 + 4)
+    t.equal(stats.refCount, 5 - 4 + 4)
+    t.equal(renderCount, 2 + 1 + 1)
+    t.equal(renderNodeCount, 5 + 1 + 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // toggle child-1 collapsed
+    state.renderedNodes[1].toggleCollapsed()
+    t.equal(nodeCreateCount, 5 + 0 + 4 + 0)
+    t.equal(stats.refCount, 5 - 4 + 4 - 1)
+    t.equal(renderCount, 2 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 5 + 1 + 5 + 4)
+    t.deepEqual(state.renderedNodes.length, 4)
+    t.notDeepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity)) // not a direct map of the tree nodes
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // toggle child-2-child-1 collapsed should be a no-op
+    state.renderedNodes[state.renderedNodes.length - 1].toggleCollapsed()
+    t.equal(nodeCreateCount, 5 + 0 + 4 + 0 + 0)
+    t.equal(stats.refCount, 5 - 4 + 4 - 1 + 0)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 0)
+    t.equal(renderNodeCount, 5 + 1 + 5 + 4 + 0)
+    t.deepEqual(state.renderedNodes.length, 4)
+    t.notDeepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity)) // not a direct map of the tree nodes
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // teardown
+    state.root = null
+    t.equal(nodeCreateCount, 5 + 0 + 4 + 0 + 0 + 0)
+    t.equal(stats.refCount, 0)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 0 + 1)
+    t.equal(renderNodeCount, 5 + 1 + 5 + 4 + 0 + 0)
+    t.deepEqual(state.renderedNodes.length, 0)
+
+    t.end()
+})
+
+test("transform tree (modifying render observable)", function(t) {
+    var pluckFn = TransformUtils.pluckFn
+    var identity = TransformUtils.identity
+    var testSet = TransformUtils.testSet()
+    var state = testSet.state
+    var stats = testSet.stats
+    var TreeNode = testSet.TreeNode
+    var DisplayNode = testSet.DisplayNode
+
+    var nodeCreateCount = 0
+    var renderCount = 0
+    var renderNodeCount = 0
+    var renderIconCalc = 0
+
+    var transformNode = m.createTransformer(
+        function(node) {
+            nodeCreateCount++
+            return new DisplayNode(node)
+        },
+        function cleanup(displayNode, node) {
+            displayNode.destroy()
+        }
+    )
+
+    // transform nodes to renderedNodes
+    m.autorun(function() {
+        var renderedNodes = state.root ? state.root.transform(transformNode) : []
+        state.renderedNodes.replace(renderedNodes)
+    })
+
+    // render
+    m.autorun(function() {
+        renderCount++
+        renderNodeCount += state.renderedNodes.length
+    })
+
+    // custom transform
+    TreeNode.prototype.transform = function(iteratee, results) {
+        node.icon.get() // icon dependency
+
+        results = results || []
+        results.push(iteratee(this))
+        this.children.forEach(function(child) {
+            child.transform(iteratee, results)
+        })
+        return results
+    }
+
+    // setup
+    var node = new TreeNode("root")
+    node.addChild(new TreeNode("root-child-1"))
+    node.children[0].addChild(new TreeNode("root-child-1-child-1"))
+    node.addChild(new TreeNode("root-child-2"))
+    node.children[1].addChild(new TreeNode("root-child-2-child-1"))
+    state.root = node
+    t.equal(nodeCreateCount, 5)
+    t.equal(stats.refCount, 5)
+    t.equal(renderCount, 2)
+    t.equal(renderNodeCount, 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    ////////////////////////////////////
+    // Icon
+    ////////////////////////////////////
+
+    // update root icon
+    state.root.icon.set("file")
+    t.equal(nodeCreateCount, 5 + 0)
+    t.equal(stats.refCount, 5 + 0)
+    t.equal(renderCount, 2 + 1)
+    t.equal(renderNodeCount, 5 + 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // teardown
+    state.root = null
+    t.equal(nodeCreateCount, 5 + 0 + 0)
+    t.equal(stats.refCount, 0)
+    t.equal(renderCount, 2 + 1 + 1)
+    t.equal(renderNodeCount, 5 + 5 + 0)
+    t.deepEqual(state.renderedNodes.length, 0)
+
+    t.end()
+})
+
+test("transform tree (modifying render-only observable)", function(t) {
+    var pluckFn = TransformUtils.pluckFn
+    var identity = TransformUtils.identity
+    var testSet = TransformUtils.testSet()
+    var state = testSet.state
+    var stats = testSet.stats
+    var TreeNode = testSet.TreeNode
+    var DisplayNode = testSet.DisplayNode
+
+    var nodeCreateCount = 0
+    var renderCount = 0
+    var renderNodeCount = 0
+    var renderIconCalc = 0
+
+    var transformNode = m.createTransformer(
+        function(node) {
+            nodeCreateCount++
+            return new DisplayNode(node)
+        },
+        function cleanup(displayNode, node) {
+            displayNode.destroy()
+        }
+    )
+
+    // transform nodes to renderedNodes
+    m.autorun(function() {
+        var renderedNodes = state.root ? state.root.map(transformNode) : []
+        state.renderedNodes.replace(renderedNodes)
+    })
+
+    // render
+    m.autorun(function() {
+        renderCount++
+        renderNodeCount += state.renderedNodes.length
+
+        state.renderedNodes.forEach(function(renderedNode) {
+            m.autorun(function() {
+                renderIconCalc++
+                renderedNode.node.icon.get() // icon dependency
+            })
+        })
+    })
+
+    // setup
+    var node = new TreeNode("root")
+    node.addChild(new TreeNode("root-child-1"))
+    node.children[0].addChild(new TreeNode("root-child-1-child-1"))
+    node.addChild(new TreeNode("root-child-2"))
+    node.children[1].addChild(new TreeNode("root-child-2-child-1"))
+    state.root = node
+    t.equal(nodeCreateCount, 5)
+    t.equal(stats.refCount, 5)
+    t.equal(renderCount, 2)
+    t.equal(renderNodeCount, 5)
+    t.equal(renderIconCalc, 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    ////////////////////////////////////
+    // Icon
+    ////////////////////////////////////
+
+    // update root icon
+    state.root.icon.set("file")
+    t.equal(nodeCreateCount, 5 + 0)
+    t.equal(stats.refCount, 5 + 0)
+    t.equal(renderCount, 2 + 0)
+    t.equal(renderNodeCount, 5 + 0)
+    t.equal(renderIconCalc, 5 + 1)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // teardown
+    state.root = null
+    t.equal(nodeCreateCount, 5 + 0 + 0)
+    t.equal(stats.refCount, 0)
+    t.equal(renderCount, 2 + 0 + 1)
+    t.equal(renderNodeCount, 5 + 0 + 0)
+    t.equal(renderIconCalc, 5 + 1 + 0)
+    t.deepEqual(state.renderedNodes.length, 0)
+
+    t.end()
+})
+
+test("transform tree (static tags / global filter only)", function(t) {
+    var intersection = TransformUtils.intersection
+    var pluckFn = TransformUtils.pluckFn
+    var identity = TransformUtils.identity
+    var testSet = TransformUtils.testSet()
+    var state = testSet.state
+    var stats = testSet.stats
+    var TreeNode = testSet.TreeNode
+    var DisplayNode = testSet.DisplayNode
+
+    var nodeCreateCount = 0
+    var renderCount = 0
+    var renderNodeCount = 0
+
+    var transformNode = m.createTransformer(
+        function(node) {
+            nodeCreateCount++
+            return new DisplayNode(node)
+        },
+        function cleanup(displayNode, node) {
+            displayNode.destroy()
+        }
+    )
+
+    // transform nodes to renderedNodes
+    m.autorun(function() {
+        var renderedNodes = state.root ? state.root.transform(transformNode) : []
+        state.renderedNodes.replace(renderedNodes)
+    })
+
+    // render
+    m.autorun(function() {
+        renderCount++
+        renderNodeCount += state.renderedNodes.length
+    })
+
+    // no tags
+    state.tags = m.observable.array([])
+
+    // custom transform
+    TreeNode.prototype.transform = function(iteratee, results) {
+        results = results || []
+        if (!state.tags.length || intersection(state.tags, this.tags).length)
+            results.push(iteratee(this))
+        this.children.forEach(function(child) {
+            child.transform(iteratee, results)
+        })
+        return results
+    }
+
+    // setup
+    var node = new TreeNode("root", { tags: [1] })
+    node.addChild(new TreeNode("root-child-1", { tags: [2] }))
+    node.children[0].addChild(new TreeNode("root-child-1-child-1", { tags: [3] }))
+    node.addChild(new TreeNode("root-child-2", { tags: [2] }))
+    node.children[1].addChild(new TreeNode("root-child-2-child-1", { tags: [3] }))
+    state.root = node
+    t.equal(nodeCreateCount, 5)
+    t.equal(stats.refCount, 5)
+    t.equal(renderCount, 2)
+    t.equal(renderNodeCount, 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    ////////////////////////////////////
+    // Tags
+    ////////////////////////////////////
+
+    // add search tag
+    state.tags.push(2)
+    t.equal(nodeCreateCount, 5 + 0)
+    t.equal(stats.refCount, 5 - 3)
+    t.equal(renderCount, 2 + 1)
+    t.equal(renderNodeCount, 5 + 2)
+    t.deepEqual(state.renderedNodes.length, 2)
+    t.notDeepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), ["root-child-1", "root-child-2"])
+
+    // add search tag
+    state.tags.push(3)
+    t.equal(nodeCreateCount, 5 + 0 + 2)
+    t.equal(stats.refCount, 5 - 3 + 2)
+    t.equal(renderCount, 2 + 1 + 1)
+    t.equal(renderNodeCount, 5 + 2 + 4)
+    t.deepEqual(state.renderedNodes.length, 4)
+    t.notDeepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // add search tag
+    state.tags.push(1)
+    t.equal(nodeCreateCount, 5 + 0 + 2 + 1)
+    t.equal(stats.refCount, 5 - 3 + 2 + 1)
+    t.equal(renderCount, 2 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 5 + 2 + 4 + 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // remove search tags
+    state.tags.splice(0, 2)
+    t.equal(nodeCreateCount, 5 + 0 + 2 + 1 + 0)
+    t.equal(stats.refCount, 5 - 3 + 2 + 1 - 4)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 5 + 2 + 4 + 5 + 1)
+    t.deepEqual(state.renderedNodes.length, 1)
+    t.notDeepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), ["root"])
+
+    // teardown
+    state.root = null
+    t.equal(nodeCreateCount, 5 + 0 + 2 + 1 + 0 + 0)
+    t.equal(stats.refCount, 0)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 5 + 2 + 4 + 5 + 1 + 0)
+    t.deepEqual(state.renderedNodes.length, 0)
+
+    t.end()
+})
+
+test("transform tree (dynamic tags - peek / rebuild)", function(t) {
+    var intersection = TransformUtils.intersection
+    var pluckFn = TransformUtils.pluckFn
+    var identity = TransformUtils.identity
+    var testSet = TransformUtils.testSet()
+    var state = testSet.state
+    var stats = testSet.stats
+    var TreeNode = testSet.TreeNode
+    var DisplayNode = testSet.DisplayNode
+
+    var nodeCreateCount = 0
+    var renderCount = 0
+    var renderNodeCount = 0
+
+    var transformNode = m.createTransformer(
+        function(node) {
+            nodeCreateCount++
+            return new DisplayNode(node)
+        },
+        function cleanup(displayNode, node) {
+            displayNode.destroy()
+        }
+    )
+
+    // transform nodes to renderedNodes
+    m.autorun(function() {
+        var renderedNodes = state.root ? state.root.transform(transformNode) : []
+        state.renderedNodes.replace(renderedNodes)
+    })
+
+    // render
+    m.autorun(function() {
+        renderCount++
+        renderNodeCount += state.renderedNodes.length
+    })
+
+    // no tags
+    state.tags = m.observable.array([])
+
+    // custom transform
+    TreeNode.prototype.transform = function(iteratee, results) {
+        results = results || []
+        if (!state.tags.length || intersection(state.tags, this.tags).length)
+            results.push(iteratee(this))
+        this.children.forEach(function(child) {
+            child.transform(iteratee, results)
+        })
+        return results
+    }
+
+    // setup
+    var node = new TreeNode("root", { tags: m.observable.array([1]) })
+    node.addChild(new TreeNode("root-child-1", { tags: m.observable.array([2]) }))
+    node.children[0].addChild(
+        new TreeNode("root-child-1-child-1", { tags: m.observable.array([3]) })
+    )
+    node.addChild(new TreeNode("root-child-2", { tags: m.observable.array([2]) }))
+    node.children[1].addChild(
+        new TreeNode("root-child-2-child-1", { tags: m.observable.array([3]) })
+    )
+    state.root = node
+    t.equal(nodeCreateCount, 5)
+    t.equal(stats.refCount, 5)
+    t.equal(renderCount, 2)
+    t.equal(renderNodeCount, 5)
+    t.deepEqual(state.renderedNodes.length, 5)
+    t.deepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    ////////////////////////////////////
+    // Tags
+    ////////////////////////////////////
+
+    // add search tag
+    state.tags.push(2)
+    t.equal(nodeCreateCount, 5 + 0)
+    t.equal(stats.refCount, 5 - 3)
+    t.equal(renderCount, 2 + 1)
+    t.equal(renderNodeCount, 5 + 2)
+    t.deepEqual(state.renderedNodes.length, 2)
+    t.notDeepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), ["root-child-1", "root-child-2"])
+
+    // modify search tag
+    state.root.tags.push(2)
+    t.equal(nodeCreateCount, 5 + 0 + 1)
+    t.equal(stats.refCount, 5 - 3 + 1)
+    t.equal(renderCount, 2 + 1 + 1)
+    t.equal(renderNodeCount, 5 + 2 + 3)
+    t.deepEqual(state.renderedNodes.length, 3)
+    t.notDeepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1",
+        "root-child-2"
+    ])
+
+    // perform multiple search tag operations
+    m.transaction(function() {
+        state.root.tags.shift() // no-op
+        state.root
+            .find(function(node) {
+                return node.name === "root-child-1"
+            })
+            .tags.splice(0)
+        state.root
+            .find(function(node) {
+                return node.name === "root-child-1-child-1"
+            })
+            .tags.push(2)
+        state.root
+            .find(function(node) {
+                return node.name === "root-child-2-child-1"
+            })
+            .tags.push(2)
+    })
+    t.equal(nodeCreateCount, 5 + 0 + 1 + 2)
+    t.equal(stats.refCount, 5 - 3 + 1 + 1)
+    t.equal(renderCount, 2 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 5 + 2 + 3 + 4)
+    t.deepEqual(state.renderedNodes.length, 4)
+    t.notDeepEqual(state.renderedNodes.map(pluckFn("node")), state.root.map(identity))
+    t.deepEqual(state.renderedNodes.map(pluckFn("node.name")), [
+        "root",
+        "root-child-1-child-1",
+        "root-child-2",
+        "root-child-2-child-1"
+    ])
+
+    // teardown
+    state.root = null
+    t.equal(nodeCreateCount, 5 + 0 + 1 + 2 + 0)
+    t.equal(stats.refCount, 0)
+    t.equal(renderCount, 2 + 1 + 1 + 1 + 1)
+    t.equal(renderNodeCount, 5 + 2 + 3 + 4 + 0)
+    t.deepEqual(state.renderedNodes.length, 0)
+
+    t.end()
+})
 
 // https://github.com/mobxjs/mobx/issues/886
-test('transform with primitive key', function(t) {
-	m.extras.resetGlobalState();
+test("transform with primitive key", function(t) {
+    m.extras.resetGlobalState()
 
-	function Bob() {
-		this.num = Math.floor(Math.random() * 1000);
-		m.extendObservable(this, {
-			get name() {
-				return 'Bob' + this.num;
-			}
-		});
-	}
+    function Bob() {
+        this.num = Math.floor(Math.random() * 1000)
+        m.extendObservable(this, {
+            get name() {
+                return "Bob" + this.num
+            }
+        })
+    }
 
-	var observableBobs = m.observable([]);
-	var bobs = [];
+    var observableBobs = m.observable([])
+    var bobs = []
 
-	var bobFactory = m.createTransformer(function(key) {
-		return new Bob();
-	});
+    var bobFactory = m.createTransformer(function(key) {
+        return new Bob()
+    })
 
-	m.autorun(function() {
-		bobs = observableBobs.map(function(bob) {
-			return bobFactory(bob);
-		});
-	});
+    m.autorun(function() {
+        bobs = observableBobs.map(function(bob) {
+            return bobFactory(bob)
+        })
+    })
 
-	observableBobs.push('Bob1');
-	observableBobs.push('Bob1');
-	t.equal(bobs[0].name, bobs[1].name);
+    observableBobs.push("Bob1")
+    observableBobs.push("Bob1")
+    t.equal(bobs[0].name, bobs[1].name)
 
-	observableBobs.clear();
-	observableBobs.push('Bob1');
-	observableBobs.push('Bob2');
-	t.notEqual(bobs[0].name, bobs[1].name);
+    observableBobs.clear()
+    observableBobs.push("Bob1")
+    observableBobs.push("Bob2")
+    t.notEqual(bobs[0].name, bobs[1].name)
 
-	observableBobs.clear();
-	observableBobs.push(1);
-	observableBobs.push(1);
-	t.equal(bobs[0].name, bobs[1].name);
+    observableBobs.clear()
+    observableBobs.push(1)
+    observableBobs.push(1)
+    t.equal(bobs[0].name, bobs[1].name)
 
-	observableBobs.clear();
-	observableBobs.push(1);
-	observableBobs.push(2);
-	t.notEqual(bobs[0].name, bobs[1].name);
+    observableBobs.clear()
+    observableBobs.push(1)
+    observableBobs.push(2)
+    t.notEqual(bobs[0].name, bobs[1].name)
 
-	t.end();
-});
-
+    t.end()
+})

--- a/test/typescript/tape.d.ts
+++ b/test/typescript/tape.d.ts
@@ -3,198 +3,201 @@
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Haoqun Jiang <https://github.com/sodatea>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module 'tape' {
-	export = tape;
+declare module "tape" {
+    export = tape
 
-	/**
+    /**
 	 * Create a new test with an optional name string and optional opts object.
 	 * cb(t) fires with the new test object t once all preceeding tests have finished.
 	 * Tests execute serially.
 	 */
-	function tape(name: string, cb: tape.TestCase): void;
-	function tape(name: string, opts: tape.TestOptions, cb: tape.TestCase): void;
-	function tape(cb: tape.TestCase): void;
-	function tape(opts: tape.TestOptions, cb: tape.TestCase): void;
+    function tape(name: string, cb: tape.TestCase): void
+    function tape(name: string, opts: tape.TestOptions, cb: tape.TestCase): void
+    function tape(cb: tape.TestCase): void
+    function tape(opts: tape.TestOptions, cb: tape.TestCase): void
 
-	module tape {
+    namespace tape {
+        interface TestCase {
+            (test: Test): void
+        }
 
-		interface TestCase {
-			(test: Test): void;
-		}
-
-		/**
+        /**
 		 * Available opts options for the tape function.
 		 */
-		interface TestOptions {
-			skip?: boolean;		// See tape.skip.
-			timeout?: number;	// Set a timeout for the test, after which it will fail. See tape.timeoutAfter.
-		}
+        interface TestOptions {
+            skip?: boolean // See tape.skip.
+            timeout?: number // Set a timeout for the test, after which it will fail. See tape.timeoutAfter.
+        }
 
-		/**
+        /**
 		 * Options for the createStream function.
 		 */
-		interface StreamOptions {
-			objectMode?: boolean;
-		}
+        interface StreamOptions {
+            objectMode?: boolean
+        }
 
-		/**
+        /**
 		 * Generate a new test that will be skipped over.
 		 */
-		export function skip(name: string, cb: tape.TestCase): void;
+        export function skip(name: string, cb: tape.TestCase): void
 
-		/**
+        /**
 		 * Like test(name, cb) except if you use .only this is the only test case that will run for the entire process, all other test cases using tape will be ignored.
 		 */
-		export function only(name: string, cb: tape.TestCase): void;
+        export function only(name: string, cb: tape.TestCase): void
 
-		/**
+        /**
 		 * Create a new test harness instance, which is a function like test(), but with a new pending stack and test state.
 		 */
-		export function createHarness(): typeof tape;
-		/**
+        export function createHarness(): typeof tape
+        /**
 		 * Create a stream of output, bypassing the default output stream that writes messages to console.log().
 		 * By default stream will be a text stream of TAP output, but you can get an object stream instead by setting opts.objectMode to true.
 		 */
-		export function createStream(opts?: tape.StreamOptions): any;
+        export function createStream(opts?: tape.StreamOptions): any
 
-		interface Test {
-			/**
+        interface Test {
+            /**
 			 * Create a subtest with a new test handle st from cb(st) inside the current test.
 			 * cb(st) will only fire when t finishes.
 			 * Additional tests queued up after t will not be run until all subtests finish.
 			 */
-			test(name: string, cb: tape.TestCase): void;
+            test(name: string, cb: tape.TestCase): void
 
-			/**
+            /**
 			 * Declare that n assertions should be run. end() will be called automatically after the nth assertion.
 			 * If there are any more assertions after the nth, or after end() is called, they will generate errors.
 			 */
-			plan(n: number): void;
+            plan(n: number): void
 
-			/**
+            /**
 			 * Declare the end of a test explicitly.
 			 * If err is passed in t.end will assert that it is falsey.
 			 */
-			end(err?: any): void;
+            end(err?: any): void
 
-			/**
+            /**
 			 * Generate a failing assertion with a message msg.
 			 */
-			fail(msg?: string): void;
+            fail(msg?: string): void
 
-			/**
+            /**
 			 * Generate a passing assertion with a message msg.
 			 */
-			pass(msg?: string): void;
+            pass(msg?: string): void
 
-			/**
+            /**
 			 * Automatically timeout the test after X ms.
 			 */
-			timeoutAfter(ms: number): void;
+            timeoutAfter(ms: number): void
 
-			/**
+            /**
 			 * Generate an assertion that will be skipped over.
 			 */
-			skip(msg?: string): void;
+            skip(msg?: string): void
 
-			/**
+            /**
 			 * Assert that value is truthy with an optional description message msg.
 			 */
-			ok(value: any, msg?: string): void;
-			true(value: any, msg?: string): void;
-			assert(value: any, msg?: string): void;
+            ok(value: any, msg?: string): void
+            true(value: any, msg?: string): void
+            assert(value: any, msg?: string): void
 
-			/**
+            /**
 			 * Assert that value is falsy with an optional description message msg.
 			 */
-			notOk(value: any, msg?: string): void;
-			false(value: any, msg?: string): void;
-			notok(value: any, msg?: string): void;
+            notOk(value: any, msg?: string): void
+            false(value: any, msg?: string): void
+            notok(value: any, msg?: string): void
 
-			/**
+            /**
 			 * Assert that err is falsy.
 			 * If err is non-falsy, use its err.message as the description message.
 			 */
-			error(err: any, msg?: string): void;
-			ifError(err: any, msg?: string): void;
-			ifErr(err: any, msg?: string): void;
-			iferror(err: any, msg?: string): void;
+            error(err: any, msg?: string): void
+            ifError(err: any, msg?: string): void
+            ifErr(err: any, msg?: string): void
+            iferror(err: any, msg?: string): void
 
-			/**
+            /**
 			 * Assert that a === b with an optional description msg.
 			 */
-			equal(a: any, b: any, msg?: string): void;
-			equals(a: any, b: any, msg?: string): void;
-			isEqual(a: any, b: any, msg?: string): void;
-			is(a: any, b: any, msg?: string): void;
-			strictEqual(a: any, b: any, msg?: string): void;
-			strictEquals(a: any, b: any, msg?: string): void;
+            equal(a: any, b: any, msg?: string): void
+            equals(a: any, b: any, msg?: string): void
+            isEqual(a: any, b: any, msg?: string): void
+            is(a: any, b: any, msg?: string): void
+            strictEqual(a: any, b: any, msg?: string): void
+            strictEquals(a: any, b: any, msg?: string): void
 
-			/**
+            /**
 			 * Assert that a !== b with an optional description msg.
 			 */
-			notEqual(a: any, b: any, msg?: string): void;
-			notEquals(a: any, b: any, msg?: string): void;
-			notStrictEqual(a: any, b: any, msg?: string): void;
-			notStrictEquals(a: any, b: any, msg?: string): void;
-			isNotEqual(a: any, b: any, msg?: string): void;
-			isNot(a: any, b: any, msg?: string): void;
-			not(a: any, b: any, msg?: string): void;
-			doesNotEqual(a: any, b: any, msg?: string): void;
-			isInequal(a: any, b: any, msg?: string): void;
+            notEqual(a: any, b: any, msg?: string): void
+            notEquals(a: any, b: any, msg?: string): void
+            notStrictEqual(a: any, b: any, msg?: string): void
+            notStrictEquals(a: any, b: any, msg?: string): void
+            isNotEqual(a: any, b: any, msg?: string): void
+            isNot(a: any, b: any, msg?: string): void
+            not(a: any, b: any, msg?: string): void
+            doesNotEqual(a: any, b: any, msg?: string): void
+            isInequal(a: any, b: any, msg?: string): void
 
-			/**
+            /**
 			 * Assert that a and b have the same structure and nested values using node's deepEqual() algorithm with strict comparisons (===) on leaf nodes and an optional description msg.
 			 */
-			deepEqual(a: any, b: any, msg?: string): void;
-			deepEquals(a: any, b: any, msg?: string): void;
-			isEquivalent(a: any, b: any, msg?: string): void;
-			same(a: any, b: any, msg?: string): void;
+            deepEqual(a: any, b: any, msg?: string): void
+            deepEquals(a: any, b: any, msg?: string): void
+            isEquivalent(a: any, b: any, msg?: string): void
+            same(a: any, b: any, msg?: string): void
 
-			/**
+            /**
 			 * Assert that a and b do not have the same structure and nested values using node's deepEqual() algorithm with strict comparisons (===) on leaf nodes and an optional description msg.
 			 */
-			notDeepEqual(a: any, b: any, msg?: string): void;
-			notEquivalent(a: any, b: any, msg?: string): void;
-			notDeeply(a: any, b: any, msg?: string): void;
-			notSame(a: any, b: any, msg?: string): void;
-			isNotDeepEqual(a: any, b: any, msg?: string): void;
-			isNotDeeply(a: any, b: any, msg?: string): void;
-			isNotEquivalent(a: any, b: any, msg?: string): void;
-			isInequivalent(a: any, b: any, msg?: string): void;
+            notDeepEqual(a: any, b: any, msg?: string): void
+            notEquivalent(a: any, b: any, msg?: string): void
+            notDeeply(a: any, b: any, msg?: string): void
+            notSame(a: any, b: any, msg?: string): void
+            isNotDeepEqual(a: any, b: any, msg?: string): void
+            isNotDeeply(a: any, b: any, msg?: string): void
+            isNotEquivalent(a: any, b: any, msg?: string): void
+            isInequivalent(a: any, b: any, msg?: string): void
 
-			/**
+            /**
 			 * Assert that a and b have the same structure and nested values using node's deepEqual() algorithm with loose comparisons (==) on leaf nodes and an optional description msg.
 			 */
-			deepLooseEqual(a: any, b: any, msg?: string): void;
-			looseEqual(a: any, b: any, msg?: string): void;
-			looseEquals(a: any, b: any, msg?: string): void;
+            deepLooseEqual(a: any, b: any, msg?: string): void
+            looseEqual(a: any, b: any, msg?: string): void
+            looseEquals(a: any, b: any, msg?: string): void
 
-			/**
+            /**
 			 * Assert that a and b do not have the same structure and nested values using node's deepEqual() algorithm with loose comparisons (==) on leaf nodes and an optional description msg.
 			 */
-			notDeepLooseEqual(a: any, b: any, msg?: string): void;
-			notLooseEqual(a: any, b: any, msg?: string): void;
-			notLooseEquals(a: any, b: any, msg?: string): void;
+            notDeepLooseEqual(a: any, b: any, msg?: string): void
+            notLooseEqual(a: any, b: any, msg?: string): void
+            notLooseEquals(a: any, b: any, msg?: string): void
 
-			/**
+            /**
 			 * Assert that the function call fn() throws an exception.
 			 * expected, if present, must be a RegExp or Function, which is used to test the exception object.
 			 */
-			throws(fn: () => void, msg?: string): void;
-			throws(fn: () => void, exceptionExpected: RegExp | (() => void), msg?: string): void;
+            throws(fn: () => void, msg?: string): void
+            throws(fn: () => void, exceptionExpected: RegExp | (() => void), msg?: string): void
 
-			/**
+            /**
 			 * Assert that the function call fn() does not throw an exception.
 			 */
-			doesNotThrow(fn: () => void, msg?: string): void;
-			doesNotThrow(fn: () => void, exceptionExpected: RegExp | (() => void), msg?: string): void;
+            doesNotThrow(fn: () => void, msg?: string): void
+            doesNotThrow(
+                fn: () => void,
+                exceptionExpected: RegExp | (() => void),
+                msg?: string
+            ): void
 
-			/**
+            /**
 			 * Print a message without breaking the tap output.
 			 * (Useful when using e.g. tap-colorize where output is buffered & console.log will print in incorrect order vis-a-vis tap output.)
 			 */
-			comment(msg: string): void;
-		}
-	}
+            comment(msg: string): void
+        }
+    }
 }

--- a/test/typescript/typescript-tests.ts
+++ b/test/typescript/typescript-tests.ts
@@ -1,30 +1,48 @@
 /// <reference path='tape.d.ts' />
 import {
-    observe, computed, observable, autorun, autorunAsync, extendObservable, action,
-    IObservableObject, IObservableArray, IArrayChange, IArraySplice, IArrayWillChange, IArrayWillSplice,
-    IObservableValue, isObservable, isObservableObject,
-    extras, Atom, transaction, IObjectChange, spy, useStrict, isAction
-} from "../../lib/mobx";
-import * as test from 'tape';
-import * as mobx from "../../lib/mobx";
+    observe,
+    computed,
+    observable,
+    autorun,
+    autorunAsync,
+    extendObservable,
+    action,
+    IObservableObject,
+    IObservableArray,
+    IArrayChange,
+    IArraySplice,
+    IArrayWillChange,
+    IArrayWillSplice,
+    IObservableValue,
+    isObservable,
+    isObservableObject,
+    extras,
+    Atom,
+    transaction,
+    IObjectChange,
+    spy,
+    useStrict,
+    isAction
+} from "../../lib/mobx"
+import * as test from "tape"
+import * as mobx from "../../lib/mobx"
 
-var v = observable(3);
-observe(v, () => {});
+var v = observable(3)
+observe(v, () => {})
 
-var a = observable([1,2,3]);
+var a = observable([1, 2, 3])
 
-var testFunction = function(a:any) {};
-
-
+var testFunction = function(a: any) {}
 
 class Order {
-    @observable price:number = 3;
-    @observable amount:number = 2;
-    @observable orders:string[] = [];
-    @observable aFunction = testFunction;
+    @observable price: number = 3
+    @observable amount: number = 2
+    @observable orders: string[] = []
+    @observable aFunction = testFunction
 
-    @computed get total() {
-        return this.amount * this.price * (1 + this.orders.length);
+    @computed
+    get total() {
+        return this.amount * this.price * (1 + this.orders.length)
     }
 
     // Typescript classes cannot be defined inside functions,
@@ -32,94 +50,96 @@ class Order {
     // @observable hoepie() { return 3; }
 }
 
-test('decorators', function(t) {
-	var o = new Order();
-	t.equal(isObservableObject(o), true);
-	t.equal(isObservable(o, 'amount'), true);
-	t.equal(isObservable(o, 'total'), true);
+test("decorators", function(t) {
+    var o = new Order()
+    t.equal(isObservableObject(o), true)
+    t.equal(isObservable(o, "amount"), true)
+    t.equal(isObservable(o, "total"), true)
 
-	var events: any[] = [];
-	var d1 = observe(o, (ev: IObjectChange) => events.push(ev.name, ev.oldValue));
-	var d2 = observe(o, 'price', (ev) => events.push(ev.newValue, ev.oldValue));
-	var d3 = observe(o, 'total', (ev) => events.push(ev.newValue, ev.oldValue));
+    var events: any[] = []
+    var d1 = observe(o, (ev: IObjectChange) => events.push(ev.name, ev.oldValue))
+    var d2 = observe(o, "price", ev => events.push(ev.newValue, ev.oldValue))
+    var d3 = observe(o, "total", ev => events.push(ev.newValue, ev.oldValue))
 
-	o.price = 4;
+    o.price = 4
 
-	d1();
-	d2();
-	d3();
+    d1()
+    d2()
+    d3()
 
-	o.price = 5;
+    o.price = 5
 
-	t.deepEqual(events, [
-		8, // new total
-		6, // old total
-		4, // new price
-		3, // old price
-		"price", // event name
-		3, // event oldValue
-	]);
+    t.deepEqual(events, [
+        8, // new total
+        6, // old total
+        4, // new price
+        3, // old price
+        "price", // event name
+        3 // event oldValue
+    ])
 
-	t.end();
+    t.end()
 })
 
-test('observable', function(t) {
-    var a = observable(3);
-    var b = computed(() => a.get() * 2);
-    t.equal(b.get(), 6);
-    t.end();
+test("observable", function(t) {
+    var a = observable(3)
+    var b = computed(() => a.get() * 2)
+    t.equal(b.get(), 6)
+    t.end()
 })
 
-test('annotations', function(t) {
-    var order1totals:number[] = [];
-    var order1 = new Order();
-    var order2 = new Order();
+test("annotations", function(t) {
+    var order1totals: number[] = []
+    var order1 = new Order()
+    var order2 = new Order()
 
     var disposer = autorun(() => {
         order1totals.push(order1.total)
-    });
+    })
 
-    order2.price = 4;
-    order1.amount = 1;
+    order2.price = 4
+    order1.amount = 1
 
-    t.equal(order1.price, 3);
-    t.equal(order1.total, 3);
-    t.equal(order2.total, 8);
-    order2.orders.push('bla');
-    t.equal(order2.total, 16);
+    t.equal(order1.price, 3)
+    t.equal(order1.total, 3)
+    t.equal(order2.total, 8)
+    order2.orders.push("bla")
+    t.equal(order2.total, 16)
 
-    order1.orders.splice(0,0,'boe', 'hoi');
-    t.deepEqual(order1totals, [6,3,9]);
+    order1.orders.splice(0, 0, "boe", "hoi")
+    t.deepEqual(order1totals, [6, 3, 9])
 
-    disposer();
-    order1.orders.pop();
-    t.equal(order1.total, 6);
-    t.deepEqual(order1totals, [6,3,9]);
+    disposer()
+    order1.orders.pop()
+    t.equal(order1.total, 6)
+    t.deepEqual(order1totals, [6, 3, 9])
 
-    t.equal(order1.aFunction, testFunction);
-    var x = function() { return 3; };
-    order1.aFunction = x;
-    t.equal(order1.aFunction, x);
+    t.equal(order1.aFunction, testFunction)
+    var x = function() {
+        return 3
+    }
+    order1.aFunction = x
+    t.equal(order1.aFunction, x)
 
-    t.end();
+    t.end()
 })
 
-test('scope', function(t) {
+test("scope", function(t) {
     var x = observable({
         y: 3,
         // this wo't work here.
-        get z () {
-			return 2 * this.y
-		}
-    });
+        get z() {
+            return 2 * this.y
+        }
+    })
 
-    t.equal(x.z, 6);
-    x.y = 4;
-    t.equal(x.z, 8);
+    t.equal(x.z, 6)
+    x.y = 4
+    t.equal(x.z, 8)
 
     interface IThing {
-        z: number;
-        y: number;
+        z: number
+        y: number
     }
 
     const Thing = function() {
@@ -127,1093 +147,1157 @@ test('scope', function(t) {
             y: 3,
             // this will work here
             z: computed(() => 2 * this.y)
-        });
+        })
     }
 
-    var x3: IThing = new (<any>Thing)();
-    t.equal(x3.z, 6);
-    x3.y = 4;
-    t.equal(x3.z, 8);
+    var x3: IThing = new (<any>Thing)()
+    t.equal(x3.z, 6)
+    x3.y = 4
+    t.equal(x3.z, 8)
 
-    t.end();
+    t.end()
 })
 
-test('typing', function(t) {
-    var ar:IObservableArray<number> = observable([1,2]);
-    ar.intercept((c:IArrayWillChange<number>|IArrayWillSplice<number>) => {
-        console.log(c.type);
-		return null;
-    });
-    ar.observe((d:IArrayChange<number>|IArraySplice<number>) => {
-        console.log(d.type);
-    });
+test("typing", function(t) {
+    var ar: IObservableArray<number> = observable([1, 2])
+    ar.intercept((c: IArrayWillChange<number> | IArrayWillSplice<number>) => {
+        console.log(c.type)
+        return null
+    })
+    ar.observe((d: IArrayChange<number> | IArraySplice<number>) => {
+        console.log(d.type)
+    })
 
-    var ar2:IObservableArray<number> = observable([1,2]);
-    ar2.intercept((c:IArrayWillChange<number>|IArrayWillSplice<number>) => {
-        console.log(c.type);
-		return null;
-    });
-    ar2.observe((d:IArrayChange<number>|IArraySplice<number>) => {
-        console.log(d.type);
-    });
+    var ar2: IObservableArray<number> = observable([1, 2])
+    ar2.intercept((c: IArrayWillChange<number> | IArrayWillSplice<number>) => {
+        console.log(c.type)
+        return null
+    })
+    ar2.observe((d: IArrayChange<number> | IArraySplice<number>) => {
+        console.log(d.type)
+    })
 
-    var x:IObservableValue<number> = observable(3);
+    var x: IObservableValue<number> = observable(3)
 
-    var d2 = autorunAsync(function() {
+    var d2 = autorunAsync(function() {})
 
-    });
-
-    t.end();
+    t.end()
 })
 
-const state:any = observable({
+const state: any = observable({
     authToken: null
-});
+})
 
+test("issue8", function(t) {
+    t.throws(() => {
+        class LoginStoreTest {
+            loggedIn2: boolean
+            constructor() {
+                extendObservable(this, {
+                    loggedIn2: () => !!state.authToken
+                })
+            }
 
-test('issue8', function(t){
-	t.throws(() => {
-		class LoginStoreTest {
-			loggedIn2: boolean;
-			constructor() {
-				extendObservable(this, {
-					loggedIn2: () => !!state.authToken
-				});
-			}
-
-			@observable get loggedIn() {
-				return !!state.authToken;
-			}
-		}
-		const store = new LoginStoreTest();
-	}, /@computed/);
-    t.end();
+            @observable
+            get loggedIn() {
+                return !!state.authToken
+            }
+        }
+        const store = new LoginStoreTest()
+    }, /@computed/)
+    t.end()
 })
 
 class Box {
-    @observable uninitialized:any;
-    @observable height = 20;
-    @observable sizes = [2];
-    @observable someFunc = function () { return 2; }
-    @computed get width() {
-        return this.height * this.sizes.length * this.someFunc() * (this.uninitialized ? 2 : 1);
+    @observable uninitialized: any
+    @observable height = 20
+    @observable sizes = [2]
+    @observable
+    someFunc = function() {
+        return 2
+    }
+    @computed
+    get width() {
+        return this.height * this.sizes.length * this.someFunc() * (this.uninitialized ? 2 : 1)
     }
 }
 
-test('box', function(t) {
-    var box = new Box();
+test("box", function(t) {
+    var box = new Box()
 
-    var ar:number[] = []
+    var ar: number[] = []
 
     autorun(() => {
-        ar.push(box.width);
-    });
+        ar.push(box.width)
+    })
 
-    t.deepEqual(ar.slice(), [40]);
-    box.height = 10;
-    t.deepEqual(ar.slice(), [40, 20]);
-    box.sizes.push(3, 4);
-    t.deepEqual(ar.slice(), [40, 20, 60]);
-    box.someFunc = () => 7;
-    t.deepEqual(ar.slice(), [40, 20, 60, 210]);
-    box.uninitialized = true;
-    t.deepEqual(ar.slice(), [40, 20, 60, 210, 420]);
+    t.deepEqual(ar.slice(), [40])
+    box.height = 10
+    t.deepEqual(ar.slice(), [40, 20])
+    box.sizes.push(3, 4)
+    t.deepEqual(ar.slice(), [40, 20, 60])
+    box.someFunc = () => 7
+    t.deepEqual(ar.slice(), [40, 20, 60, 210])
+    box.uninitialized = true
+    t.deepEqual(ar.slice(), [40, 20, 60, 210, 420])
 
-    t.end();
+    t.end()
 })
 
-test('computed setter should succeed', function(t) {
-	class Bla {
-		@observable a = 3;
-		@computed get propX() {
-			return this.a * 2;
-		}
-		set propX(v) {
-			this.a = v
-		}
-	}
+test("computed setter should succeed", function(t) {
+    class Bla {
+        @observable a = 3
+        @computed
+        get propX() {
+            return this.a * 2
+        }
+        set propX(v) {
+            this.a = v
+        }
+    }
 
-	const b = new Bla();
-	t.equal(b.propX, 6);
-	b.propX = 4;
-	t.equal(b.propX, 8);
+    const b = new Bla()
+    t.equal(b.propX, 6)
+    b.propX = 4
+    t.equal(b.propX, 8)
 
-	t.end();
-});
+    t.end()
+})
 
-test('atom clock example', function(t) {
-	let ticks = 0;
-	const time_factor = 500; // speed up / slow down tests
+test("atom clock example", function(t) {
+    let ticks = 0
+    const time_factor = 500 // speed up / slow down tests
 
-	class Clock {
-		atom: Atom;
-		intervalHandler: number = null;
-		currentDateTime: string;
+    class Clock {
+        atom: Atom
+        intervalHandler: number = null
+        currentDateTime: string
 
-		constructor() {
-			console.log("create");
-			// creates an atom to interact with the mobx core algorithm
-			this.atom =	new Atom(
-				// first param a name for this atom, for debugging purposes
-				"Clock",
-				// second (optional) parameter: callback for when this atom transitions from unobserved to observed.
-				() => this.startTicking(),
-				// third (optional) parameter: callback for when this atom transitions from observed to unobserved
-				// note that the same atom transition multiple times between these two states
-				() => this.stopTicking()
-			);
-		}
+        constructor() {
+            console.log("create")
+            // creates an atom to interact with the mobx core algorithm
+            this.atom = new Atom(
+                // first param a name for this atom, for debugging purposes
+                "Clock",
+                // second (optional) parameter: callback for when this atom transitions from unobserved to observed.
+                () => this.startTicking(),
+                // third (optional) parameter: callback for when this atom transitions from observed to unobserved
+                // note that the same atom transition multiple times between these two states
+                () => this.stopTicking()
+            )
+        }
 
-		getTime() {
-			console.log("get time");
-			// let mobx now this observable data source has been used
-			this.atom.reportObserved(); // will trigger startTicking and thus tick
-			return this.currentDateTime;
-		}
+        getTime() {
+            console.log("get time")
+            // let mobx now this observable data source has been used
+            this.atom.reportObserved() // will trigger startTicking and thus tick
+            return this.currentDateTime
+        }
 
-		tick() {
-			console.log("tick");
-			ticks++;
-			this.currentDateTime = new Date().toString();
-			this.atom.reportChanged();
-		}
+        tick() {
+            console.log("tick")
+            ticks++
+            this.currentDateTime = new Date().toString()
+            this.atom.reportChanged()
+        }
 
-		startTicking() {
-			console.log("start ticking");
-			this.tick();
-			// The cast to any here is to force TypeScript to select the correct
-			// overload of setInterval: the one that returns number, as opposed
-			// to the one defined in @types/node
-			this.intervalHandler = setInterval(() => this.tick(), (1 * time_factor) as any);
-		}
+        startTicking() {
+            console.log("start ticking")
+            this.tick()
+            // The cast to any here is to force TypeScript to select the correct
+            // overload of setInterval: the one that returns number, as opposed
+            // to the one defined in @types/node
+            this.intervalHandler = setInterval(() => this.tick(), (1 * time_factor) as any)
+        }
 
-		stopTicking() {
-			console.log("stop ticking");
-			clearInterval(this.intervalHandler);
-			this.intervalHandler = null;
-		}
-	}
+        stopTicking() {
+            console.log("stop ticking")
+            clearInterval(this.intervalHandler)
+            this.intervalHandler = null
+        }
+    }
 
-	const clock = new Clock();
+    const clock = new Clock()
 
-	const values: string[] = [];
+    const values: string[] = []
 
-	// ... prints the time each second
-	const disposer = autorun(() => {
-		values.push(clock.getTime());
-		console.log(clock.getTime());
-	});
+    // ... prints the time each second
+    const disposer = autorun(() => {
+        values.push(clock.getTime())
+        console.log(clock.getTime())
+    })
 
-	// printing stops. If nobody else uses the same `clock` the clock will stop ticking as well.
-	setTimeout(disposer, 4.5 * time_factor);
+    // printing stops. If nobody else uses the same `clock` the clock will stop ticking as well.
+    setTimeout(disposer, 4.5 * time_factor)
 
-	setTimeout(() => {
-		t.equal(ticks, 5);
-		t.equal(values.length, 5);
-		t.equal(values.filter(x => x.length > 0).length, 5);
-		t.end();
-	}, 10 * time_factor);
+    setTimeout(() => {
+        t.equal(ticks, 5)
+        t.equal(values.length, 5)
+        t.equal(values.filter(x => x.length > 0).length, 5)
+        t.end()
+    }, 10 * time_factor)
+})
 
-});
+test("typescript: parameterized computed decorator", t => {
+    class TestClass {
+        @observable x = 3
+        @observable y = 3
+        @computed.struct
+        get boxedSum() {
+            return { sum: Math.round(this.x) + Math.round(this.y) }
+        }
+    }
 
-test('typescript: parameterized computed decorator', (t) => {
-	class TestClass {
-		@observable x = 3;
-		@observable y = 3;
-		@computed.struct get boxedSum() {
-			return { sum: Math.round(this.x) + Math.round(this.y) };
-		}
-	}
+    const t1 = new TestClass()
+    const changes: { sum: number }[] = []
+    const d = autorun(() => changes.push(t1.boxedSum))
 
-	const t1 = new TestClass();
-	const changes: { sum: number}[] = [];
-	const d = autorun(() => changes.push(t1.boxedSum));
+    t1.y = 4 // change
+    t.equal(changes.length, 2)
+    t1.y = 4.2 // no change
+    t.equal(changes.length, 2)
+    transaction(() => {
+        t1.y = 3
+        t1.x = 4
+    }) // no change
+    t.equal(changes.length, 2)
+    t1.x = 6 // change
+    t.equal(changes.length, 3)
+    d()
 
-	t1.y = 4; // change
-	t.equal(changes.length, 2);
-	t1.y = 4.2; // no change
-	t.equal(changes.length, 2);
-	transaction(() => {
-		t1.y = 3;
-		t1.x = 4;
-	}); // no change
-	t.equal(changes.length, 2);
-	t1.x = 6; // change
-	t.equal(changes.length, 3);
-	d();
+    t.deepEqual(changes, [{ sum: 6 }, { sum: 7 }, { sum: 9 }])
 
-	t.deepEqual(changes, [{ sum: 6 }, { sum: 7 }, { sum: 9 }]);
+    t.end()
+})
 
-	t.end();
-});
+test("issue 165", function(t) {
+    function report<T>(msg: string, value: T) {
+        console.log(msg, ":", value)
+        return value
+    }
 
-test('issue 165', function(t) {
-	function report<T>(msg: string, value: T) {
-		console.log(msg, ':', value);
-		return value;
-	}
+    class Card {
+        constructor(public game: Game, public id: number) {}
 
-	class Card {
-		constructor(public game: Game, public id: number) {
-		}
+        @computed
+        get isWrong() {
+            return report(
+                "Computing isWrong for card " + this.id,
+                this.isSelected && this.game.isMatchWrong
+            )
+        }
 
-		@computed get isWrong() {
-			return report('Computing isWrong for card ' + this.id, this.isSelected && this.game.isMatchWrong);
-		}
+        @computed
+        get isSelected() {
+            return report(
+                "Computing isSelected for card" + this.id,
+                this.game.firstCardSelected === this || this.game.secondCardSelected === this
+            )
+        }
+    }
 
-		@computed get isSelected() {
-			return report('Computing isSelected for card'+ this.id,
-				this.game.firstCardSelected === this || this.game.secondCardSelected === this);
-		}
-	}
+    class Game {
+        @observable firstCardSelected: Card = null
+        @observable secondCardSelected: Card = null
 
-	class Game {
-		@observable firstCardSelected: Card = null;
-		@observable secondCardSelected: Card = null;
+        @computed
+        get isMatchWrong() {
+            return report(
+                "Computing isMatchWrong",
+                this.secondCardSelected !== null &&
+                    this.firstCardSelected.id !== this.secondCardSelected.id
+            )
+        }
+    }
 
-		@computed get isMatchWrong() {
-			return report('Computing isMatchWrong',
-				this.secondCardSelected !== null && this.firstCardSelected.id !== this.secondCardSelected.id);
-		}
-	}
+    let game = new Game()
+    let card1 = new Card(game, 1),
+        card2 = new Card(game, 2)
 
-	let game = new Game();
-	let card1 = new Card(game, 1), card2 = new Card(game, 2);
+    autorun(() => {
+        console.log("card1.isWrong =", card1.isWrong)
+        console.log("card2.isWrong =", card2.isWrong)
+        console.log("------------------------------")
+    })
 
-	autorun(() => {
-		console.log('card1.isWrong =', card1.isWrong);
-		console.log('card2.isWrong =', card2.isWrong);
-		console.log('------------------------------');
-	});
+    console.log("Selecting first card")
+    game.firstCardSelected = card1
+    console.log("Selecting second card")
+    game.secondCardSelected = card2
 
-	console.log('Selecting first card');
-	game.firstCardSelected = card1;
-	console.log('Selecting second card');
-	game.secondCardSelected = card2;
+    t.equal(card1.isWrong, true)
+    t.equal(card2.isWrong, true)
 
-	t.equal(card1.isWrong, true);
-	t.equal(card2.isWrong, true);
+    t.end()
+})
 
-	t.end();
-});
+test("issue 191 - shared initializers (ts)", function(t) {
+    class Test {
+        @observable obj = { a: 1 }
+        @observable array = [2]
+    }
 
-test('issue 191 - shared initializers (ts)', function(t) {
-	class Test {
-		@observable obj = { a: 1 };
-		@observable array = [2];
-	}
+    var t1 = new Test()
+    t1.obj.a = 2
+    t1.array.push(3)
 
-	var t1 = new Test();
-	t1.obj.a = 2;
-	t1.array.push(3);
+    var t2 = new Test()
+    t2.obj.a = 3
+    t2.array.push(4)
 
-	var t2 = new Test();
-	t2.obj.a = 3;
-	t2.array.push(4);
+    t.notEqual(t1.obj, t2.obj)
+    t.notEqual(t1.array, t2.array)
+    t.equal(t1.obj.a, 2)
+    t.equal(t2.obj.a, 3)
 
-	t.notEqual(t1.obj, t2.obj);
-	t.notEqual(t1.array, t2.array);
-	t.equal(t1.obj.a, 2);
-	t.equal(t2.obj.a, 3);
+    t.deepEqual(t1.array.slice(), [2, 3])
+    t.deepEqual(t2.array.slice(), [2, 4])
 
-	t.deepEqual(t1.array.slice(), [2,3]);
-	t.deepEqual(t2.array.slice(), [2,4]);
-
-	t.end();
-});
+    t.end()
+})
 
 function normalizeSpyEvents(events: any[]) {
-	events.forEach(ev => {
-		delete ev.fn;
-		delete ev.time;
-	});
-	return events;
+    events.forEach(ev => {
+        delete ev.fn
+        delete ev.time
+    })
+    return events
 }
 
 test("action decorator (typescript)", function(t) {
-	class Store {
-		constructor(private multiplier: number) {}
+    class Store {
+        constructor(private multiplier: number) {}
 
-		@action
-		add(a: number, b: number): number {
-			return (a + b) * this.multiplier;
-		}
-	}
+        @action
+        add(a: number, b: number): number {
+            return (a + b) * this.multiplier
+        }
+    }
 
-	const store1 =  new Store(2);
-	const store2 = new Store(3);
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(2, 2), 12);
-	t.equal(store1.add(1, 1), 4);
+    const store1 = new Store(2)
+    const store2 = new Store(3)
+    const events: any[] = []
+    const d = spy(events.push.bind(events))
+    t.equal(store1.add(3, 4), 14)
+    t.equal(store2.add(2, 2), 12)
+    t.equal(store1.add(1, 1), 4)
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 2, 2 ], name: "add", spyReportStart: true, object: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 1, 1 ], name: "add", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true }
-	]);
+    t.deepEqual(normalizeSpyEvents(events), [
+        { arguments: [3, 4], name: "add", spyReportStart: true, object: store1, type: "action" },
+        { spyReportEnd: true },
+        { arguments: [2, 2], name: "add", spyReportStart: true, object: store2, type: "action" },
+        { spyReportEnd: true },
+        { arguments: [1, 1], name: "add", spyReportStart: true, object: store1, type: "action" },
+        { spyReportEnd: true }
+    ])
 
-	d();
-	t.end();
-});
+    d()
+    t.end()
+})
 
 test("custom action decorator (typescript)", function(t) {
-	class Store {
-		constructor(private multiplier: number) {}
+    class Store {
+        constructor(private multiplier: number) {}
 
-		@action("zoem zoem")
-		add(a: number, b: number): number {
-			return (a + b) * this.multiplier;
-		}
-	}
+        @action("zoem zoem")
+        add(a: number, b: number): number {
+            return (a + b) * this.multiplier
+        }
+    }
 
-	const store1 =  new Store(2);
-	const store2 =  new Store(3);
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(2, 2), 12);
-	t.equal(store1.add(1, 1), 4);
+    const store1 = new Store(2)
+    const store2 = new Store(3)
+    const events: any[] = []
+    const d = spy(events.push.bind(events))
+    t.equal(store1.add(3, 4), 14)
+    t.equal(store2.add(2, 2), 12)
+    t.equal(store1.add(1, 1), 4)
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 2, 2 ], name: "zoem zoem", spyReportStart: true, object: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 1, 1 ], name: "zoem zoem", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true }
-	]);
+    t.deepEqual(normalizeSpyEvents(events), [
+        {
+            arguments: [3, 4],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store1,
+            type: "action"
+        },
+        { spyReportEnd: true },
+        {
+            arguments: [2, 2],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store2,
+            type: "action"
+        },
+        { spyReportEnd: true },
+        {
+            arguments: [1, 1],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store1,
+            type: "action"
+        },
+        { spyReportEnd: true }
+    ])
 
-	d();
-	t.end();
-});
+    d()
+    t.end()
+})
 
 test("action decorator on field (typescript)", function(t) {
-	class Store {
-		constructor(private multiplier: number) {}
+    class Store {
+        constructor(private multiplier: number) {}
 
-		@action
-		add = (a: number, b: number) => {
-			return (a + b) * this.multiplier;
-		};
-	}
+        @action
+        add = (a: number, b: number) => {
+            return (a + b) * this.multiplier
+        }
+    }
 
-	const store1 = new Store(2);
-	const store2 = new Store(7);
+    const store1 = new Store(2)
+    const store2 = new Store(7)
 
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(4, 5), 63);
-	t.equal(store1.add(2, 2), 8);
+    const events: any[] = []
+    const d = spy(events.push.bind(events))
+    t.equal(store1.add(3, 4), 14)
+    t.equal(store2.add(4, 5), 63)
+    t.equal(store1.add(2, 2), 8)
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "add", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 4, 5 ], name: "add", spyReportStart: true, object: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 2, 2 ], name: "add", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true }
-	]);
+    t.deepEqual(normalizeSpyEvents(events), [
+        { arguments: [3, 4], name: "add", spyReportStart: true, object: store1, type: "action" },
+        { spyReportEnd: true },
+        { arguments: [4, 5], name: "add", spyReportStart: true, object: store2, type: "action" },
+        { spyReportEnd: true },
+        { arguments: [2, 2], name: "add", spyReportStart: true, object: store1, type: "action" },
+        { spyReportEnd: true }
+    ])
 
-	d();
-	t.end();
-});
+    d()
+    t.end()
+})
 
 test("custom action decorator on field (typescript)", function(t) {
-	class Store {
-		constructor(private multiplier: number) {}
+    class Store {
+        constructor(private multiplier: number) {}
 
-		@action("zoem zoem")
-		add = (a: number, b: number) => {
-			return (a + b) * this.multiplier;
-		};
-	}
+        @action("zoem zoem")
+        add = (a: number, b: number) => {
+            return (a + b) * this.multiplier
+        }
+    }
 
-	const store1 = new Store(2);
-	const store2 = new Store(7);
+    const store1 = new Store(2)
+    const store2 = new Store(7)
 
-	const events: any[] = [];
-	const d = spy(events.push.bind(events));
-	t.equal(store1.add(3, 4), 14);
-	t.equal(store2.add(4, 5), 63);
-	t.equal(store1.add(2, 2), 8);
+    const events: any[] = []
+    const d = spy(events.push.bind(events))
+    t.equal(store1.add(3, 4), 14)
+    t.equal(store2.add(4, 5), 63)
+    t.equal(store1.add(2, 2), 8)
 
-	t.deepEqual(normalizeSpyEvents(events),	[
-		{ arguments: [ 3, 4 ], name: "zoem zoem", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 4, 5 ], name: "zoem zoem", spyReportStart: true, object: store2, type: "action" },
-		{ spyReportEnd: true },
-		{ arguments: [ 2, 2 ], name: "zoem zoem", spyReportStart: true, object: store1, type: "action" },
-		{ spyReportEnd: true }
-	]);
+    t.deepEqual(normalizeSpyEvents(events), [
+        {
+            arguments: [3, 4],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store1,
+            type: "action"
+        },
+        { spyReportEnd: true },
+        {
+            arguments: [4, 5],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store2,
+            type: "action"
+        },
+        { spyReportEnd: true },
+        {
+            arguments: [2, 2],
+            name: "zoem zoem",
+            spyReportStart: true,
+            object: store1,
+            type: "action"
+        },
+        { spyReportEnd: true }
+    ])
 
-	d();
-	t.end();
-});
+    d()
+    t.end()
+})
 
 test("267 (typescript) should be possible to declare properties observable outside strict mode", t => {
-	useStrict(true);
+    useStrict(true)
 
-	class Store {
-		@observable timer: number;
-	}
+    class Store {
+        @observable timer: number
+    }
 
-	useStrict(false);
-	t.end();
-});
+    useStrict(false)
+    t.end()
+})
 
 test("288 atom not detected for object property", t => {
-	class Store {
-		@observable foo = '';
-	}
+    class Store {
+        @observable foo = ""
+    }
 
-	const store = new Store();
+    const store = new Store()
 
-	mobx.observe(store, 'foo', () => {
-		console.log('Change observed');
-	}, true);
+    mobx.observe(
+        store,
+        "foo",
+        () => {
+            console.log("Change observed")
+        },
+        true
+    )
 
-	t.end()
+    t.end()
 })
 
 test("observable performance", t => {
-	const AMOUNT = 100000;
+    const AMOUNT = 100000
 
-	class A {
-		@observable a = 1;
-		@observable b = 2;
-		@observable c = 3;
-		@computed get d() {
-			return this.a + this.b + this.c;
-		}
-	}
+    class A {
+        @observable a = 1
+        @observable b = 2
+        @observable c = 3
+        @computed
+        get d() {
+            return this.a + this.b + this.c
+        }
+    }
 
-	const objs: any[] = [];
-	const start = Date.now();
+    const objs: any[] = []
+    const start = Date.now()
 
-	for (var i = 0; i < AMOUNT; i++)
-		objs.push(new A());
+    for (var i = 0; i < AMOUNT; i++) objs.push(new A())
 
-	console.log("created in ", Date.now() - start);
+    console.log("created in ", Date.now() - start)
 
-	for (var j = 0; j < 4; j++) {
-		for (var i = 0; i < AMOUNT; i++) {
-			const obj = objs[i]
-			obj.a += 3;
-			obj.b *= 4;
-			obj.c = obj.b - obj.a;
-			obj.d;
-		}
-	}
+    for (var j = 0; j < 4; j++) {
+        for (var i = 0; i < AMOUNT; i++) {
+            const obj = objs[i]
+            obj.a += 3
+            obj.b *= 4
+            obj.c = obj.b - obj.a
+            obj.d
+        }
+    }
 
-	console.log("changed in ", Date.now() - start);
+    console.log("changed in ", Date.now() - start)
 
-	t.end();
+    t.end()
 })
 
 test("unbound methods", t => {
-	class A {
-		// shared across all instances
-		@action m1() {
+    class A {
+        // shared across all instances
+        @action
+        m1() {}
 
-		}
+        // per instance
+        @action m2 = () => {}
+    }
 
-		// per instance
-		@action m2 = () => {};
-	}
+    const a1 = new A()
+    const a2 = new A()
 
-	const a1 = new A();
-	const a2 = new A();
-
-	t.equal(a1.m1, a2.m1);
-	t.notEqual(a1.m2, a2.m2);
-	t.equal(a1.hasOwnProperty("m1"), false);
-	t.equal(a1.hasOwnProperty("m2"), true);
-	t.equal(a2.hasOwnProperty("m1"), false);
-	t.equal(a2.hasOwnProperty("m2"), true);
-	t.end();
-
+    t.equal(a1.m1, a2.m1)
+    t.notEqual(a1.m2, a2.m2)
+    t.equal(a1.hasOwnProperty("m1"), false)
+    t.equal(a1.hasOwnProperty("m2"), true)
+    t.equal(a2.hasOwnProperty("m1"), false)
+    t.equal(a2.hasOwnProperty("m2"), true)
+    t.end()
 })
 
 test("inheritance", t => {
-	class A {
-		@observable a = 2;
-	}
+    class A {
+        @observable a = 2
+    }
 
-	class B extends A {
-		@observable b = 3;
-		@computed get c() {
-			return this.a + this.b;
-		}
-	}
+    class B extends A {
+        @observable b = 3
+        @computed
+        get c() {
+            return this.a + this.b
+        }
+    }
 
-	const b1 = new B();
-	const b2 = new B();
-	const values: any[] = []
-	mobx.autorun(() => values.push(b1.c + b2.c));
+    const b1 = new B()
+    const b2 = new B()
+    const values: any[] = []
+    mobx.autorun(() => values.push(b1.c + b2.c))
 
-	b1.a = 3;
-	b1.b = 4;
-	b2.b = 5;
-	b2.a = 6;
+    b1.a = 3
+    b1.b = 4
+    b2.b = 5
+    b2.a = 6
 
-	t.deepEqual(values, [
-		10,
-		11,
-		12,
-		14,
-		18
-	])
+    t.deepEqual(values, [10, 11, 12, 14, 18])
 
-	t.end();
+    t.end()
 })
 
 test("inheritance overrides observable", t => {
-	class A {
-		@observable a = 2;
-	}
+    class A {
+        @observable a = 2
+    }
 
-	class B {
-		@observable a = 5;
-		@observable b = 3;
-		@computed get c() {
-			return this.a + this.b;
-		}
-	}
+    class B {
+        @observable a = 5
+        @observable b = 3
+        @computed
+        get c() {
+            return this.a + this.b
+        }
+    }
 
-	const b1 = new B();
-	const b2 = new B();
-	const values: any[] = []
-	mobx.autorun(() => values.push(b1.c + b2.c));
+    const b1 = new B()
+    const b2 = new B()
+    const values: any[] = []
+    mobx.autorun(() => values.push(b1.c + b2.c))
 
-	b1.a = 3;
-	b1.b = 4;
-	b2.b = 5;
-	b2.a = 6;
+    b1.a = 3
+    b1.b = 4
+    b2.b = 5
+    b2.a = 6
 
-	t.deepEqual(values, [
-		16,
-		14,
-		15,
-		17,
-		18
-	])
+    t.deepEqual(values, [16, 14, 15, 17, 18])
 
-	t.end();
+    t.end()
 })
 
 test("reusing initializers", t => {
-	class A {
-		@observable a = 3;
-		@observable b = this.a + 2;
-		@computed get c() {
-			return this.a + this.b;
-		}
-		@computed get d() {
-			return this.c + 1;
-		}
-	}
+    class A {
+        @observable a = 3
+        @observable b = this.a + 2
+        @computed
+        get c() {
+            return this.a + this.b
+        }
+        @computed
+        get d() {
+            return this.c + 1
+        }
+    }
 
-	const a = new A();
-	const values: any[] = [];
-	mobx.autorun(() => values.push(a.d));
+    const a = new A()
+    const values: any[] = []
+    mobx.autorun(() => values.push(a.d))
 
-	a.a = 4;
-	t.deepEqual(values, [
-		9,
-		10
-	])
+    a.a = 4
+    t.deepEqual(values, [9, 10])
 
-	t.end();
+    t.end()
 })
 
 test("enumerability", t => {
-	class A {
-		@observable a = 1; // enumerable, on proto
-		@computed get b () { return this.a } // non-enumerable, on proto
-		@action m() {} // non-enumerable, on proto
-		@action m2 = () => {}; // non-enumerable, on self
-	}
+    class A {
+        @observable a = 1 // enumerable, on proto
+        @computed
+        get b() {
+            return this.a
+        } // non-enumerable, on proto
+        @action
+        m() {} // non-enumerable, on proto
+        @action m2 = () => {} // non-enumerable, on self
+    }
 
-	const a = new A();
+    const a = new A()
 
-	// not initialized yet
-	let ownProps = Object.keys(a);
-	let props: string[] = [];
-	for (var key in a)
-		props.push(key);
+    // not initialized yet
+    let ownProps = Object.keys(a)
+    let props: string[] = []
+    for (var key in a) props.push(key)
 
-	t.deepEqual(ownProps, [
-		"a" // yeej!
-	]);
+    t.deepEqual(ownProps, [
+        "a" // yeej!
+    ])
 
-	t.deepEqual(props, [ // also 'a' would be ok
-		"a"
-	]);
+    t.deepEqual(props, [
+        // also 'a' would be ok
+        "a"
+    ])
 
-	t.equal("a" in a, true);
-	t.equal(a.hasOwnProperty("a"), true);
-	t.equal(a.hasOwnProperty("b"), false);
-	t.equal(a.hasOwnProperty("m"), false);
-	t.equal(a.hasOwnProperty("m2"), true);
+    t.equal("a" in a, true)
+    t.equal(a.hasOwnProperty("a"), true)
+    t.equal(a.hasOwnProperty("b"), false)
+    t.equal(a.hasOwnProperty("m"), false)
+    t.equal(a.hasOwnProperty("m2"), true)
 
-	t.equal(mobx.isAction(a.m), true);
-	t.equal(mobx.isAction(a.m2), true);
+    t.equal(mobx.isAction(a.m), true)
+    t.equal(mobx.isAction(a.m2), true)
 
-	// after initialization
-	a.a;
-	a.b;
-	a.m;
-	a.m2;
+    // after initialization
+    a.a
+    a.b
+    a.m
+    a.m2
 
-	ownProps = Object.keys(a);
-	props = [];
-	for (var key in a)
-		props.push(key);
+    ownProps = Object.keys(a)
+    props = []
+    for (var key in a) props.push(key)
 
-	t.deepEqual(ownProps, [
-		"a"
-	]);
+    t.deepEqual(ownProps, ["a"])
 
-	t.deepEqual(props, [
-		"a"
-	]);
+    t.deepEqual(props, ["a"])
 
-	t.equal("a" in a, true);
-	t.equal(a.hasOwnProperty("a"), true);
-	t.equal(a.hasOwnProperty("b"), false);
-	t.equal(a.hasOwnProperty("m"), false);
-	t.equal(a.hasOwnProperty("m2"), true);
+    t.equal("a" in a, true)
+    t.equal(a.hasOwnProperty("a"), true)
+    t.equal(a.hasOwnProperty("b"), false)
+    t.equal(a.hasOwnProperty("m"), false)
+    t.equal(a.hasOwnProperty("m2"), true)
 
-
-	t.end();
+    t.end()
 })
 
 test("issue 285 (babel)", t => {
-	const {observable, toJS} = mobx;
+    const { observable, toJS } = mobx
 
-	class Todo {
-		id = 1;
-		@observable title: string;
-		@observable finished = false;
-		@observable childThings = [1,2,3];
-		constructor(title: string) {
-			this.title = title;
-		}
-	}
+    class Todo {
+        id = 1
+        @observable title: string
+        @observable finished = false
+        @observable childThings = [1, 2, 3]
+        constructor(title: string) {
+            this.title = title
+        }
+    }
 
-	var todo = new Todo("Something to do");
+    var todo = new Todo("Something to do")
 
-	t.deepEqual(toJS(todo), {
-		id: 1,
-		title: "Something to do",
-		finished: false,
-		childThings: [1,2,3]
-	})
+    t.deepEqual(toJS(todo), {
+        id: 1,
+        title: "Something to do",
+        finished: false,
+        childThings: [1, 2, 3]
+    })
 
-	t.end();
+    t.end()
 })
 
 test("verify object assign (typescript)", t => {
-	class Todo {
-		@observable title = "test";
-		@computed get upperCase() {
-			return this.title.toUpperCase()
-		}
-	}
+    class Todo {
+        @observable title = "test"
+        @computed
+        get upperCase() {
+            return this.title.toUpperCase()
+        }
+    }
 
-	t.deepEqual((Object as any).assign({}, new Todo()), {
-		title: "test"
-	});
-	t.end();
+    t.deepEqual((Object as any).assign({}, new Todo()), {
+        title: "test"
+    })
+    t.end()
 })
-
 
 test("379, inheritable actions (typescript)", t => {
-	class A {
-		@action method() {
-			return 42;
-		}
-	}
+    class A {
+        @action
+        method() {
+            return 42
+        }
+    }
 
-	class B extends A {
-		@action method() {
-			return super.method() * 2
-		}
-	}
+    class B extends A {
+        @action
+        method() {
+            return super.method() * 2
+        }
+    }
 
-	class C extends B {
-		@action method() {
-			return super.method() + 3
-		}
-	}
+    class C extends B {
+        @action
+        method() {
+            return super.method() + 3
+        }
+    }
 
-	const b = new B()
-	t.equal(b.method(), 84)
-	t.equal(isAction(b.method), true)
+    const b = new B()
+    t.equal(b.method(), 84)
+    t.equal(isAction(b.method), true)
 
-	const a = new A()
-	t.equal(a.method(), 42)
-	t.equal(isAction(a.method), true)
+    const a = new A()
+    t.equal(a.method(), 42)
+    t.equal(isAction(a.method), true)
 
-	const c = new C()
-	t.equal(c.method(), 87)
-	t.equal(isAction(c.method), true)
+    const c = new C()
+    t.equal(c.method(), 87)
+    t.equal(isAction(c.method), true)
 
-	t.end()
+    t.end()
 })
 
-
 test("379, inheritable actions - 2 (typescript)", t => {
-	class A {
-		@action("a method") method() {
-			return 42;
-		}
-	}
+    class A {
+        @action("a method")
+        method() {
+            return 42
+        }
+    }
 
-	class B extends A {
-		@action("b method") method() {
-			return super.method() * 2
-		}
-	}
+    class B extends A {
+        @action("b method")
+        method() {
+            return super.method() * 2
+        }
+    }
 
-	class C extends B {
-		@action("c method") method() {
-			return super.method() + 3
-		}
-	}
+    class C extends B {
+        @action("c method")
+        method() {
+            return super.method() + 3
+        }
+    }
 
-	const b = new B()
-	t.equal(b.method(), 84)
-	t.equal(isAction(b.method), true)
+    const b = new B()
+    t.equal(b.method(), 84)
+    t.equal(isAction(b.method), true)
 
-	const a = new A()
-	t.equal(a.method(), 42)
-	t.equal(isAction(a.method), true)
+    const a = new A()
+    t.equal(a.method(), 42)
+    t.equal(isAction(a.method), true)
 
-	const c = new C()
-	t.equal(c.method(), 87)
-	t.equal(isAction(c.method), true)
+    const c = new C()
+    t.equal(c.method(), 87)
+    t.equal(isAction(c.method), true)
 
-	t.end()
+    t.end()
 })
 
 test("373 - fix isObservable for unused computed", t => {
-	class Bla {
-		@computed get computedVal() { return 3 }
-		constructor() {
-			t.equal(isObservable(this, "computedVal"), true)
-			this.computedVal;
-			t.equal(isObservable(this, "computedVal"), true)
-		}
-	}
+    class Bla {
+        @computed
+        get computedVal() {
+            return 3
+        }
+        constructor() {
+            t.equal(isObservable(this, "computedVal"), true)
+            this.computedVal
+            t.equal(isObservable(this, "computedVal"), true)
+        }
+    }
 
-	new Bla();
-	t.end();
+    new Bla()
+    t.end()
 })
 
 test("505, don't throw when accessing subclass fields in super constructor (typescript)", t => {
-	const values: any = { }
-	class A {
-		@observable a = 1
-		constructor() {
-			values.b = (this as any)['b']
-			values.a = this.a
-		}
-	}
+    const values: any = {}
+    class A {
+        @observable a = 1
+        constructor() {
+            values.b = (this as any)["b"]
+            values.a = this.a
+        }
+    }
 
-	class B extends A {
-		@observable b = 2
-	}
+    class B extends A {
+        @observable b = 2
+    }
 
-	new B()
-	t.deepEqual(values, { a: 1, b: undefined}) // undefined, as A constructor runs before B constructor
-	t.end()
+    new B()
+    t.deepEqual(values, { a: 1, b: undefined }) // undefined, as A constructor runs before B constructor
+    t.end()
 })
 
+test("computed getter / setter for plan objects should succeed (typescript)", function(t) {
+    const b = observable({
+        a: 3,
+        get propX() {
+            return this.a * 2
+        },
+        set propX(v) {
+            this.a = v
+        }
+    })
 
-test('computed getter / setter for plan objects should succeed (typescript)', function(t) {
-	const b = observable({
-		a: 3,
-		get propX() { return this.a * 2 },
-		set propX(v) { this.a = v }
-	})
+    const values: number[] = []
+    mobx.autorun(() => values.push(b.propX))
+    t.equal(b.propX, 6)
+    b.propX = 4
+    t.equal(b.propX, 8)
 
-	const values: number[] = []
-	mobx.autorun(() => values.push(b.propX))
-	t.equal(b.propX, 6);
-	b.propX = 4;
-	t.equal(b.propX, 8);
-
-	t.deepEqual(values, [6, 8])
-	t.end()
+    t.deepEqual(values, [6, 8])
+    t.end()
 })
 
 test("484 - observable objects are IObservableObject", t => {
-	const needs_observable_object = (o: IObservableObject): any => null;
-	const o = observable({stuff: "things"});
+    const needs_observable_object = (o: IObservableObject): any => null
+    const o = observable({ stuff: "things" })
 
-	needs_observable_object(o);
-	t.pass();
-	t.end();
-});
+    needs_observable_object(o)
+    t.pass()
+    t.end()
+})
 
 test("484 - observable objects are still type T", t => {
-	const o = observable({stuff: "things"});
-	o.stuff = "new things";
-	t.pass();
-	t.end();
-});
+    const o = observable({ stuff: "things" })
+    o.stuff = "new things"
+    t.pass()
+    t.end()
+})
 
 test("484 - isObservableObject type guard includes type T", t => {
-	const o = observable({stuff: "things"});
-	if(isObservableObject(o)) {
-		o.stuff = "new things";
-		t.pass();
-	} else {
-		t.fail("object should have been observable");
-	}
-	t.end();
-});
+    const o = observable({ stuff: "things" })
+    if (isObservableObject(o)) {
+        o.stuff = "new things"
+        t.pass()
+    } else {
+        t.fail("object should have been observable")
+    }
+    t.end()
+})
 
 test("484 - isObservableObject type guard includes type IObservableObject", t => {
-	const requires_observable_object = (o: IObservableObject): void => null;
-	const o = observable({stuff: "things"});
+    const requires_observable_object = (o: IObservableObject): void => null
+    const o = observable({ stuff: "things" })
 
-	if(isObservableObject(o)) {
-		requires_observable_object(o);
-		t.pass();
-	} else {
-		t.fail("object should have been IObservableObject");
-	}
-	t.end();
-});
+    if (isObservableObject(o)) {
+        requires_observable_object(o)
+        t.pass()
+    } else {
+        t.fail("object should have been IObservableObject")
+    }
+    t.end()
+})
 
 test("705 - setter undoing caching (typescript)", t => {
-	let recomputes = 0;
-	let autoruns = 0;
+    let recomputes = 0
+    let autoruns = 0
 
-	class Person {
-		@observable name: string;
-		@observable title: string;
+    class Person {
+        @observable name: string
+        @observable title: string
 
-		// Typescript bug: if fullName is before the getter, the property is defined twice / incorrectly, see #705
-		// set fullName(val) {
-		// 	// Noop
-		// }
-		@computed get fullName() {
-			recomputes++;
-			return this.title+" "+this.name;
-		}
-		// Should also be possible to define the setter _before_ the fullname
-		set fullName(val) {
-			// Noop
-		}
-	}
+        // Typescript bug: if fullName is before the getter, the property is defined twice / incorrectly, see #705
+        // set fullName(val) {
+        // 	// Noop
+        // }
+        @computed
+        get fullName() {
+            recomputes++
+            return this.title + " " + this.name
+        }
+        // Should also be possible to define the setter _before_ the fullname
+        set fullName(val) {
+            // Noop
+        }
+    }
 
-	let p1 = new Person();
-	p1.name="Tom Tank";
-	p1.title="Mr.";
+    let p1 = new Person()
+    p1.name = "Tom Tank"
+    p1.title = "Mr."
 
-	t.equal(recomputes, 0);
-	t.equal(autoruns, 0);
+    t.equal(recomputes, 0)
+    t.equal(autoruns, 0)
 
-	const d1 = autorun(()=> {
-		autoruns++;
-		p1.fullName;
-	})
+    const d1 = autorun(() => {
+        autoruns++
+        p1.fullName
+    })
 
-	const d2 = autorun(()=> {
-		autoruns++;
-		p1.fullName;
-	})
+    const d2 = autorun(() => {
+        autoruns++
+        p1.fullName
+    })
 
-	t.equal(recomputes, 1);
-	t.equal(autoruns, 2);
+    t.equal(recomputes, 1)
+    t.equal(autoruns, 2)
 
-	p1.title="Master";
-	t.equal(recomputes, 2);
-	t.equal(autoruns, 4);
+    p1.title = "Master"
+    t.equal(recomputes, 2)
+    t.equal(autoruns, 4)
 
-	d1();
-	d2();
-	t.end();
+    d1()
+    d2()
+    t.end()
 })
 
 test("@observable.ref (TS)", t => {
-	class A {
-		@observable.ref ref = { a: 3}
-	}
+    class A {
+        @observable.ref ref = { a: 3 }
+    }
 
-	const a = new A();
-	t.equal(a.ref.a, 3);
-	t.equal(mobx.isObservable(a.ref), false);
-	t.equal(mobx.isObservable(a, "ref"), true);
+    const a = new A()
+    t.equal(a.ref.a, 3)
+    t.equal(mobx.isObservable(a.ref), false)
+    t.equal(mobx.isObservable(a, "ref"), true)
 
-	t.end();
+    t.end()
 })
 
 test("@observable.shallow (TS)", t => {
-	class A {
-		@observable.shallow arr = [{ todo: 1 }]
-	}
+    class A {
+        @observable.shallow arr = [{ todo: 1 }]
+    }
 
-	const a = new A();
-	const todo2 = { todo: 2 };
-	a.arr.push(todo2)
-	t.equal(mobx.isObservable(a.arr), true);
-	t.equal(mobx.isObservable(a, "arr"), true);
-	t.equal(mobx.isObservable(a.arr[0]), false);
-	t.equal(mobx.isObservable(a.arr[1]), false);
-	t.ok(a.arr[1] === todo2)
+    const a = new A()
+    const todo2 = { todo: 2 }
+    a.arr.push(todo2)
+    t.equal(mobx.isObservable(a.arr), true)
+    t.equal(mobx.isObservable(a, "arr"), true)
+    t.equal(mobx.isObservable(a.arr[0]), false)
+    t.equal(mobx.isObservable(a.arr[1]), false)
+    t.ok(a.arr[1] === todo2)
 
-	t.end();
+    t.end()
 })
-
 
 test("@observable.deep (TS)", t => {
-	class A {
-		@observable.deep arr = [{ todo: 1 }]
-	}
+    class A {
+        @observable.deep arr = [{ todo: 1 }]
+    }
 
-	const a = new A();
-	const todo2 = { todo: 2 };
-	a.arr.push(todo2)
+    const a = new A()
+    const todo2 = { todo: 2 }
+    a.arr.push(todo2)
 
-	t.equal(mobx.isObservable(a.arr), true);
-	t.equal(mobx.isObservable(a, "arr"), true);
-	t.equal(mobx.isObservable(a.arr[0]), true);
-	t.equal(mobx.isObservable(a.arr[1]), true);
-	t.ok(a.arr[1] !== todo2)
-	t.equal(isObservable(todo2), false);
+    t.equal(mobx.isObservable(a.arr), true)
+    t.equal(mobx.isObservable(a, "arr"), true)
+    t.equal(mobx.isObservable(a.arr[0]), true)
+    t.equal(mobx.isObservable(a.arr[1]), true)
+    t.ok(a.arr[1] !== todo2)
+    t.equal(isObservable(todo2), false)
 
-	t.end();
+    t.end()
 })
 
-test("action.bound binds (TS)", t=> {
-	class A {
-		@observable x = 0;
-		@action.bound
-		inc(value: number) {
-			this.x += value;
-		}
-	}
+test("action.bound binds (TS)", t => {
+    class A {
+        @observable x = 0
+        @action.bound
+        inc(value: number) {
+            this.x += value
+        }
+    }
 
-	const a = new A();
-	const runner = a.inc;
-	runner(2);
+    const a = new A()
+    const runner = a.inc
+    runner(2)
 
-	t.equal(a.x, 2);
+    t.equal(a.x, 2)
 
-	t.end();
+    t.end()
 })
 
 test("803 - action.bound and action preserve type info", t => {
-	function thingThatAcceptsCallback(cb: (elem: { x: boolean }) => void) {
+    function thingThatAcceptsCallback(cb: (elem: { x: boolean }) => void) {}
 
-	}
+    thingThatAcceptsCallback(elem => {
+        console.log(elem.x) // x is boolean
+    })
 
-	thingThatAcceptsCallback((elem) => {
-		console.log(elem.x) // x is boolean
-	})
+    thingThatAcceptsCallback(
+        action((elem: any) => {
+            // TODO: ideally, type of action would be inferred!
+            console.log(elem.x) // x is boolean
+        })
+    )
 
-	thingThatAcceptsCallback(action((elem: any) => { // TODO: ideally, type of action would be inferred!
-		console.log(elem.x) // x is boolean
-	}))
+    const bound = action.bound(() => {
+        return { x: "3" } as Object
+    }) as () => void
 
-	const bound = action.bound(() => {
-		return { x: "3"} as Object
-	}) as () => void
-
-	const bound2 = action.bound(function () {}) as (() => void)
-	t.end()
+    const bound2 = action.bound(function() {}) as (() => void)
+    t.end()
 })
 
 test("@computed.equals (TS)", t => {
-	const sameTime = (from: Time, to: Time) => from.hour === to.hour && from.minute === to.minute;
-	class Time {
-		constructor(hour: number, minute: number) {
-			this.hour = hour;
-			this.minute = minute;
-		}
+    const sameTime = (from: Time, to: Time) => from.hour === to.hour && from.minute === to.minute
+    class Time {
+        constructor(hour: number, minute: number) {
+            this.hour = hour
+            this.minute = minute
+        }
 
-		@observable public hour: number;
-		@observable public minute: number;
+        @observable public hour: number
+        @observable public minute: number
 
-		@computed.equals(sameTime) public get time() {
-			return { hour: this.hour, minute: this.minute };
-		}
-	}
-	const time = new Time(9, 0);
+        @computed.equals(sameTime)
+        public get time() {
+            return { hour: this.hour, minute: this.minute }
+        }
+    }
+    const time = new Time(9, 0)
 
-	const changes: Array<{ hour: number, minute: number }> = [];
-	const disposeAutorun = autorun(() => changes.push(time.time));
+    const changes: Array<{ hour: number; minute: number }> = []
+    const disposeAutorun = autorun(() => changes.push(time.time))
 
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }]);
-	time.hour = 9;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }]);
-	time.minute = 0;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }]);
-	time.hour = 10;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }, { hour: 10, minute: 0 }]);
-	time.minute = 30;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }, { hour: 10, minute: 0 }, { hour: 10, minute: 30 }]);
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }])
+    time.hour = 9
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }])
+    time.minute = 0
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }])
+    time.hour = 10
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    time.minute = 30
+    t.deepEqual(changes, [
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 },
+        { hour: 10, minute: 30 }
+    ])
 
-	disposeAutorun();
+    disposeAutorun()
 
-	t.end();
-});
+    t.end()
+})
 
 test("computed comparer works with extendObservable (TS)", t => {
-	const sameTime = (from: Time, to: Time) => from.hour === to.hour && from.minute === to.minute;
-	class Time {
-		constructor(hour: number, minute: number) {
-			this.hour = hour;
-			this.minute = minute;
-			extendObservable(this, {
-				hour,
-				minute,
-				time: computed(() => {
-					return { hour: this.hour, minute: this.minute };
-				}, { equals: sameTime })
-			})
-		}
+    const sameTime = (from: Time, to: Time) => from.hour === to.hour && from.minute === to.minute
+    class Time {
+        constructor(hour: number, minute: number) {
+            this.hour = hour
+            this.minute = minute
+            extendObservable(this, {
+                hour,
+                minute,
+                time: computed(
+                    () => {
+                        return { hour: this.hour, minute: this.minute }
+                    },
+                    { equals: sameTime }
+                )
+            })
+        }
 
-		public hour: number;
-		public minute: number;
-		public time: { hour: number, minute: number };
-	}
-	const time = new Time(9, 0);
+        public hour: number
+        public minute: number
+        public time: { hour: number; minute: number }
+    }
+    const time = new Time(9, 0)
 
-	const changes: Array<{ hour: number, minute: number }> = [];
-	const disposeAutorun = autorun(() => changes.push(time.time));
+    const changes: Array<{ hour: number; minute: number }> = []
+    const disposeAutorun = autorun(() => changes.push(time.time))
 
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }]);
-	time.hour = 9;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }]);
-	time.minute = 0;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }]);
-	time.hour = 10;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }, { hour: 10, minute: 0 }]);
-	time.minute = 30;
-	t.deepEqual(changes, [ { hour: 9, minute: 0 }, { hour: 10, minute: 0 }, { hour: 10, minute: 30 }]);
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }])
+    time.hour = 9
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }])
+    time.minute = 0
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }])
+    time.hour = 10
+    t.deepEqual(changes, [{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    time.minute = 30
+    t.deepEqual(changes, [
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 },
+        { hour: 10, minute: 30 }
+    ])
 
-	disposeAutorun();
+    disposeAutorun()
 
-	t.end();
-});
+    t.end()
+})
 
 test("1072 - @observable without initial value and observe before first access", t => {
-	class User {
-		@observable loginCount: number;
-	}
+    class User {
+        @observable loginCount: number
+    }
 
-	const user = new User();
-	observe(user, 'loginCount', () => {});
-	t.end()
+    const user = new User()
+    observe(user, "loginCount", () => {})
+    t.end()
 })

--- a/test/untracked.js
+++ b/test/untracked.js
@@ -1,36 +1,40 @@
-var test = require('tape');
-var m = require('..');
+var test = require("tape")
+var m = require("..")
 
-test('untracked 1', function(t) {
-	var cCalcs = 0, dCalcs = 0;
-	var a = m.observable(1);
-	var b = m.observable(2);
-	var c = m.computed(function() {
-		cCalcs++;
-		return a.get() + m.untracked(function() {
-			return b.get();
-		});
-	});
-	var result;
+test("untracked 1", function(t) {
+    var cCalcs = 0,
+        dCalcs = 0
+    var a = m.observable(1)
+    var b = m.observable(2)
+    var c = m.computed(function() {
+        cCalcs++
+        return (
+            a.get() +
+            m.untracked(function() {
+                return b.get()
+            })
+        )
+    })
+    var result
 
-	var d = m.autorun(function() {
-		dCalcs++;
-		result = c.get();
-	});
+    var d = m.autorun(function() {
+        dCalcs++
+        result = c.get()
+    })
 
-	t.equal(result, 3);
-	t.equal(cCalcs, 1);
-	t.equal(dCalcs, 1);
+    t.equal(result, 3)
+    t.equal(cCalcs, 1)
+    t.equal(dCalcs, 1)
 
-	b.set(3);
-	t.equal(result, 3);
-	t.equal(cCalcs, 1);
-	t.equal(dCalcs, 1);
+    b.set(3)
+    t.equal(result, 3)
+    t.equal(cCalcs, 1)
+    t.equal(dCalcs, 1)
 
-	a.set(2);
-	t.equal(result, 5);
-	t.equal(cCalcs, 2);
-	t.equal(dCalcs, 2);
+    a.set(2)
+    t.equal(result, 5)
+    t.equal(cCalcs, 2)
+    t.equal(dCalcs, 2)
 
-	t.end();
-});
+    t.end()
+})

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -1,25 +1,22 @@
-"use strict";
+"use strict"
 
 exports.consoleError = function(t, block, regex) {
-	let messages = "";
-	const orig = console.error;
-	console.error = function() {
-		Object.keys(arguments).forEach(key => {
-			messages += ", " + arguments[key];
-		})
-		messages += "\n";
-	}
-	try {
-		block();
-	} finally {
-		console.error = orig;
-	}
-	if (!messages)
-		t.ok(false, "Expected error, but nothing was logged");
-	else if (regex.test(messages))
-		t.ok(true, "console.error");
-	else
-		t.ok(false, "Expected " + regex +  ", got: " + messages);
+    let messages = ""
+    const orig = console.error
+    console.error = function() {
+        Object.keys(arguments).forEach(key => {
+            messages += ", " + arguments[key]
+        })
+        messages += "\n"
+    }
+    try {
+        block()
+    } finally {
+        console.error = orig
+    }
+    if (!messages) t.ok(false, "Expected error, but nothing was logged")
+    else if (regex.test(messages)) t.ok(true, "console.error")
+    else t.ok(false, "Expected " + regex + ", got: " + messages)
 }
 
 // TODO: move check globalState, cleanSpyEvents to here.

--- a/test/utils/transform.js
+++ b/test/utils/transform.js
@@ -1,83 +1,103 @@
-var m = require('../../');
+var m = require("../../")
 
-module.exports.intersection = require('lodash.intersection');
+module.exports.intersection = require("lodash.intersection")
 
 module.exports.pluckFn = function(key) {
-  return function(obj) {
-    var keys = key.split('.'), value = obj;
-    for (var i = 0, l = keys.length; i < l; i++) { if (!value) return; value = value[keys[i]]; }
-    return value;
-  }
+    return function(obj) {
+        var keys = key.split("."),
+            value = obj
+        for (var i = 0, l = keys.length; i < l; i++) {
+            if (!value) return
+            value = value[keys[i]]
+        }
+        return value
+    }
 }
-module.exports.identity = function(value) { return value; }
+module.exports.identity = function(value) {
+    return value
+}
 
 module.exports.testSet = function() {
-  var testSet = {};
+    var testSet = {}
 
-  var state = testSet.state = m.observable({
-    root: null,
-    renderedNodes: m.observable.array(),
-    collapsed: new m.map() // KM: ideally, I would like to use a set
-  });
+    var state = (testSet.state = m.observable({
+        root: null,
+        renderedNodes: m.observable.array(),
+        collapsed: new m.map() // KM: ideally, I would like to use a set
+    }))
 
-  var stats = testSet.stats = {
-    refCount: 0
-  }
+    var stats = (testSet.stats = {
+        refCount: 0
+    })
 
-  var TreeNode = testSet.TreeNode = function(name, extensions) {
-    this.children = m.observable.array();
-    this.icon = m.observable('folder');
+    var TreeNode = (testSet.TreeNode = function(name, extensions) {
+        this.children = m.observable.array()
+        this.icon = m.observable("folder")
 
-    this.parent = null; // not observed
-    this.name = name; // not observed
+        this.parent = null // not observed
+        this.name = name // not observed
 
-    // optional extensions
-    if (extensions) { for (var key in extensions) { this[key] = extensions[key]; } }
-  }
-  TreeNode.prototype.addChild = function(node) { node.parent = this; this.children.push(node); }
-  TreeNode.prototype.addChildren = function(nodes) {
-    var _this = this;
-    nodes.map(function(node) { node.parent = _this; });
-    this.children.splice.apply(this.children, [this.children.length, 0].concat(nodes));
-  }
-
-  TreeNode.prototype.path = function() {
-    var node = this, parts = [];
-    while (node) {
-      parts.push(node.name);
-      node = node.parent;
+        // optional extensions
+        if (extensions) {
+            for (var key in extensions) {
+                this[key] = extensions[key]
+            }
+        }
+    })
+    TreeNode.prototype.addChild = function(node) {
+        node.parent = this
+        this.children.push(node)
     }
-    return parts.join('/');
-  }
-
-  TreeNode.prototype.map = function(iteratee, results) {
-    results = results || [];
-    results.push(iteratee(this));
-    this.children.forEach(function(child) { child.map(iteratee, results); });
-    return results;
-  }
-
-  TreeNode.prototype.find = function(predicate) {
-    if (predicate(this)) return this;
-
-    var result;
-    for (var i = 0, l = this.children.length; i < l; i++) {
-      result = this.children[i].find(predicate);
-      if (result) return result;
+    TreeNode.prototype.addChildren = function(nodes) {
+        var _this = this
+        nodes.map(function(node) {
+            node.parent = _this
+        })
+        this.children.splice.apply(this.children, [this.children.length, 0].concat(nodes))
     }
-    return null;
-  }
 
-  var DisplayNode = testSet.DisplayNode = function(node) {
-    stats.refCount++;
-    this.node = node;
-  }
-  DisplayNode.prototype.destroy = function() { stats.refCount--; }
+    TreeNode.prototype.path = function() {
+        var node = this,
+            parts = []
+        while (node) {
+            parts.push(node.name)
+            node = node.parent
+        }
+        return parts.join("/")
+    }
 
-  DisplayNode.prototype.toggleCollapsed = function() {
-    var path = this.node.path();
-    state.collapsed.has(path) ? state.collapsed.delete(path) : state.collapsed.set(path, true); // KM: ideally, I would like to use a set
-  }
+    TreeNode.prototype.map = function(iteratee, results) {
+        results = results || []
+        results.push(iteratee(this))
+        this.children.forEach(function(child) {
+            child.map(iteratee, results)
+        })
+        return results
+    }
 
-  return testSet;
+    TreeNode.prototype.find = function(predicate) {
+        if (predicate(this)) return this
+
+        var result
+        for (var i = 0, l = this.children.length; i < l; i++) {
+            result = this.children[i].find(predicate)
+            if (result) return result
+        }
+        return null
+    }
+
+    var DisplayNode = (testSet.DisplayNode = function(node) {
+        stats.refCount++
+        this.node = node
+    })
+    DisplayNode.prototype.destroy = function() {
+        stats.refCount--
+    }
+
+    DisplayNode.prototype.toggleCollapsed = function() {
+        var path = this.node.path()
+        state.collapsed.has(path) ? state.collapsed.delete(path) : state.collapsed.set(path, true) // KM: ideally, I would like to use a set
+    }
+
+    return testSet
 }

--- a/test/whyrun.js
+++ b/test/whyrun.js
@@ -1,91 +1,91 @@
 "use strict"
 
-const test = require('tape');
-const mobx = require('../');
-const noop = () => {};
+const test = require("tape")
+const mobx = require("../")
+const noop = () => {}
 
 test("whyrun", t => {
-	const baselog = console.log;
-	let lastButOneLine = "";
-	let lastLine = "";
+    const baselog = console.log
+    let lastButOneLine = ""
+    let lastLine = ""
 
-	const whyRun = function () {
-		lastButOneLine = lastLine;
-		console.log = noop;
-		lastLine = mobx.whyRun.apply(null, arguments);
-		console.log = baselog;
-		return lastLine;
-	}
+    const whyRun = function() {
+        lastButOneLine = lastLine
+        console.log = noop
+        lastLine = mobx.whyRun.apply(null, arguments)
+        console.log = baselog
+        return lastLine
+    }
 
-	const x = mobx.observable({
-		firstname: "Michel",
-		lastname: "Weststrate",
-		get fullname() {
-			var res = this.firstname + " " + this.lastname;
-			whyRun();
-			return res;
-		}
-	});
+    const x = mobx.observable({
+        firstname: "Michel",
+        lastname: "Weststrate",
+        get fullname() {
+            var res = this.firstname + " " + this.lastname
+            whyRun()
+            return res
+        }
+    })
 
-	x.fullname;
-	// TODO: enable this assertion
-	// t.ok(lastLine.match(/suspended/), "just accessed fullname"); // no normal report, just a notification that nothing is being derived atm
+    x.fullname
+    // TODO: enable this assertion
+    // t.ok(lastLine.match(/suspended/), "just accessed fullname"); // no normal report, just a notification that nothing is being derived atm
 
-	t.ok(whyRun(x, "fullname").match(/\[idle\]/));
-	t.ok(whyRun(x, "fullname").match(/suspended/));
+    t.ok(whyRun(x, "fullname").match(/\[idle\]/))
+    t.ok(whyRun(x, "fullname").match(/suspended/))
 
-	const d = mobx.autorun("loggerzz", () => {
-		x.fullname;
-		whyRun();
-	})
+    const d = mobx.autorun("loggerzz", () => {
+        x.fullname
+        whyRun()
+    })
 
-	t.ok(lastButOneLine.match(/\[active\]/));
-	t.ok(lastButOneLine.match(/\.firstname/));
-	t.ok(lastButOneLine.match(/\.lastname/));
+    t.ok(lastButOneLine.match(/\[active\]/))
+    t.ok(lastButOneLine.match(/\.firstname/))
+    t.ok(lastButOneLine.match(/\.lastname/))
 
-	t.ok(lastLine.match(/loggerzz/));
-	t.ok(lastLine.match(/\[running\]/));
-	t.ok(lastLine.match(/\.fullname/));
+    t.ok(lastLine.match(/loggerzz/))
+    t.ok(lastLine.match(/\[running\]/))
+    t.ok(lastLine.match(/\.fullname/))
 
-	t.ok(whyRun(x, "fullname").match(/\[idle\]/));
-	t.ok(whyRun(x, "fullname").match(/\.firstname/));
-	t.ok(whyRun(x, "fullname").match(/\.lastname/));
-	t.ok(whyRun(x, "fullname").match(/loggerzz/));
+    t.ok(whyRun(x, "fullname").match(/\[idle\]/))
+    t.ok(whyRun(x, "fullname").match(/\.firstname/))
+    t.ok(whyRun(x, "fullname").match(/\.lastname/))
+    t.ok(whyRun(x, "fullname").match(/loggerzz/))
 
-	t.ok(whyRun(d).match(/\[idle\]/));
-	t.ok(whyRun(d).match(/\.fullname/));
+    t.ok(whyRun(d).match(/\[idle\]/))
+    t.ok(whyRun(d).match(/\.fullname/))
 
-	t.ok(whyRun(d).match(/loggerzz/));
+    t.ok(whyRun(d).match(/loggerzz/))
 
-	mobx.transaction(() => {
-		x.firstname = "Veria";
-		t.ok(whyRun(x, "fullname").match(/\[idle\]/), "made change in transaction");
+    mobx.transaction(() => {
+        x.firstname = "Veria"
+        t.ok(whyRun(x, "fullname").match(/\[idle\]/), "made change in transaction")
 
-		t.ok(whyRun(d).match(/\[scheduled\]/));
-	})
+        t.ok(whyRun(d).match(/\[scheduled\]/))
+    })
 
-	t.ok(lastButOneLine.match(/will re-run/));
-	t.ok(lastButOneLine.match(/\.firstname/));
-	t.ok(lastButOneLine.match(/\.lastname/));
-	t.ok(lastButOneLine.match(/\loggerzz/));
+    t.ok(lastButOneLine.match(/will re-run/))
+    t.ok(lastButOneLine.match(/\.firstname/))
+    t.ok(lastButOneLine.match(/\.lastname/))
+    t.ok(lastButOneLine.match(/\loggerzz/))
 
-	t.ok(lastLine.match(/\[running\]/));
-	t.ok(lastLine.match(/\.fullname/));
+    t.ok(lastLine.match(/\[running\]/))
+    t.ok(lastLine.match(/\.fullname/))
 
-	t.ok(whyRun(x, "fullname").match(/\[idle\]/));
-	t.ok(whyRun(x, "fullname").match(/\.firstname/));
-	t.ok(whyRun(x, "fullname").match(/\.lastname/));
-	t.ok(whyRun(x, "fullname").match(/loggerzz/));
+    t.ok(whyRun(x, "fullname").match(/\[idle\]/))
+    t.ok(whyRun(x, "fullname").match(/\.firstname/))
+    t.ok(whyRun(x, "fullname").match(/\.lastname/))
+    t.ok(whyRun(x, "fullname").match(/loggerzz/))
 
-	t.ok(whyRun(d).match(/\[idle\]/));
-	t.ok(whyRun(d).match(/\.fullname/));
-	t.ok(whyRun(d).match(/loggerzz/));
+    t.ok(whyRun(d).match(/\[idle\]/))
+    t.ok(whyRun(d).match(/\.fullname/))
+    t.ok(whyRun(d).match(/loggerzz/))
 
-	d();
+    d()
 
-	t.ok(whyRun(d).match(/\[stopped\]/));
-	t.ok(whyRun(x, "fullname").match(/\[idle\]/));
-	t.ok(whyRun(x, "fullname").match(/suspended/));
+    t.ok(whyRun(d).match(/\[stopped\]/))
+    t.ok(whyRun(x, "fullname").match(/\[idle\]/))
+    t.ok(whyRun(x, "fullname").match(/suspended/))
 
-	t.end();
+    t.end()
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,6 +84,10 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
+ansi-escapes@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -108,6 +112,10 @@ anymatch@^1.3.0:
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 aproba@^1.0.3:
   version "1.1.2"
@@ -1380,7 +1388,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1422,6 +1430,23 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
+
+cli-cursor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  dependencies:
+    restore-cursor "^1.0.1"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1550,6 +1575,19 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+  dependencies:
+    graceful-fs "^4.1.2"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.0.1"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    pinkie-promise "^2.0.0"
+    require-from-string "^1.1.0"
+
 coveralls@^2.11.4:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.13.1.tgz#d70bb9acc1835ec4f063ff9dac5423c17b11f178"
@@ -1601,6 +1639,14 @@ cross-spawn@^4.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -1645,6 +1691,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.27.2:
+  version "1.28.5"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -1847,6 +1897,10 @@ electron@^1.4.4:
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+
 elliptic@^6.0.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"
@@ -2007,6 +2061,10 @@ esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
 esrecurse@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.0.tgz#fa9568d98d3823f9a41d91e902dcab9ea6e5b163"
@@ -2069,6 +2127,22 @@ execa@^0.5.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -2167,6 +2241,13 @@ fd-slicer@~1.0.1:
 fibers@^1.0.2:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/fibers/-/fibers-1.0.15.tgz#22f039c8f18b856190fbbe4decf056154c1eae9c"
+
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -2353,6 +2434,10 @@ get-stream@^2.2.0:
   dependencies:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -2595,6 +2680,10 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
+indent-string@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.1.0.tgz#08ff4334603388399b329e6b9538dc7a3cf5de7d"
+
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
@@ -2764,6 +2853,10 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -2845,6 +2938,13 @@ js-yaml@3.6.1, js-yaml@3.x:
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
+
+js-yaml@^3.4.3:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -2976,6 +3076,67 @@ lexical-scope@^1.2.0:
   dependencies:
     astw "^2.0.0"
 
+lint-staged@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-3.6.1.tgz#24423c8b7bd99d96e15acd1ac8cb392a78e58582"
+  dependencies:
+    app-root-path "^2.0.0"
+    cosmiconfig "^1.1.0"
+    execa "^0.7.0"
+    listr "^0.12.0"
+    lodash.chunk "^4.2.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    staged-git-files "0.0.4"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.2.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    p-map "^1.1.1"
+    rxjs "^5.0.0-beta.11"
+    stream-to-observable "^0.1.0"
+    strip-ansi "^3.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -3032,6 +3193,10 @@ lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
+lodash.chunk@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
+
 lodash.intersection@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.intersection/-/lodash.intersection-3.2.0.tgz#e5b3611298a1187247b99eeadb385a3da018c570"
@@ -3064,6 +3229,19 @@ lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0:
 log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3346,6 +3524,12 @@ normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+npm-path@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+  dependencies:
+    which "^1.2.10"
+
 npm-run-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
@@ -3357,6 +3541,14 @@ npm-run-path@^2.0.0:
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   dependencies:
     path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -3432,6 +3624,10 @@ once@1.x, once@^1.3.0, once@^1.3.3:
   dependencies:
     wrappy "1"
 
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+
 opener@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
@@ -3454,6 +3650,15 @@ optionator@^0.5.0:
     type-check "~0.3.1"
     wordwrap "~0.0.2"
 
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
 ordered-emitter@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ordered-emitter/-/ordered-emitter-0.1.1.tgz#aa20bdafbdcc1631834a350f68b4ef8eb34eed7b"
@@ -3466,7 +3671,7 @@ os-browserify@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.1.2.tgz#49ca0293e0b19590a5f5de10c7f265a617d8fe54"
 
-os-homedir@^1.0.0:
+os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -3516,6 +3721,10 @@ p-locate@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-map@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.1.1.tgz#05f5e4ae97a068371bc2a5cc86bfbdbc19c4ae7a"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -3659,6 +3868,10 @@ prelude-ls@~1.1.0, prelude-ls@~1.1.1, prelude-ls@~1.1.2:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+prettier@^1.4.4:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
 
 pretty-bytes@^1.0.2:
   version "1.0.4"
@@ -3975,6 +4188,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -3988,6 +4205,13 @@ resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@~1.3.3:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
     path-parse "^1.0.5"
+
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
 
 resumer@~0.0.0:
   version "0.0.0"
@@ -4038,6 +4262,12 @@ rollup@^0.41.6:
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
   dependencies:
     source-map-support "^0.4.0"
+
+rxjs@^5.0.0-beta.11:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
+  dependencies:
+    symbol-observable "^1.0.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -4115,6 +4345,16 @@ shasum@^1.0.0:
     json-stable-stringify "~0.0.0"
     sha.js "~2.4.4"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
 shell-quote@^1.4.3:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
@@ -4150,6 +4390,10 @@ size-limit@^0.2.0:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -4235,6 +4479,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
@@ -4286,6 +4534,10 @@ stream-splicer@^2.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
+
+stream-to-observable@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -4388,6 +4640,10 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.1.0.tgz#92cc14bb3dad8928ca5656c33e19a19f20af5c7a"
   dependencies:
     has-flag "^2.0.0"
+
+symbol-observable@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 syntax-error@^1.1.1:
   version "1.3.0"
@@ -4782,7 +5038,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.1.1, which@^1.2.8, which@^1.2.9:
+which@^1.1.1, which@^1.2.10, which@^1.2.8, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:


### PR DESCRIPTION
This PR attempts to address issue #1060.

In short it introduces the `prettier` and `lint-staged` dependencies and setups the same tasks and configuration as in [mobxjs/mobx-state-tree](https://github.com/mobxjs/mobx-state-tree). The prettier was also run across the codebase to ensure it aligns with the new codestyle. 

It should be notes that the codestyle in `mobx-state-tree` is not the same as in this codebase and thus this commit introduces a lot of changes. If you prefer I could align the rules used by prettier to more closely match this repository to minimize the amount of changes in the pull request.
