### PR TITLE
Flow-typed: add missing runInAction declaration

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -290,6 +290,7 @@ declare export function action(
 declare export function action<T>(name: string, func: T): T
 declare export function action<T>(func: T): T
 
+declare export function runInAction<T>(name: string, block: () => T): T
 declare export function runInAction<T>(block: () => T): T
 declare export function isAction(thing: any): boolean
 declare export function autorun(


### PR DESCRIPTION
Updated the flow typings with the missing runInAction declaration.