### PR TITLE
add example of reaction invoke once

### DIFF
--- a/docs/refguide/reaction.md
+++ b/docs/refguide/reaction.md
@@ -1,6 +1,6 @@
 # Reaction
 
-Usage: `reaction(() => data, data => { sideEffect }, options?)`.
+Usage: `reaction(() => data, (data, reaction) => { sideEffect }, options?)`.
 
 A variation on `autorun` that gives more fine grained control on which observables will be tracked.
 It takes two functions, the first one (the *data* function) is tracked and returns data that is used as input for the second one, the *effect* function.
@@ -55,6 +55,15 @@ const reaction1 = reaction(
 const reaction2 = reaction(
     () => todos.map(todo => todo.title),
     titles => console.log("reaction 2:", titles.join(", "))
+);
+
+// invoke once of reaction: reacts to length changes
+const reactionOnce = reaction(
+    () => todos.length,
+    (length, reaction) => {
+        console.log("invoked once"));
+        reaction.dispose();
+    }
 );
 
 // autorun reacts to just everything that is used in its function

--- a/docs/refguide/reaction.md
+++ b/docs/refguide/reaction.md
@@ -57,15 +57,6 @@ const reaction2 = reaction(
     titles => console.log("reaction 2:", titles.join(", "))
 );
 
-// invoke once of reaction: reacts to length changes
-const reactionOnce = reaction(
-    () => todos.length,
-    (length, reaction) => {
-        console.log("invoked once"));
-        reaction.dispose();
-    }
-);
-
 // autorun reacts to just everything that is used in its function
 const autorun1 = autorun(
     () => console.log("autorun 1:", todos.map(todo => todo.title).join(", "))
@@ -81,6 +72,35 @@ todos[0].title = "Make tea"
 // prints:
 // reaction 2: Make tea, find biscuit, explain reactions
 // autorun 1: Make tea, find biscuit, explain reactions
+```
+
+In the following example `reaction3`, will react to the change in the `counter` count.
+When invoked `reaction`, second argument can use as disposer.
+The following example shows a `reaction` that is invoked only once.
+
+```javascript
+const counter = observable({ count: 0 });
+
+// invoke once of and dispose reaction: reacts to obserbable value.
+const reaction3 = reaction(
+    () => counter.count,
+    (count, reaction) => {
+        console.log("reaction 3: invoked. counter.count = " + count);
+        reaction.dispose();
+    }
+);
+
+counter.count = 1;
+// prints:
+// reaction 3: invoked. counter.count = 1
+
+counter.count = 2;
+// prints:
+// (There are no logging, because of reaction disposed. But, counter continue reaction)
+
+console.log(counter.count);
+// prints:
+// 2
 ```
 
 Reaction is roughly speaking sugar for: `computed(expression).observe(action(sideEffect))` or `autorun(() => action(sideEffect)(expression)`

--- a/docs/refguide/reaction.md
+++ b/docs/refguide/reaction.md
@@ -9,7 +9,7 @@ Any observables that are accessed while executing the side effect will not be tr
 
 The side effect can be debounced, just like `autorunAsync`.
 `reaction` returns a disposer function.
-The functions passed to `reaction` will receive one argument when invoked, the current reaction, which can be used to dispose the when during execution.
+The functions passed to `reaction` will receive two argument when invoked, the current reaction, which can be used to dispose the when during execution.
 
 It is important to notice that the side effect will *only* react to data that was *accessed* in the data expression, which might be less then the data that is actually used in the effect.
 Also, the side effect will only be triggered when the data returned by the expression has changed.


### PR DESCRIPTION
As long as I see the src code, I can invoke a reaction only once with this example. Is there any reason for being hidden?