### PR TITLE
Fix Flow typing for observable.map

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -236,7 +236,10 @@ export interface IObservableFactory {
 declare export class IObservableFactories {
     box<T>(value?: T, name?: string): IObservableValue<T>,
     array<T>(initialValues?: T[], name?: string): IObservableArray<T>,
-    map<T>(initialValues?: IObservableMapInitialValues<T>, name?: string): ObservableMap<T>,
+    map<K, V>(
+        initialValues?: IObservableMapInitialValues<K, V>,
+        name?: string
+    ): ObservableMap<K, V>,
     object<T>(props: T, name?: string): T & IObservableObject,
     ref(target: Object, property?: string, descriptor?: PropertyDescriptor): any,
     shallow(target: Object, property?: string, descriptor?: PropertyDescriptor): any,


### PR DESCRIPTION
It is a PR to address #1500 

Flow typing of `observable.map` is changed from generic of `<T>` to `<K, V>`
