### PR TITLE
Don't try/catch errors when globalstate.disableErrorBoundaries is on.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.5.0
+* Added extras.disableErrorBoundaries()
+
 # 3.4.0
 
 * Improve Flow support support by exposing typings regularly. Flow will automatically include them now. In your `.flowconfig` will have to remove the import in the `[libs]` section (as it's done [here](https://github.com/mobxjs/mobx/pull/1254#issuecomment-348926416)). Fixes [#1232](https://github.com/mobxjs/mobx/issues/1232).

--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -189,10 +189,14 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
         if (track) {
             res = trackDerivedFunction(this, this.derivation, this.scope)
         } else {
-            try {
+            if (globalState.disableErrorBoundaries) {
                 res = this.derivation.call(this.scope)
-            } catch (e) {
-                res = new CaughtException(e)
+            } else {
+                try {
+                    res = this.derivation.call(this.scope)
+                } catch (e) {
+                    res = new CaughtException(e)
+                }
             }
         }
         globalState.computationDepth--

--- a/src/core/derivation.ts
+++ b/src/core/derivation.ts
@@ -81,12 +81,16 @@ export function shouldCompute(derivation: IDerivation): boolean {
             for (let i = 0; i < l; i++) {
                 const obj = obs[i]
                 if (isComputedValue(obj)) {
-                    try {
+                    if (globalState.disableErrorBoundaries) {
                         obj.get()
-                    } catch (e) {
-                        // we are not interested in the value *or* exception at this moment, but if there is one, notify all
-                        untrackedEnd(prevUntracked)
-                        return true
+                    } else {
+                        try {
+                            obj.get()
+                        } catch (e) {
+                            // we are not interested in the value *or* exception at this moment, but if there is one, notify all
+                            untrackedEnd(prevUntracked)
+                            return true
+                        }
                     }
                     // if ComputedValue `obj` actually changed it will be computed and propagated to its observers.
                     // and `derivation` is an observer of `obj`
@@ -131,10 +135,14 @@ export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T, con
     const prevTracking = globalState.trackingDerivation
     globalState.trackingDerivation = derivation
     let result
-    try {
+    if (globalState.disableErrorBoundaries) {
         result = f.call(context)
-    } catch (e) {
-        result = new CaughtException(e)
+    } else {
+        try {
+            result = f.call(context)
+        } catch (e) {
+            result = new CaughtException(e)
+        }
     }
     globalState.trackingDerivation = prevTracking
     bindDependencies(derivation)

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -84,6 +84,12 @@ export class MobXGlobals {
      * Globally attached error handlers that react specifically to errors in reactions
      */
     globalReactionErrorHandlers: ((error: any, derivation: IDerivation) => void)[] = []
+
+    /**
+     * Don't catch and rethrow exceptions. This is useful for inspecting the state of
+     * the stack when an exception occurs while debugging.
+     */
+    disableErrorBoundaries = false
 }
 
 export let globalState: MobXGlobals = new MobXGlobals()
@@ -152,4 +158,20 @@ export function resetGlobalState() {
     for (let key in defaultGlobals)
         if (persistentKeys.indexOf(key) === -1) globalState[key] = defaultGlobals[key]
     globalState.allowStateChanges = !globalState.strictMode
+}
+
+/**
+ * Don't catch and rethrow exceptions. This is useful for inspecting the state of
+ * the stack when an exception occurs while debugging.
+ */
+export function disableErrorBoundaries() {
+    console.warn("WARNING: Debug feature only. MobX will NOT recover from errors if this is on.")
+    globalState.disableErrorBoundaries = true
+}
+
+/**
+ * Opposite of disableErrorBoundaries
+ */
+export function enableErrorBoundaries() {
+    globalState.disableErrorBoundaries = false
 }

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -98,7 +98,9 @@ import {
     resetGlobalState,
     shareGlobalState,
     getGlobalState,
-    isolateGlobalState
+    isolateGlobalState,
+    disableErrorBoundaries,
+    enableErrorBoundaries
 } from "./core/globalstate"
 import { IDerivation } from "./core/derivation"
 import { IDepTreeNode } from "./core/observable"
@@ -139,7 +141,9 @@ export const extras = {
     spyReport,
     spyReportEnd,
     spyReportStart,
-    setReactionScheduler
+    setReactionScheduler,
+    disableErrorBoundaries,
+    enableErrorBoundaries,
 }
 
 // Deprecated default export (will be removed in 4.0)


### PR DESCRIPTION
Fixes https://github.com/mobxjs/mobx/issues/1241

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [ ] Added unit tests Not sure if testable: As default behavior is to rethrow the exception, different behavior is only noticeable when debugging.
* [X] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings N/A
* [ ] Verified that there is no significant performance drop (`npm run perf`)
```
'PERSIST' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! mobx@3.4.0 perf: `npm run small-build && PERSIST=true time node --expose-gc test/perf/index.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the mobx@3.4.0 perf script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

