### PR TITLE
IObservableArray.find() typing fix

### DIFF
--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -54,7 +54,7 @@ export interface IObservableArray<T> extends Array<T> {
         predicate: (item: T, index: number, array: IObservableArray<T>) => boolean,
         thisArg?: any,
         fromIndex?: number
-    ): T
+    ): T | undefined
     findIndex(
         predicate: (item: T, index: number, array: IObservableArray<T>) => boolean,
         thisArg?: any,


### PR DESCRIPTION
Hi! Currently, `IObservableArray<T>.find` returns `T` instead of `T | undefined` which leads to runtime errors.

I’ve tried to write a test, but it seems that `typescript-tests.ts` is not being typechecked, because even `var x:string = 1` doesn’t fail. Is there any way to test this?