### PR TITLE
Clarify docs about React lifecycles hooks #GoodnessSquadKyiv

### DIFF
--- a/docs/refguide/observer-component.md
+++ b/docs/refguide/observer-component.md
@@ -61,8 +61,8 @@ const Timer = observer(({ timerData }) =>
 
 Just like normal classes, you can introduce observable properties on a component by using the `@observable` decorator.
 This means that you can have local state in components that doesn't need to be manged by React's verbose and imperative `setState` mechanism, but is as powerful.
-The reactive state will be picked up by `render` but will not explicitly invoke other React lifecycle methods like `componentShouldUpdate` or `componentWillUpdate`.
-If you need those, just use the normal React `state` based APIs.
+The reactive state will be picked up by `render` but will not explicitly invoke other React lifecycle methods except `componentWillUpdate` and `componentDidUpdate`.
+If you need other React lifecycle methods, just use the normal React `state` based APIs.
 
 The example above could also have been written as:
 


### PR DESCRIPTION
According to issue #1113 (https://github.com/mobxjs/mobx/issues/1113) create an explanation like this: "The reactive state will be picked up by render but will not explicitly invoke other React lifecycle methods except componentWillUpdate and component did update. If you need other React lifecycle methods, just use the normal React state based APIs."
