### PR TITLE
refactor: replace the memorizer from array to ES6 map in mobx.tojs()

### DIFF
--- a/src/api/tojs.ts
+++ b/src/api/tojs.ts
@@ -15,62 +15,79 @@ const defaultOptions: ToJSOptions = {
     exportMapsAsObjects: true
 }
 
+function cache<K, V>(map: Map<any, any>, key: K, value: V, options: ToJSOptions): V {
+    if (options.detectCycles) map.set(key, value)
+    return value
+}
+
+function toJSHelper(source, options: ToJSOptions, __alreadySeen: Map<any, any>) {
+    if (!isObservable(source)) return source
+
+    const detectCycles = options.detectCycles === true
+
+    if (
+        detectCycles &&
+        source !== null &&
+        typeof source === "object" &&
+        __alreadySeen.has(source)
+    ) {
+        return __alreadySeen.get(source)
+    }
+
+    if (isObservableArray(source)) {
+        const res = cache(__alreadySeen, source, [] as any, options)
+        const toAdd = source.map(value => toJSHelper(value, options!, __alreadySeen))
+        res.length = toAdd.length
+        for (let i = 0, l = toAdd.length; i < l; i++) res[i] = toAdd[i]
+        return res
+    }
+
+    if (isObservableObject(source)) {
+        const res = cache(__alreadySeen, source, {}, options)
+        keys(source) // make sure we track the keys of the object
+        for (let key in source) {
+            res[key] = toJSHelper(source[key], options!, __alreadySeen)
+        }
+        return res
+    }
+
+    if (isObservableMap(source)) {
+        if (options.exportMapsAsObjects === false) {
+            const res = cache(__alreadySeen, source, new Map(), options)
+            source.forEach((value, key) => {
+                res.set(key, toJSHelper(value, options!, __alreadySeen))
+            })
+            return res
+        } else {
+            const res = cache(__alreadySeen, source, {}, options)
+            source.forEach((value, key) => {
+                res[key] = toJSHelper(value, options!, __alreadySeen)
+            })
+            return res
+        }
+    }
+
+    if (isObservableValue(source)) return toJSHelper(source.get(), options!, __alreadySeen)
+
+    return source
+}
+
 /**
  * Basically, a deep clone, so that no reactive property will exist anymore.
  */
 export function toJS<T>(source: T, options?: ToJSOptions): T
 export function toJS(source: any, options?: ToJSOptions): any
-export function toJS(source, options: ToJSOptions, __alreadySeen: [any, any][]) // internal overload
-export function toJS(source, options?: ToJSOptions, __alreadySeen: [any, any][] = []) {
+export function toJS(source, options: ToJSOptions) // internal overload
+export function toJS(source, options: ToJSOptions) {
+    if (!isObservable(source)) return source
+
     // backward compatibility
     if (typeof options === "boolean") options = { detectCycles: options }
-
     if (!options) options = defaultOptions
     const detectCycles = options.detectCycles === true
-    // optimization: using ES6 map would be more efficient!
-    // optimization: lift this function outside toJS, this makes recursion expensive
-    function cache(value) {
-        if (detectCycles) __alreadySeen.push([source, value])
-        return value
-    }
-    if (isObservable(source)) {
-        if (detectCycles && __alreadySeen === null) __alreadySeen = []
-        if (detectCycles && source !== null && typeof source === "object") {
-            for (let i = 0, l = __alreadySeen.length; i < l; i++)
-                if (__alreadySeen[i][0] === source) return __alreadySeen[i][1]
-        }
 
-        if (isObservableArray(source)) {
-            const res = cache([])
-            const toAdd = source.map(value => toJS(value, options!, __alreadySeen))
-            res.length = toAdd.length
-            for (let i = 0, l = toAdd.length; i < l; i++) res[i] = toAdd[i]
-            return res
-        }
-        if (isObservableObject(source)) {
-            const res = cache({})
-            keys(source) // make sure we track the keys of the object
-            for (let key in source) {
-                res[key] = toJS(source[key], options!, __alreadySeen)
-            }
-            return res
-        }
-        if (isObservableMap(source)) {
-            if (options.exportMapsAsObjects === false) {
-                const res = cache(new Map())
-                source.forEach((value, key) => {
-                    res.set(key, toJS(value, options!, __alreadySeen))
-                })
-                return res
-            } else {
-                const res = cache({})
-                source.forEach((value, key) => {
-                    res[key] = toJS(value, options!, __alreadySeen)
-                })
-                return res
-            }
-        }
-        if (isObservableValue(source)) return toJS(source.get(), options!, __alreadySeen)
-    }
-    return source
+    let __alreadySeen
+    if (detectCycles) __alreadySeen = new Map()
+
+    return toJSHelper(source, options, __alreadySeen)
 }

--- a/src/core/spy.ts
+++ b/src/core/spy.ts
@@ -26,7 +26,6 @@ export function spyReportEnd(change?) {
 export function spy(listener: (change: any) => void): Lambda {
     globalState.spyListeners.push(listener)
     return once(() => {
-        globalState.spyListeners = globalState.spyListeners
-          .filter(l => l !== listener)
+        globalState.spyListeners = globalState.spyListeners.filter(l => l !== listener)
     })
 }


### PR DESCRIPTION
refactor: replace the memorizer from array to ES6 map in mobx.tojs() & extract the common cache method from recursion

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [x] Added unit tests
* [x] Updated changelog
* [x] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [x] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
