### PR TITLE
useStrict doesn't return a value

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -459,7 +459,7 @@ declare module 'mobx' {
     ___alreadySeen?: [any, any][],
   ): any;
   declare function whyRun(thing?: any, prop?: string): string;
-  declare function useStrict(strict: boolean): any;
+  declare function useStrict(strict: boolean): void;
 
   declare function isStrictModeEnabled(): boolean;
   declare function untracked<T>(action: () => T): T;


### PR DESCRIPTION
Flow reports uncovered code when "useStrict(true)" is used due to the defined return type. Because then useStrict function doesn't return a value, a void return definition is most appropriate.

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
