### PR TITLE
Fix error for enforceActions option in flow

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -2,7 +2,7 @@
 
 export type IObservableMapInitialValues<K, V> = IMapEntries<K, V> | KeyValueMap<V> | IMap<K, V>
 
-export interface IMobxConfigurationOptions {
+export type IMobxConfigurationOptions = {
     enforceActions?: boolean | "strict",
     computedRequiresReaction?: boolean,
     isolateGlobalState?: boolean,


### PR DESCRIPTION
Since recently we have a flow error in our project, which seems to be an error in flow itself, I already created an issue there: https://github.com/facebook/flow/issues/6186

However, this error only applies if an interface is used for the `enforceActions` attribute. Somehow flow misinterprets a union as an intersection within an interface, but not within an object.

When looking at that I was wondering why it is an interface instead of a simple type definition. I propose this change here, and as a side effect flow would continue working for us :-)