### PR TITLE
introduced canceellable flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The changes mentioned here are discussed in detail in the [release highlights](h
 * Introduced `mobx.configure({ disableErrorBoundaries })`, for easier debugging of exceptoins. By [NaridaL](https://github.com/NaridaL) through [#1262](https://github.com/mobxjs/mobx/pull/1262)
 * `toJS` now accepts the options: `{ detectCycles?: boolean, exportMapsAsObjects?: boolean }`, both `true` by default
 * Introduced `flow` to create a chain of async actions. This is the same function as [`asyncActions`](https://github.com/mobxjs/mobx-utils#asyncaction) of the mobx-utils package
+* These `flow`'s are now cancellable, by calling `.cancel()` on the returned promise, which will throw a cancellation exception into the generator function.
 * The flow typings have been updated. Since this is a manual effort, there can be mistakes, so feel free to PR!
 
 * `computed(fn, options?)` / `@computed(options) get fn()` now accept the following options:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The changes mentioned here are discussed in detail in the [release highlights](h
 * `toJS` now accepts the options: `{ detectCycles?: boolean, exportMapsAsObjects?: boolean }`, both `true` by default
 * Introduced `flow` to create a chain of async actions. This is the same function as [`asyncActions`](https://github.com/mobxjs/mobx-utils#asyncaction) of the mobx-utils package
 * These `flow`'s are now cancellable, by calling `.cancel()` on the returned promise, which will throw a cancellation exception into the generator function.
+* `flow` also has experimental support for async iterators (`async * function`)
 * The flow typings have been updated. Since this is a manual effort, there can be mistakes, so feel free to PR!
 
 * `computed(fn, options?)` / `@computed(options) get fn()` now accept the following options:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "typings": "lib/mobx.d.ts",
   "scripts": {
     "test": "yarn quick-build && yarn jest",
-    "watch": "yarn test --watch",
+    "watch": "yarn jest --watch",
     "test:mixed-versions": "jest --testRegex mixed-versions",
     "test:all": "yarn small-build && yarn jest -i && yarn test:flow && yarn test:mixed-versions",
     "test:webpack": "node scripts/webpack-regression-tests.js",

--- a/src/api/flow.ts
+++ b/src/api/flow.ts
@@ -135,8 +135,8 @@ export function createFlowGenerator(name: string, generator: Function) {
                 } catch (e) {
                     return reject(e)
                 }
+
                 next(ret)
-                return null
             }
 
             function onRejected(err: any) {
@@ -155,10 +155,7 @@ export function createFlowGenerator(name: string, generator: Function) {
 
             function next(ret: any) {
                 if (ret.done) return resolve(ret.value)
-                // TODO: support more type of values? See https://github.com/tj/co/blob/249bbdc72da24ae44076afd716349d2089b31c4c/index.js#L100
-                if (!ret.value || typeof ret.value.then !== "function")
-                    return fail("Only promises can be yielded to asyncAction, got: " + ret)
-                pendingPromise = ret.value
+                pendingPromise = Promise.resolve(ret.value) as any
                 return pendingPromise!.then(onFulfilled, onRejected)
             }
 

--- a/src/api/flow.ts
+++ b/src/api/flow.ts
@@ -2,16 +2,19 @@ import { BabelDescriptor } from "../utils/decorators2"
 import { addHiddenFinalProp } from "../utils/utils"
 import { action } from "./action"
 
+export type CancellablePromise<T> = Promise<T> & { cancel(): void }
+
 // method decorator:
 export function flow(
     target: Object,
     propertyKey: string,
     descriptor: PropertyDescriptor
 ): PropertyDescriptor
-
 // non-decorator forms
-export function flow<R>(generator: () => IterableIterator<any>): () => Promise<R>
-export function flow<A1>(generator: (a1: A1) => IterableIterator<any>): (a1: A1) => Promise<any> // Ideally we want to have R instead of Any, but cannot specify R without specifying A1 etc... 'any' as result is better then not specifying request args
+export function flow<R>(generator: () => IterableIterator<any>): () => CancellablePromise<R>
+export function flow<A1>(
+    generator: (a1: A1) => IterableIterator<any>
+): (a1: A1) => CancellablePromise<any> // Ideally we want to have R instead of Any, but cannot specify R without specifying A1 etc... 'any' as result is better then not specifying request args
 export function flow<A1, A2, A3, A4, A5, A6, A7, A8>(
     generator: (
         a1: A1,
@@ -23,32 +26,37 @@ export function flow<A1, A2, A3, A4, A5, A6, A7, A8>(
         a7: A7,
         a8: A8
     ) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8) => Promise<any>
+): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4, A5, A6, A7>(
     generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => Promise<any>
+): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4, A5, A6>(
     generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => Promise<any>
+): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4, A5>(
     generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => Promise<any>
+): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4>(
     generator: (a1: A1, a2: A2, a3: A3, a4: A4) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4) => Promise<any>
+): (a1: A1, a2: A2, a3: A3, a4: A4) => CancellablePromise<any>
 export function flow<A1, A2, A3>(
     generator: (a1: A1, a2: A2, a3: A3) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3) => Promise<any>
+): (a1: A1, a2: A2, a3: A3) => CancellablePromise<any>
 export function flow<A1, A2>(
     generator: (a1: A1, a2: A2) => IterableIterator<any>
-): (a1: A1, a2: A2) => Promise<any>
-export function flow<A1>(generator: (a1: A1) => IterableIterator<any>): (a1: A1) => Promise<any>
+): (a1: A1, a2: A2) => CancellablePromise<any>
+export function flow<A1>(
+    generator: (a1: A1) => IterableIterator<any>
+): (a1: A1) => CancellablePromise<any>
 // ... with name
-export function flow<R>(name: string, generator: () => IterableIterator<any>): () => Promise<R>
+export function flow<R>(
+    name: string,
+    generator: () => IterableIterator<any>
+): () => CancellablePromise<R>
 export function flow<A1>(
     name: string,
     generator: (a1: A1) => IterableIterator<any>
-): (a1: A1) => Promise<any> // Ideally we want to have R instead of Any, but cannot specify R without specifying A1 etc... 'any' as result is better then not specifying request args
+): (a1: A1) => CancellablePromise<any> // Ideally we want to have R instead of Any, but cannot specify R without specifying A1 etc... 'any' as result is better then not specifying request args
 export function flow<A1, A2, A3, A4, A5, A6, A7, A8>(
     name: string,
     generator: (
@@ -61,101 +69,35 @@ export function flow<A1, A2, A3, A4, A5, A6, A7, A8>(
         a7: A7,
         a8: A8
     ) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8) => Promise<any>
+): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4, A5, A6, A7>(
     name: string,
     generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => Promise<any>
+): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4, A5, A6>(
     name: string,
     generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => Promise<any>
+): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4, A5>(
     name: string,
     generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => Promise<any>
+): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4>(
     name: string,
     generator: (a1: A1, a2: A2, a3: A3, a4: A4) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3, a4: A4) => Promise<any>
+): (a1: A1, a2: A2, a3: A3, a4: A4) => CancellablePromise<any>
 export function flow<A1, A2, A3>(
     name: string,
     generator: (a1: A1, a2: A2, a3: A3) => IterableIterator<any>
-): (a1: A1, a2: A2, a3: A3) => Promise<any>
+): (a1: A1, a2: A2, a3: A3) => CancellablePromise<any>
 export function flow<A1, A2>(
     name: string,
     generator: (a1: A1, a2: A2) => IterableIterator<any>
-): (a1: A1, a2: A2) => Promise<any>
+): (a1: A1, a2: A2) => CancellablePromise<any>
 export function flow<A1>(
     name: string,
     generator: (a1: A1) => IterableIterator<any>
-): (a1: A1) => Promise<any>
-
-/**
- * `asyncAction` takes a generator function and automatically wraps all parts of the process in actions. See the examples below.
- * `asyncAction` can be used both as decorator or to wrap functions.
- *
- * - It is important that `asyncAction should always be used with a generator function (recognizable as `function*` or `*name` syntax)
- * - Each yield statement should return a Promise. The generator function will continue as soon as the promise settles, with the settled value
- * - When the generator function finishes, you can return a normal value. The `asyncAction` wrapped function will always produce a promise delivering that value.
- *
- * When using the mobx devTools, an asyncAction will emit `action` events with names like:
- * * `"fetchUsers - runid: 6 - init"`
- * * `"fetchUsers - runid: 6 - yield 0"`
- * * `"fetchUsers - runid: 6 - yield 1"`
- *
- * The `runId` represents the generator instance. In other words, if `fetchUsers` is invoked multiple times concurrently, the events with the same `runid` belong toghether.
- * The `yield` number indicates the progress of the generator. `init` indicates spawning (it won't do anything, but you can find the original arguments of the `asyncAction` here).
- * `yield 0` ... `yield n` indicates the code block that is now being executed. `yield 0` is before the first `yield`, `yield 1` after the first one etc. Note that yield numbers are not determined lexically but by the runtime flow.
- *
- * `asyncActions` requires `Promise` and `generators` to be available on the target environment. Polyfill `Promise` if needed. Both TypeScript and Babel can compile generator functions down to ES5.
- *
- *  N.B. due to a [babel limitation](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy/issues/26), in Babel generatos cannot be combined with decorators. See also [#70](https://github.com/mobxjs/mobx-utils/issues/70)
- *
- * @example
- * import {asyncAction} from "mobx-utils"
- *
- * let users = []
- *
- * const fetchUsers = asyncAction("fetchUsers", function* (url) {
- *   const start = Date.now()
- *   const data = yield window.fetch(url)
- *   users = yield data.json()
- *   return start - Date.now()
- * })
- *
- * fetchUsers("http://users.com").then(time => {
- *   console.dir("Got users", users, "in ", time, "ms")
- * })
- *
- * @example
- * import {asyncAction} from "mobx-utils"
- *
- * mobx.useStrict(true) // don't allow state modifications outside actions
- *
- * class Store {
- * 	\@observable githubProjects = []
- * 	\@state = "pending" // "pending" / "done" / "error"
- *
- * 	\@asyncAction
- * 	*fetchProjects() { // <- note the star, this a generator function!
- * 		this.githubProjects = []
- * 		this.state = "pending"
- * 		try {
- * 			const projects = yield fetchGithubProjectsSomehow() // yield instead of await
- * 			const filteredProjects = somePreprocessing(projects)
- * 			// the asynchronous blocks will automatically be wrapped actions
- * 			this.state = "done"
- * 			this.githubProjects = filteredProjects
- * 		} catch (error) {
- * 			this.state = "error"
- * 		}
- * 	}
- * }
- *
- * @export
- * @returns {Promise}
- */
+): (a1: A1) => CancellablePromise<any>
 export function flow(arg1: any, arg2?: any): any {
     // decorator
     if (typeof arguments[1] === "string") return flowDecorator.apply(null, arguments)
@@ -173,47 +115,56 @@ export function createFlowGenerator(name: string, generator: Function) {
     return function() {
         const ctx = this
         const args = arguments
-        return new Promise(function(resolve, reject) {
-            const runId = ++generatorId
-            let stepId = 0
-            const gen = action(`${name} - runid: ${runId} - init`, generator).apply(ctx, args)
+        const runId = ++generatorId
+        const gen = action(`${name} - runid: ${runId} - init`, generator).apply(ctx, args)
+        let stepId = 0
+        let resolver: (value: any) => void
+        let rejector: (error: any) => void
+
+        function onFulfilled(res: any) {
+            let ret
+            try {
+                ret = action(`${name} - runid: ${runId} - yield ${stepId++}`, gen.next).call(
+                    gen,
+                    res
+                )
+            } catch (e) {
+                return rejector(e)
+            }
+            next(ret)
+            return null
+        }
+
+        function onRejected(err: any) {
+            let ret
+            try {
+                ret = action(`${name} - runid: ${runId} - yield ${stepId++}`, gen.throw).call(
+                    gen,
+                    err
+                )
+            } catch (e) {
+                return rejector(e)
+            }
+            next(ret)
+        }
+
+        function next(ret: any) {
+            if (ret.done) return resolver(ret.value)
+            // TODO: support more type of values? See https://github.com/tj/co/blob/249bbdc72da24ae44076afd716349d2089b31c4c/index.js#L100
+            if (!ret.value || typeof ret.value.then !== "function")
+                return fail("Only promises can be yielded to asyncAction, got: " + ret)
+            return ret.value.then(onFulfilled, onRejected)
+        }
+
+        const res = new Promise(function(resolve, reject) {
+            resolver = resolve
+            rejector = reject
             onFulfilled(undefined) // kick off the process
-
-            function onFulfilled(res: any) {
-                let ret
-                try {
-                    ret = action(`${name} - runid: ${runId} - yield ${stepId++}`, gen.next).call(
-                        gen,
-                        res
-                    )
-                } catch (e) {
-                    return reject(e)
-                }
-                next(ret)
-                return null
-            }
-
-            function onRejected(err: any) {
-                let ret
-                try {
-                    ret = action(`${name} - runid: ${runId} - yield ${stepId++}`, gen.throw).call(
-                        gen,
-                        err
-                    )
-                } catch (e) {
-                    return reject(e)
-                }
-                next(ret)
-            }
-
-            function next(ret: any) {
-                if (ret.done) return resolve(ret.value)
-                // TODO: support more type of values? See https://github.com/tj/co/blob/249bbdc72da24ae44076afd716349d2089b31c4c/index.js#L100
-                if (!ret.value || typeof ret.value.then !== "function")
-                    fail("Only promises can be yielded to asyncAction, got: " + ret)
-                return ret.value.then(onFulfilled, onRejected)
-            }
-        })
+        }) as any
+        res.cancel = function() {
+            onRejected(new Error("FLOW_CANCELLED"))
+        }
+        return res
     }
 }
 

--- a/src/api/flow.ts
+++ b/src/api/flow.ts
@@ -154,6 +154,11 @@ export function createFlowGenerator(name: string, generator: Function) {
             }
 
             function next(ret: any) {
+                if (ret && typeof ret.then === "function") {
+                    // an async iterator
+                    ret.then(next, reject)
+                    return
+                }
                 if (ret.done) return resolve(ret.value)
                 pendingPromise = Promise.resolve(ret.value) as any
                 return pendingPromise!.then(onFulfilled, onRejected)

--- a/test/base/flow.js
+++ b/test/base/flow.js
@@ -317,3 +317,14 @@ test("flows can be cancelled - 5 - flows cancel recursively", done => {
     )
     p.cancel()
 })
+
+test("flows yield anything", async () => {
+    let steps = 0
+    const start = flow(function*() {
+        const x = yield 2
+        return x
+    })
+
+    const res = await start()
+    expect(res).toBe(2)
+})

--- a/test/base/flow.js
+++ b/test/base/flow.js
@@ -232,7 +232,7 @@ test("flows can be cancelled - 3 - rethrow cancellation", done => {
     promise.cancel()
 })
 
-test("flows can be cancelled - 3 - pending Promise will be ignored", done => {
+test("flows can be cancelled - 4 - pending Promise will be ignored", done => {
     let steps = 0
     const start = flow(function*() {
         steps = 1
@@ -256,4 +256,23 @@ test("flows can be cancelled - 3 - pending Promise will be ignored", done => {
         }
     )
     promise.cancel()
+})
+
+test("flows can be cancelled - 5 - return before cancel", done => {
+    let steps = 0
+    const start = flow(function*() {
+        steps = 1
+        return Promise.resolve(2) // cancel will be to late..
+    })
+
+    const promise = start()
+    promise.then(
+        value => {
+            expect(value).toBe(2), done()
+        },
+        err => {
+            fail()
+        }
+    )
+    promise.cancel() // no-op
 })

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,9 +2,11 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es5",
+        "lib": ["esnext"],
         "noImplicitAny": true,
         "sourceMap": false,
         "experimentalDecorators": true,
-        "strict":true
+        "strict":true,
+        "downlevelIteration": true
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
         "noUnusedLocals": true,
         "noImplicitAny": false,
         "moduleResolution": "node",
+        "downlevelIteration": true,
         "lib": [
             "es6"
         ]


### PR DESCRIPTION
```javascript
const asyncFlow = flow(function * () { 
    // do stuff
   try {
      yield Promise.resolve(3)
   } catch (e) {
       // cancel end's up here, e is "FLOW_CANCELLED"
      throw e // now 'promise' will reject with "FLOW_CANCELLED"
   }
})
const promise = asyncFlow()

promise.cancel() // rejects the next yield / return
```

Would you mind reviewing @benjamingr ? Does this approach make sense?