### PR TITLE
fix type definition for when

### DIFF
--- a/src/api/autorun.ts
+++ b/src/api/autorun.ts
@@ -82,7 +82,7 @@ export function when(
  * @param scope (optional)
  * @returns disposer function to prematurely end the observer.
  */
-export function when(predicate: () => boolean, effect: Lambda, scope?: any): Lambda
+export function when(predicate: () => boolean, effect: Lambda, scope?: any): IReactionDisposer
 
 export function when(arg1: any, arg2: any, arg3?: any, arg4?: any) {
     let name: string, predicate: () => boolean, effect: Lambda, scope: any


### PR DESCRIPTION
right now some of the when definitions return IReactionDisposer and others return Lambda, this pull requests makes both use IReactionDisposer

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [x] Added unit tests
* [ ] Updated changelog
* [x] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [x] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
