### PR TITLE
Support weex

### DIFF
--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -119,6 +119,29 @@ function inherit(ctor, proto) {
 }
 inherit(StubArray, Array.prototype)
 
+// Weex freeze Array.prototype
+// https://github.com/alibaba/weex/pull/1529
+;[
+	"constructor",
+    "push",
+    "shift",
+    "concat",
+    "pop",
+    "unshift",
+    "replace",
+	"find",
+	"findIndex",
+	"splice",
+	"reverse",
+	"sort"
+].forEach(function (key) {
+    Object.defineProperty(StubArray.prototype, key, {
+        configurable: true,
+        writable: true,
+        value: Array.prototype[key]
+    })
+})
+
 class ObservableArrayAdministration<T>
     implements IInterceptable<IArrayWillChange<T> | IArrayWillSplice<T>>, IListenable {
     atom: BaseAtom

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -120,27 +120,30 @@ function inherit(ctor, proto) {
 inherit(StubArray, Array.prototype)
 
 // Weex freeze Array.prototype
+// Make them writeable and configurable in prototype chain
 // https://github.com/alibaba/weex/pull/1529
-;[
-	"constructor",
-    "push",
-    "shift",
-    "concat",
-    "pop",
-    "unshift",
-    "replace",
-	"find",
-	"findIndex",
-	"splice",
-	"reverse",
-	"sort"
-].forEach(function (key) {
-    Object.defineProperty(StubArray.prototype, key, {
-        configurable: true,
-        writable: true,
-        value: Array.prototype[key]
-    })
-})
+if (Object.isFrozen(Array)) {
+	;[
+		"constructor",
+		"push",
+		"shift",
+		"concat",
+		"pop",
+		"unshift",
+		"replace",
+		"find",
+		"findIndex",
+		"splice",
+		"reverse",
+		"sort"
+	].forEach(function (key) {
+		Object.defineProperty(StubArray.prototype, key, {
+			configurable: true,
+			writable: true,
+			value: Array.prototype[key]
+		})
+	})
+}
 
 class ObservableArrayAdministration<T>
     implements IInterceptable<IArrayWillChange<T> | IArrayWillSplice<T>>, IListenable {


### PR DESCRIPTION
## About this PR
[Weex](https://github.com/alibaba/weex) is a framework like `ReactNative`. It runs javascript in JavaScriptCore/V8 runtime and freezed `Array.prototype`.

Mobx is a awesome library so I want make it works in weex. `ObservableArray` in mobx override `push/sort/etc` could not run in weex. We'd better make this original array method writeable in `StubArray.prorotype`.

See https://github.com/alibaba/weex/pull/1529

## PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [X] Added typescript typings
* [X] Verified that there is no significant performance drop (`npm run perf`)

![ezgif-4-d59f90397f](https://user-images.githubusercontent.com/5436704/30262815-00502a5a-9705-11e7-963f-9d38b135b287.gif)
