### PR TITLE
Spy: fix stop listen from handler

### DIFF
--- a/src/core/spy.ts
+++ b/src/core/spy.ts
@@ -26,7 +26,7 @@ export function spyReportEnd(change?) {
 export function spy(listener: (change: any) => void): Lambda {
     globalState.spyListeners.push(listener)
     return once(() => {
-        const idx = globalState.spyListeners.indexOf(listener)
-        if (idx !== -1) globalState.spyListeners.splice(idx, 1)
+        globalState.spyListeners = globalState.spyListeners
+          .filter(l => l !== listener)
     })
 }

--- a/test/base/spy.js
+++ b/test/base/spy.js
@@ -95,3 +95,9 @@ test("spy error", () => {
         stop()
     })
 })
+
+test("spy stop listen from handler, #1459", () => {
+    const stop = mobx.spy(() => stop())
+    mobx.spy(() => {})
+    doStuff()
+})


### PR DESCRIPTION
Fix https://github.com/mobxjs/mobx/issues/1459

Making copy of `listeners` in `spyReport` can have performance impact so I changed unsubscribe action because it rarer event. Also all same listeners is removed with this change (not only first).