### PR TITLE
WIP: Make observable map structurally match an ES6 Map

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "quick-build": "tsc --pretty",
     "small-build": "node scripts/build.js",
     "lint": "tslint -c tslint.json src/*.ts src/types/*.ts src/api/*.ts src/core/*.ts src/utils/*.ts",
-    "size": "size-limit 20KB lib/mobx.js",
+    "size": "size-limit 21KB lib/mobx.js",
     "precommit": "lint-staged"
   },
   "repository": {

--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -11,7 +11,8 @@ import {
     deprecated,
     isES6Map,
     getMapLikeKeys,
-    fail
+    fail,
+    declareStringTag
 } from "../utils/utils"
 import {
     IInterceptable,
@@ -40,7 +41,16 @@ export interface IMap<K, V> {
     get(key: K): V | undefined
     has(key: K): boolean
     set(key: K, value?: V): this
+    [Symbol.toStringTag]: "Map"
+    [Symbol.iterator](): IterableIterator<[K, V]>
+    entries(): IterableIterator<[K, V]>
+    keys(): IterableIterator<K>
+    values(): IterableIterator<V>
     readonly size: number
+}
+
+export interface IterableIterator<T> extends Iterator<T> {
+    [Symbol.iterator](): IterableIterator<T>
 }
 
 export interface IKeyValueMap<V> {
@@ -376,9 +386,19 @@ export class ObservableMap<V>
     }
 }
 
+/**
+ * Include the interface to cover the implementations added to the prototype directly.
+ */
+export interface ObservableMap<V> {
+    [Symbol.toStringTag]: "Map"
+    [Symbol.iterator](): IterableIterator<[string, V]>
+}
+
 declareIterator(ObservableMap.prototype, function() {
     return this.entries()
 })
+
+declareStringTag(ObservableMap.prototype, "Map")
 
 export function map<V>(initialValues?: IObservableMapInitialValues<V>): ObservableMap<V> {
     deprecated("`mobx.map` is deprecated, use `new ObservableMap` or `mobx.observable.map` instead")

--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -41,7 +41,8 @@ export interface IMap<K, V> {
     get(key: K): V | undefined
     has(key: K): boolean
     set(key: K, value?: V): this
-    [Symbol.toStringTag]: "Map"
+    // prettier-ignore
+    [Symbol.toStringTag]: "Map"; // necessary semicolon
     [Symbol.iterator](): IterableIterator<[K, V]>
     entries(): IterableIterator<[K, V]>
     keys(): IterableIterator<K>
@@ -390,7 +391,8 @@ export class ObservableMap<V>
  * Include the interface to cover the implementations added to the prototype directly.
  */
 export interface ObservableMap<V> {
-    [Symbol.toStringTag]: "Map"
+    // prettier-ignore
+    [Symbol.toStringTag]: "Map"; // necessary semicolon
     [Symbol.iterator](): IterableIterator<[string, V]>
 }
 

--- a/src/utils/iterable.ts
+++ b/src/utils/iterable.ts
@@ -10,11 +10,15 @@ function iteratorSymbol() {
 
 export const IS_ITERATING_MARKER = "__$$iterating"
 
+export interface IteratorResult<T> {
+    done: boolean
+    value: T
+}
+
 export interface Iterator<T> {
-    next(): {
-        done: boolean
-        value?: T
-    }
+    next(value?: any): IteratorResult<T>
+    return?(value?: any): IteratorResult<T>
+    throw?(e?: any): IteratorResult<T>
 }
 
 export function arrayAsIterator<T>(array: T[]): T[] & Iterator<T> {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -192,10 +192,12 @@ export function toPrimitive(value) {
     return value === null ? null : typeof value === "object" ? "" + value : value
 }
 
-const stringTagSymbol = (typeof Symbol === "function" && Symbol.toStringTag) || "@@toStringTag"
+export function stringTagSymbol() {
+    return (typeof Symbol === "function" && Symbol.toStringTag) || "@@toStringTag"
+}
 
 export function declareStringTag<T>(prototType, tag: string) {
-    addHiddenFinalProp(prototType, stringTagSymbol, tag)
+    addHiddenFinalProp(prototType, stringTagSymbol(), tag)
 }
 
 import { globalState } from "../core/globalstate"

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -192,6 +192,12 @@ export function toPrimitive(value) {
     return value === null ? null : typeof value === "object" ? "" + value : value
 }
 
+const stringTagSymbol = (typeof Symbol === "function" && Symbol.toStringTag) || "@@toStringTag"
+
+export function declareStringTag<T>(prototType, tag: string) {
+    addHiddenFinalProp(prototType, stringTagSymbol, tag)
+}
+
 import { globalState } from "../core/globalstate"
 import { IObservableArray, isObservableArray } from "../types/observablearray"
 import { isObservableMap, ObservableMap, IKeyValueMap } from "../types/observablemap"

--- a/test/base/map.js
+++ b/test/base/map.js
@@ -642,3 +642,9 @@ test("#1258 cannot replace maps anymore", () => {
     const items = mobx.observable.map()
     items.replace(mobx.observable.map())
 })
+
+test("map should implement toStringTag", () => {
+    const m = mobx.observable.map({ a: 1 })
+    const name = Object.prototype.toString.call(m)
+    expect(name).toBe("[object Map]")
+})

--- a/test/base/typescript-tests.ts
+++ b/test/base/typescript-tests.ts
@@ -1247,3 +1247,8 @@ test("1072 - @observable without initial value and observe before first access",
     const user = new User()
     observe(user, "loginCount", () => {})
 })
+
+test("map should structurally match ES6 Map", () => {
+    // Including this line strictly for type checking.
+    const m: Map<string, number> = mobx.observable.map({ a: 1, b: 2 })
+})

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,6 +4,9 @@
         "target": "es5",
         "noImplicitAny": true,
         "sourceMap": false,
-		"experimentalDecorators": true
+		"experimentalDecorators": true,
+        "lib": [
+          "es2015"
+        ]
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
         "noImplicitAny": false,
         "moduleResolution": "node",
         "lib": [
-            "es5",
+            "es2015",
             "dom"
         ]
     },


### PR DESCRIPTION
Observable map now has the typings to structurally match `Map`. Also implements `toStringTag` properly as if it were a Map. This should resolve https://github.com/mobxjs/mobx/issues/1204

***

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [x] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [x] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
