### PR TITLE
Added ObservableArray.removeAll issue #1248

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+* Added `ObservableArray.removeAll`, [#1248](https://github.com/mobxjs/mobx/issues/1248)
+
 # 3.3.2
 
 * Fix bug where custom comparers could be invoked with `undefined` values. Fixes [#1208](https://github.com/mobxjs/mobx/issues/1208)

--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -156,7 +156,10 @@ declare module "mobx" {
             thisArg?: any,
             fromIndex?: number
         ): number,
-        remove(value: T): boolean
+        remove(value: T): boolean,
+        removeAll(
+            predicate: (item: T, index: number, array: Array<T>) => boolean
+        ): void
     }
 
     declare interface IArrayChange<T> {

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -483,7 +483,8 @@ export class ObservableArray<T> extends StubArray {
     removeAll( 
         predicate: (item: T, index: number, array: T[]) => boolean
     ): void {
-        this.replace(this.$mobx.values.filter(predicate))
+        const invertedPerdicate = (item:T, index:number, array:T[]) => !predicate(item,index,array)
+        this.replace(this.$mobx.values.filter(invertedPerdicate))
     }
 
     move(fromIndex: number, toIndex: number): void {

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -61,6 +61,9 @@ export interface IObservableArray<T> extends Array<T> {
         fromIndex?: number
     ): number
     remove(value: T): boolean
+    removeAll(
+        predicate: (item: T, index:number, array: T[])=> boolean
+    ): void
     move(fromIndex: number, toIndex: number): void
 }
 
@@ -477,6 +480,12 @@ export class ObservableArray<T> extends StubArray {
         return false
     }
 
+    removeAll( 
+        predicate: (item: T, index: number, array: T[]) => boolean
+    ): void {
+        this.replace(this.$mobx.values.filter(predicate))
+    }
+
     move(fromIndex: number, toIndex: number): void {
         function checkIndex(index: number) {
             if (index < 0) {
@@ -637,6 +646,7 @@ makeNonEnumerable(ObservableArray.prototype, [
     "reverse",
     "sort",
     "remove",
+    "removeAll",
     "move",
     "toString",
     "toLocaleString"

--- a/test/array.js
+++ b/test/array.js
@@ -268,6 +268,23 @@ test("array modification functions", function(t) {
     t.end()
 })
 
+test("array modification .removeAll", function(t) {
+    var array = [];
+    for(var i = 0; i < 100; i++) array.push(i);
+    var predicates = [
+        function (x) {return x % 2 == 0 },
+        function (x) { return x > 20 },
+        function (x) { return x == 3}
+    ]
+    predicates.forEach(function(predicate) {
+        var a = array.filter(predicate)
+        var b = mobx.observable(a)
+        b.removeAll(predicate)
+        t.deepEqual(a, b.slice())
+    })
+    t.end()
+})
+
 test("array modifications", function(t) {
     var a2 = mobx.observable([])
     var inputs = [undefined, -10, -4, -3, -1, 0, 1, 3, 4, 10]

--- a/test/array.js
+++ b/test/array.js
@@ -269,18 +269,18 @@ test("array modification functions", function(t) {
 })
 
 test("array modification .removeAll", function(t) {
-    var array = [];
-    for(var i = 0; i < 100; i++) array.push(i);
+    var array = []
+    for(var i = 0; i < 100; i++) array.push(i)
     var predicates = [
         function (x) {return x % 2 == 0 },
         function (x) { return x > 20 },
         function (x) { return x == 3}
     ]
     predicates.forEach(function(predicate) {
-        var a = array.filter(predicate)
-        var b = mobx.observable(a)
-        b.removeAll(predicate)
-        t.deepEqual(a, b.slice())
+        var filteredArray = array.filter(predicate)
+        var observableArray = mobx.observable(array)
+        observableArray.removeAll(predicate)
+        t.deepEqual(filteredArray, observableArray.slice())
     })
     t.end()
 })

--- a/test/array.js
+++ b/test/array.js
@@ -277,7 +277,7 @@ test("array modification .removeAll", function(t) {
         function (x) { return x == 3}
     ]
     predicates.forEach(function(predicate) {
-        var filteredArray = array.filter(predicate)
+        var filteredArray = array.filter((x)=> !predicate(x))
         var observableArray = mobx.observable(array)
         observableArray.removeAll(predicate)
         t.deepEqual(filteredArray, observableArray.slice())


### PR DESCRIPTION
`myArray.removeAll(predicate)` is logically equivalent to `myArray.replace(myArray.filter(predicate))`.
`.removeAll` has yet to be added to github pages I will submit a second PR later. 