### PR TITLE
Fix #1120: isComputed should return false for non existing property

### DIFF
--- a/src/api/iscomputed.ts
+++ b/src/api/iscomputed.ts
@@ -6,6 +6,7 @@ export function isComputed(value, property?: string): boolean {
     if (value === null || value === undefined) return false
     if (property !== undefined) {
         if (isObservableObject(value) === false) return false
+        if (!value.$mobx.values[property]) return false
         const atom = getAtom(value, property)
         return isComputedValue(atom)
     }

--- a/test/observables.js
+++ b/test/observables.js
@@ -1943,6 +1943,12 @@ test("Issue 1092 - We should be able to define observable on all siblings", t =>
     t.end()
 })
 
+test("Issue 1120 - isComputed should return false for a non existing property", t => {
+    t.equal(mobx.isComputed({}, "x"), false)
+    t.equal(mobx.isComputed(observable({}), "x"), false)
+    t.end()
+})
+
 test("Issue 1121 - It should be possible to redefine a computed property", t => {
     t.plan(4)
 


### PR DESCRIPTION
Fix for #1120: isComputed now returns false for non existing properties.

PR checklist:

* [x] Added unit tests
* [x] Verified that there is no significant performance drop (`npm run perf`)

