### PR TITLE
Update extendObservableHelper for Typescript 2.6

### DIFF
--- a/src/api/extendobservable.ts
+++ b/src/api/extendobservable.ts
@@ -46,7 +46,7 @@ export function extendObservableHelper(
                 definedProps[key] = true
                 if ((target as any) === propSet && !isPropertyConfigurable(target, key)) continue // see #111, skip non-configurable or non-writable props for `observable(object)`.
                 const descriptor = Object.getOwnPropertyDescriptor(propSet, key)
-                defineObservablePropertyFromDescriptor(adm, key, descriptor, defaultEnhancer)
+                defineObservablePropertyFromDescriptor(adm, key, descriptor!, defaultEnhancer)
             }
     }
     return target


### PR DESCRIPTION
In Typescript 2.6, Object.getOwnPropertyDescriptor now returns `PropertyDescriptor | undefined`. Assert that the type is still just `PropertyDescriptor`, because it is checked with `hasOwnProperty` just above.

Fixes #1215