### PR TITLE
Update object api set to write through parent mobx administrator

### DIFF
--- a/src/api/object-api.ts
+++ b/src/api/object-api.ts
@@ -65,7 +65,7 @@ export function set(obj: any, key: any, value?: any): void {
         const adm = ((obj as any) as IIsObservableObject).$mobx
         const existingObservable = adm.values[key]
         if (existingObservable) {
-            existingObservable.set(value)
+            adm.write(obj, key, value)
         } else {
             defineObservableProperty(obj, key, value, adm.defaultEnhancer)
         }

--- a/test/base/object-api.js
+++ b/test/base/object-api.js
@@ -177,6 +177,25 @@ test("observe & intercept", () => {
     })
 })
 
+test("observe & intercept set called multiple times", () => {
+    const a = mobx.observable({})
+    const interceptLogs = []
+    const observeLogs = []
+
+    mobx.intercept(a, change => {
+        interceptLogs.push(`${change.name}: ${change.newValue}`)
+        return change
+    })
+    mobx.observe(a, change => observeLogs.push(`${change.name}: ${change.newValue}`))
+
+    mobx.set(a, "x", 0)
+    a.x = 1
+    mobx.set(a, "x", 2)
+
+    expect(interceptLogs).toEqual(["x: 0", "x: 1", "x: 2"])
+    expect(observeLogs).toEqual(["x: 0", "x: 1", "x: 2"])
+})
+
 test("dynamically adding properties should preserve the original modifiers of an object", () => {
     const todos = observable(
         {


### PR DESCRIPTION
This PR is to address #1512

* [x] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)
