### PR TITLE
Resolves#1092

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.2
+
+* Fixes a bug (or a known limitation) described in #1092. It is now possible to have different observable administration on different levels of the prototype chain.
+
 # 3.2.1
 
 * Introduced customizable value comperators to reactions and computed values. `reaction` and `computed` now support an additional option, `equals`, which takes a comparision function. See [#951](https://github.com/mobxjs/mobx/pull/951/) by @jamiewinder. Fixes #802 and #943. See the updated [`computed` docs](https://mobx.js.org/refguide/computed-decorator.html) for more details.

--- a/src/types/observableobject.ts
+++ b/src/types/observableobject.ts
@@ -58,7 +58,7 @@ export interface IIsObservableObject {
 }
 
 export function asObservableObject(target, name?: string): ObservableObjectAdministration {
-	if (isObservableObject(target))
+	if (isObservableObject(target) && target.hasOwnProperty('$mobx'))
 		return (target as any).$mobx;
 
 	invariant(Object.isExtensible(target), getMessage("m035"));

--- a/test/observables.js
+++ b/test/observables.js
@@ -1779,16 +1779,19 @@ test("computed equals function only invoked when necessary", t => {
 	t.end();
 });
 
-test('Issue 1092 - extendsObservable should not go through the prototype chain', t => {
-  t.plan(1);
+test('Issue 1092 - Should not access attributes of siblings in the prot. chain', t => {
+  t.plan(2);
 
   // The parent is an observable
+  // and has an attribute
   const parent = {};
-  mobx.extendObservable(parent, {});
+  mobx.extendObservable(parent, {
+    staticObservable: 11
+  });
 
   // Child1 "inherit" from the parent
   // and has an observable attribute
-  var child1 = Object.create(parent);
+  const child1 = Object.create(parent);
   mobx.extendObservable(child1, {
       attribute: 7
   });
@@ -1799,7 +1802,38 @@ test('Issue 1092 - extendsObservable should not go through the prototype chain',
 
   // The second child should not be aware of the attribute of his
   // sibling child1
-  t.equals(typeof child2.attribute, 'undefined');
+  t.equals(typeof child2.attribute, 'undefined',
+    'We should not access attributes of siblings');
+
+  // We still should be able to read the value from the parent
+  t.equals(child2.staticObservable, 11,
+    'We should be able to read attributes from parents');
+
+  t.end();
+});
+
+test('Issue 1092 - We should be able to define observable on all siblings', t => {
+  t.plan(1);
+
+  // The parent is an observable
+  const parent = {};
+  mobx.extendObservable(parent, {});
+
+  // Child1 "inherit" from the parent
+  // and has an observable attribute
+  const child1 = Object.create(parent);
+  mobx.extendObservable(child1, {
+      attribute: 7
+  });
+
+  // Child2 also "inherit" from the parent
+  // But does not have any observable attribute
+  const child2 = Object.create(parent);
+  t.doesNotThrow(() => {
+    mobx.extendObservable(child2, {
+      attribute: 8
+    })
+  }, 'The attribute should not collide between the two siblings');
 
   t.end();
 });

--- a/test/observables.js
+++ b/test/observables.js
@@ -1778,3 +1778,29 @@ test("computed equals function only invoked when necessary", t => {
 
 	t.end();
 });
+
+test('Issue 1092 - extendsObservable should not go through the prototype chain', t => {
+  t.plan(1);
+
+  // The parent is an observable
+  const parent = {};
+  mobx.extendObservable(parent, {});
+
+  // Child1 "inherit" from the parent
+  // and has an observable attribute
+  var child1 = Object.create(parent);
+  mobx.extendObservable(child1, {
+      attribute: 7
+  });
+
+  // Child2 also "inherit" from the parent
+  // But does not have any observable attribute
+  const child2 = Object.create(parent);
+
+  // The second child should not be aware of the attribute of his
+  // sibling child1
+  t.equals(typeof child2.attribute, 'undefined');
+
+  t.end();
+});
+


### PR DESCRIPTION
* [x] Added unit tests
Two tests with three assertions were added before any attempt to fix the bug. The first test is directly adapted from the repro in #1092.
I can add more tests if needed
* [x] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
There is no API change. I don't know if this box is applicable for this PR.
* [ ] Added typescript typings.
There is no API change. I don't know if this box is applicable for this PR.
* [x] Verified that there is no significant performance drop (`npm run perf
```
before (5e359b1ce29934ee3c70d2b5d795942ddd7e4bee)
> 38.69user 0.37system 0:37.66elapsed 103%CPU (0avgtext+0avgdata 523600maxresident)k

after (1c97af37ac27df9797779e0a182ce11b38115b75)
> 38.53user 0.37system 0:37.59elapsed 103%CPU (0avgtext+0avgdata 518368maxresident)k
```