### PR TITLE
Revert "Rename ESM output to .mjs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # 3.3.0
 
 * Undeprecated `transaction`, see [#1139](https://github.com/mobxjs/mobx/issues/1139)
-* Use `.mjs` extension for module build [1131](https://github.com/mobxjs/mobx/issues/1131)
 * Fixed typings of reaction [#1136](https://github.com/mobxjs/mobx/issues/1136)
 * It is now possible to re-define a computed property [#1121](https://github.com/mobxjs/mobx/issues/1121)
 * Print an helpful error message when using `@action` on a getter [#971](https://github.com/mobxjs/mobx/issues/971)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple, scalable state management.",
   "main": "lib/mobx.js",
   "umd:main": "lib/mobx.umd.js",
-  "module": "lib/mobx.mjs",
+  "module": "lib/mobx.module.js",
   "typings": "lib/mobx.d.ts",
   "scripts": {
     "prettier": "prettier --write --print-width 100 --tab-width 4 --no-semi \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.ts\"",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -100,7 +100,7 @@ function build() {
 
         generateBundledModule(
             path.resolve(".build.es", "mobx.js"),
-            path.resolve("lib", "mobx.mjs"),
+            path.resolve("lib", "mobx.module.js"),
             "es"
         )
     ]).then(() => {


### PR DESCRIPTION
Reverts mobxjs/mobx#1131

Reverted `.mjs` extension until https://github.com/facebook/metro-bundler/issues/59 is resolved