### PR TITLE
fix access to global object (fixes #1109)

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,7 +3,7 @@ Object.freeze(EMPTY_ARRAY);
 
 declare var global;
 export function getGlobal() {
-	return global;
+	return typeof window !== 'undefined' ? window : global;
 }
 
 export interface Lambda {


### PR DESCRIPTION
webpack UMD builds pass in the global object (`global` in node and `window` in the browser) as a parameter named `global`. In RollupJS this is not the case. Access to the global object has to be handled manually, so let's just check for `window`, and if it doesn't exist fall back to `global`.