### PR TITLE
gets rid of untyped-type-import flowtype warning

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -1,3 +1,4 @@
+// @flow
 declare module "mobx" {
     declare type Extras = {
         allowStateChanges: <T>(allowStateChanges: boolean, func: () => T) => T,


### PR DESCRIPTION
gets rid of this warning:
```
Warning: src/components/event/SplitDateTimeInput.js:7
  7: import type { IReactionDisposer } from 'mobx/lib/mobx.js.flow'
                   ^^^^^^^^^^^^^^^^^ untyped-type-import: Importing a type from an untyped module makes it `any` and is not safe! Did you mean to add `// @flow` to the top of `mobx/lib/mobx.js.flow`?
```