### PR TITLE
Rename ESM output to .mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple, scalable state management.",
   "main": "lib/mobx.js",
   "umd:main": "lib/mobx.umd.js",
-  "module": "lib/mobx.module.js",
+  "module": "lib/mobx.mjs",
   "typings": "lib/mobx.d.ts",
   "scripts": {
     "prettier": "prettier --write --print-width 100 --tab-width 4 --no-semi \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.ts\"",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -100,7 +100,7 @@ function build() {
 
         generateBundledModule(
             path.resolve(".build.es", "mobx.js"),
-            path.resolve("lib", "mobx.module.js"),
+            path.resolve("lib", "mobx.mjs"),
             "es"
         )
     ]).then(() => {


### PR DESCRIPTION
I've just been playing around with the [@std/esm](https://medium.com/web-on-the-edge/es-modules-in-node-today-32cff914e4b) loader, which makes reference to the fact that Node's ES6 module support is going to be tied to the file extension `*.mjs`. I admit I don't know much context around this issue but I saw this and thought it might make sense to follow the new convention.