### PR TITLE
add another missing import of `fail`

### DIFF
--- a/src/api/flow.ts
+++ b/src/api/flow.ts
@@ -1,5 +1,5 @@
 import { action } from "./action"
-import { noop } from "../utils/utils"
+import { fail, noop } from "../utils/utils"
 
 let generatorId = 0
 


### PR DESCRIPTION
this makes strict compilation error out