### PR TITLE
Don't pass undefined to custom equality checks on becoming observed a…

### DIFF
--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -110,7 +110,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
 
     onBecomeUnobserved() {
         clearObserving(this)
-        this.value = undefined
+        this.value = new CaughtException(null)
     }
 
     /**

--- a/test/errorhandling.js
+++ b/test/errorhandling.js
@@ -682,7 +682,7 @@ test("peeking inside autorun doesn't bork (global) state", t => {
         t.equal(b.diffValue, 0)
         t.equal(b.lowestObserverState, 0)
         t.equal(b.unboundDepsCount, 1)
-        t.equal(b.value, undefined)
+        t.notEqual(b.value, 3)
         t.equal(b.isComputing, false)
 
         t.equal(c.dependenciesState, -1)

--- a/test/observables.js
+++ b/test/observables.js
@@ -1853,7 +1853,7 @@ test("computed equals function only invoked when necessary", t => {
     )
 
     const values = []
-    const disposeAutorun = mobx.autorun(() => values.push(combinedToLowerCase.get()))
+    let disposeAutorun = mobx.autorun(() => values.push(combinedToLowerCase.get()))
 
     // No comparison should be made on the first value
     t.deepEqual(comparisons, [])
@@ -1879,7 +1879,12 @@ test("computed equals function only invoked when necessary", t => {
     right.set("F")
     t.deepEqual(comparisons, [{ from: "ab", to: "cb" }, { from: "de", to: "df" }])
 
-    t.deepEqual(values, ["ab", "cb", "de", "df"])
+    // Becoming unobserved, then observed won't cause a comparison
+    disposeAutorun()
+    disposeAutorun = mobx.autorun(() => values.push(combinedToLowerCase.get()));
+    t.deepEqual(comparisons, [{ from: "ab", to: "cb" }, { from: "de", to: "df" }])
+
+    t.deepEqual(values, ["ab", "cb", "de", "df", "df"])
 
     disposeAutorun()
 

--- a/test/observables.js
+++ b/test/observables.js
@@ -1881,7 +1881,7 @@ test("computed equals function only invoked when necessary", t => {
 
     // Becoming unobserved, then observed won't cause a comparison
     disposeAutorun()
-    disposeAutorun = mobx.autorun(() => values.push(combinedToLowerCase.get()));
+    disposeAutorun = mobx.autorun(() => values.push(combinedToLowerCase.get()))
     t.deepEqual(comparisons, [{ from: "ab", to: "cb" }, { from: "de", to: "df" }])
 
     t.deepEqual(values, ["ab", "cb", "de", "df", "df"])


### PR DESCRIPTION
…gain

This PR attempts to fix #1208.

I've extended one of the tests added in #951 to cover this bug, but I'm not sure if that's sufficient. The difference between `test/babel/*.js`, `test/typescript/*.js`, and `test/*.js` isn't clear to me so please let me know if I should add more tests.

PR checklist:

* [x] Added unit tests
* [x] Verified that there is no significant performance drop (`npm run perf`)
