### PR TITLE
make deep NaN === deep NaN for computed values when using compareStructural

### DIFF
--- a/src/types/comparer.ts
+++ b/src/types/comparer.ts
@@ -1,4 +1,4 @@
-import { deepEqual, areBothNan } from "../utils/utils"
+import { deepEqual, areBothNaN } from "../utils/utils"
 
 export interface IEqualsComparer<T> {
     (a: T, b: T): boolean
@@ -13,7 +13,7 @@ function structuralComparer(a: any, b: any): boolean {
 }
 
 function defaultComparer(a: any, b: any): boolean {
-    return areBothNan(a,b) || identityComparer(a, b)
+    return areBothNaN(a,b) || identityComparer(a, b)
 }
 
 export const comparer = {

--- a/src/types/comparer.ts
+++ b/src/types/comparer.ts
@@ -1,4 +1,4 @@
-import { deepEqual } from "../utils/utils"
+import { deepEqual, areBothNan } from "../utils/utils"
 
 export interface IEqualsComparer<T> {
     (a: T, b: T): boolean
@@ -9,17 +9,11 @@ function identityComparer(a: any, b: any): boolean {
 }
 
 function structuralComparer(a: any, b: any): boolean {
-    if (typeof a === "number" && typeof b === "number" && isNaN(a) && isNaN(b)) {
-        return true
-    }
     return deepEqual(a, b)
 }
 
 function defaultComparer(a: any, b: any): boolean {
-    if (typeof a === "number" && typeof b === "number" && isNaN(a) && isNaN(b)) {
-        return true
-    }
-    return identityComparer(a, b)
+    return areBothNan(a,b) || identityComparer(a, b)
 }
 
 export const comparer = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -145,7 +145,7 @@ export function getEnumerableKeys(obj) {
 export function deepEqual(a, b) {
     if (a === null && b === null) return true
     if (a === undefined && b === undefined) return true
-    if (areBothNan(a, b)) return true    
+    if (areBothNaN(a, b)) return true    
     if (typeof a !== "object") return a === b
     const aIsArray = isArrayLike(a)
     const aIsMap = isMapLike(a)
@@ -192,7 +192,7 @@ export function createInstanceofPredicate<T>(
     } as any
 }
 
-export function areBothNan(a: any, b: any): boolean {
+export function areBothNaN(a: any, b: any): boolean {
     return (typeof a === "number" && typeof b === "number" && isNaN(a) && isNaN(b));
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -145,6 +145,7 @@ export function getEnumerableKeys(obj) {
 export function deepEqual(a, b) {
     if (a === null && b === null) return true
     if (a === undefined && b === undefined) return true
+    if (areBothNan(a, b)) return true    
     if (typeof a !== "object") return a === b
     const aIsArray = isArrayLike(a)
     const aIsMap = isMapLike(a)
@@ -189,6 +190,10 @@ export function createInstanceofPredicate<T>(
     return function(x) {
         return isObject(x) && x[propName] === true
     } as any
+}
+
+export function areBothNan(a: any, b: any): boolean {
+    return (typeof a === "number" && typeof b === "number" && isNaN(a) && isNaN(b));
 }
 
 /**

--- a/test/observables.js
+++ b/test/observables.js
@@ -1223,6 +1223,31 @@ test("computed values believe NaN === NaN", function(t) {
     t.end()
 })
 
+test("computed values believe deep NaN === deep NaN when using compareStructural", function(t) {
+    var a = observable({ b: { a: 1 } })
+    var c = computed(function() {
+        return a.b
+    }, {compareStructural: true})
+
+    var buf = new buffer()
+    c.observe((newValue) => { 
+        buf(newValue)
+    });
+
+    a.b = { a: NaN }
+    a.b = { a: NaN }
+    a.b = { a: NaN }
+    a.b = { a: 2 }
+    a.b = { a: NaN }
+
+    var bufArray = buf.toArray()
+    t.equal(isNaN(bufArray[0].b), true)
+    t.deepEqual(bufArray[1], { a: 2 })
+    t.deepEqual(isNaN(bufArray[2].b), true)  
+    t.equal(bufArray.length, 3)
+    t.end()
+})
+
 test.skip("issue 65; transaction causing transaction", function(t) {
     // MWE: disabled, bad test; depends on transaction being tracked, transaction should not be used in computed!
     var x = mobx.observable({


### PR DESCRIPTION
There seemed to be an inconsistent behavior where NaN === NaN but deep NaN !== NaN.
I think @benjamingr talked with you about it. 

PR checklist:

* [X] Added unit tests
* [X] Verified that there is no significant performance drop (`npm run perf`) - it does seem to add around 1-3 second on my machine, not sure if this is significant. 