### PR TITLE
More strict objectAssign typings

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -78,7 +78,8 @@ export function isPlainObject(value) {
     return proto === Object.prototype || proto === null
 }
 
-export function objectAssign(...objs: Object[]): Object
+export function objectAssign<T extends object>(target: { [key: string]: never }, clonedSource: T, ...sources: (Partial<T> & object)[]): T;
+export function objectAssign<T extends object>(target: T, ...sources: (Partial<T> & object)[]): T;
 export function objectAssign() {
     const res = arguments[0]
     for (let i = 1, l = arguments.length; i < l; i++) {


### PR DESCRIPTION

PR checklist:

* [ ] Added unit tests
_The implementation wasn't changed_

* [ ] Updated changelog
_Nothing of what the end user would notice_

* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
_This change doesnt affect the public API_

* [x] Added typescript typings

* [ ] Verified that there is no significant performance drop (`npm run perf`)
_The implementation wasn't changed, only typings_

---

More strict `tools`/`objectAssign` typings:

- Allow extending object only by objects that `Partial`ly implements it.
- Guess type better when `objectAssign` is used for cloning an object.

Imagine we have an interface `Cat` and an object of that interface.

```ts
interface Cat { age: number; name: string; }
const fluffy = { age: 3, name: "Fluffy" };
```

If source is a `Partial<Cat>`, nothing is changed:
```ts
objectAssign(fluffy, { age: 4 }); // Okay. Fluffy's age was updated.
```

But if it is not, the error is thrown. We typically don't want Cats to stop being just Cats, do we?
```ts
objectAssign(fluffy, { woofs: true }); // error: { woofs: true } is not a partial of Cat
```

Non-object arguments are still disallowed:
```ts
objectAssign(4, {}); // error: not an object
objectAssign({}, 4, {}); // error: not an object
```

There's also a special treatment of the first argument added. If it's an empty object, the result type is deducted from the 2nd argument.
```ts
let cat2: Cat = objectAssign({}, fluffy, { age: 4 }); // okay. objectAssign returns `typeof fluffy` in this case
```
If any of the arguments is not a `Partial<Cat>`, the return type won't be a `Cat`.
```ts
let obj: object = objectAssign({}, fluffy, { woofs: true }); // Plain object. Not a Cat
```