### PR TITLE
Allow autorunAsync to take a debouncing function in addition to a delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.5.0
+
+* `autorunAsync` now accepts a scheduler function to allow improved performance for tasks such as rendering to canvas
+
 # 3.4.1
 
 * Republished 3.4.0, because the package update doesn't seem to distibute consistently through yarn / npm

--- a/src/api/autorun.ts
+++ b/src/api/autorun.ts
@@ -122,11 +122,11 @@ export function autorunAsync(
 ): IReactionDisposer
 export function autorunAsync(
     func: (r: IReactionPublic) => any,
-    scheduler: (func: () => any) => any,
+    scheduler: (callback: () => void) => any,
     scope?: any
 ): IReactionDisposer
 export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
-    let name: string, func: (r: IReactionPublic) => any, scheduler: (func: () => any) => any, scope: any
+    let name: string, func: (r: IReactionPublic) => any, scheduler: (callback: () => void) => any, scope: any
     if (typeof arg1 === "string") {
         name = arg1
         arg1 = arg2
@@ -136,8 +136,8 @@ export function autorunAsync(arg1: any, arg2: any, arg3?: any, arg4?: any) {
         name = arg1.name || "AutorunAsync@" + getNextId()
     }
     func = arg1
-    scheduler = arg2 === void 0 ? (f: () => any) => setTimeout(f, 1)
-              : typeof arg2 === "number" ? (f: () => any) => setTimeout(f, arg2)
+    scheduler = arg2 === void 0 ? (f: () => void) => setTimeout(f, 1)
+              : typeof arg2 === "number" ? (f: () => void) => setTimeout(f, arg2)
               : arg2
     scope = arg3
 

--- a/test/base/autorunAsync.js
+++ b/test/base/autorunAsync.js
@@ -128,6 +128,37 @@ test("autorunAsync passes Reaction as an argument to view function", function(do
     }, 1000)
 })
 
+test("autorunAsync accepts a scheduling function", function(done) {
+
+    var a = m.observable({
+        x: 0,
+        y: 1,
+    })
+
+    var autoRunsCalled = 0
+    var schedulingsCalled = 0
+
+    m.autorunAsync(function(r) {
+        autoRunsCalled++
+        expect(a.y).toBe(a.x + 1)
+
+        if (a.x < 10) {
+            // Queue the two actions separately, if this was autorun it would fail
+            setTimeout(function() { a.x = a.x + 1 }, 0)
+            setTimeout(function() { a.y = a.y + 1 }, 0)
+        }
+    }, function (fn) {
+        schedulingsCalled++
+        setTimeout(fn, 0)
+    })
+
+    setTimeout(function() {
+        expect(autoRunsCalled).toBe(11)
+        expect(schedulingsCalled).toBe(11)
+        done()
+    }, 100)
+})
+
 test("autorunAsync warns when passed an action", function() {
     var action = m.action(() => {})
     expect.assertions(1)

--- a/test/base/autorunAsync.js
+++ b/test/base/autorunAsync.js
@@ -156,7 +156,7 @@ test("autorunAsync accepts a scheduling function", function(done) {
         expect(autoRunsCalled).toBe(11)
         expect(schedulingsCalled).toBe(11)
         done()
-    }, 100)
+    }, 1000)
 })
 
 test("autorunAsync warns when passed an action", function() {


### PR DESCRIPTION
When mobx autorun is used to execute canvas rendering functions it can cause slowdowns as it tries to rerun the rendering function for every model update even though the system can't render yet.
This PR proposes to add a way to fix this by allowing autorunAsync to take a function instead of a delay.
This function (for the case of canvas requestAnimationFrame) would allow mobx to only run the expensive render function once the system was ready to render.

This effect can be seen in the two examples below
 * https://jsbin.com/sineton/2/edit?js,output
 * https://jsbin.com/sineton/1/edit?js,output
The code is rendering 10000 lines in a spinning circle updating on an interval of 1.
The first of these is using autorun as normal and a significant slowdown can be seen compared to how fast it should be spinning.
The second is using requestAnimationFrame to let mobx know when it can update the canvas which gives much better performance.

Before I go and update the docs etc, is this a feature that would be wanted in the mobx codebase?
Are there any suggestions on how this could be improved?

PR checklist:
* [x] Added unit tests
* [x] Updated changelog
* [x] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [x] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)
