### PR TITLE
avoid the unnecessary reassign with the equivalent comparison result

### DIFF
--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -197,13 +197,19 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
         const oldValue = this.value
         const wasSuspended =
             /* see #1208 */ this.dependenciesState === IDerivationState.NOT_TRACKING
-        const newValue = (this.value = this.computeValue(true))
-        return (
+        const newValue = this.computeValue(true)
+
+        const changed =
             wasSuspended ||
             isCaughtException(oldValue) ||
             isCaughtException(newValue) ||
             !this.equals(oldValue, newValue)
-        )
+
+        if (changed) {
+            this.value = newValue
+        }
+
+        return changed
     }
 
     computeValue(track: boolean) {

--- a/test/base/babel-tests.js
+++ b/test/base/babel-tests.js
@@ -102,6 +102,29 @@ test("babel: parameterized computed decorator", () => {
     expect(changes).toEqual([{ sum: 6 }, { sum: 7 }, { sum: 9 }])
 })
 
+test("computed value should be the same around comparer judged equivalent reassign", () => {
+    class TestClass {
+        @observable c = null
+        defaultCollection = []
+        @computed.struct
+        get collection() {
+            return this.c || this.defaultCollection
+        }
+    }
+
+    const t1 = new TestClass()
+
+    const d = autorun(() => t1.collection)
+
+    const oldCollection = t1.collection
+    t1.c = []
+    const newCollection = t1.collection
+
+    expect(oldCollection).toBe(newCollection)
+
+    d()
+})
+
 class Order {
     @observable price = 3
     @observable amount = 2

--- a/test/base/babel-tests.js
+++ b/test/base/babel-tests.js
@@ -102,7 +102,7 @@ test("babel: parameterized computed decorator", () => {
     expect(changes).toEqual([{ sum: 6 }, { sum: 7 }, { sum: 9 }])
 })
 
-test("computed value should be the same around comparer judged equivalent reassign", () => {
+test("computed value should be the same around changing which was considered equivalent", () => {
     class TestClass {
         @observable c = null
         defaultCollection = []


### PR DESCRIPTION
Now the computed value will be reassign although the assignment was equivalent by the comparer.

@mweststrate 
Here is the [jsfiddle demo](https://jsfiddle.net/Kuitos/ycv4bb2a/15/) which describes the unexpected behavior, or u can check the added unit test for details🙂

* [x] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)