### PR TITLE
Extending ObservableMap with computed properties fails

### DIFF
--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -1,5 +1,6 @@
 import { IEnhancer, deepEnhancer } from "./modifiers"
 import { untracked } from "../core/derivation"
+import { asObservableObject } from "./observableobject"
 import { IObservableArray, ObservableArray } from "./observablearray"
 import { ObservableValue, UNCHANGED } from "./observablevalue"
 import {
@@ -70,6 +71,8 @@ export type IObservableMapInitialValues<K = any, V = any> =
 
 export class ObservableMap<K = any, V = any>
     implements Map<K, V>, IInterceptable<IMapWillChange<K, V>>, IListenable {
+    // removing this "fixes" the inheritance,
+    // however it breaks the deep observable spec
     $mobx = ObservableMapMarker
     private _data: Map<K, ObservableValue<V>>
     private _hasMap: Map<K, ObservableValue<boolean>> // hasMap, not hashMap >-).
@@ -97,7 +100,11 @@ export class ObservableMap<K = any, V = any>
         }
         this._data = new Map()
         this._hasMap = new Map()
+
         this.merge(initialData)
+        // i also attempted to make map observable as objects are
+        // this brok quite a few specs
+        // asObservableObject(this, name, enhancer)
     }
 
     private _has(key: K): boolean {

--- a/src/types/observableobject.ts
+++ b/src/types/observableobject.ts
@@ -241,6 +241,7 @@ export function asObservableObject(
 
     adm = new ObservableObjectAdministration(target, name, defaultEnhancer)
     addHiddenFinalProp(target, "$mobx", adm)
+    //console.log(target.$mobx)
     return adm
 }
 


### PR DESCRIPTION
I've been updating to mobx4 and discovered an interesting bug

As we discussed in https://github.com/mobxjs/mobx/issues/1496 maps weren't exported at first, but you kindly re-exported them.  However I've now discovered that extending a map works fine except if you add a @computed decorator to a getter.

That causes a `Cannot set property '<property>' of undefined`, because the $mobx property on maps isn't a "real" instance of ObservableObjectAdministration, and lacks the `values` property (stacktrace below).  I attempted various things to fix that (commented in this PR), but that broke several specs.   

If you can provide some guidance on what you think the best approach would be I'll attempt to do that, but I'm out of ideas for now.


The backtrace of the error:
```
    TypeError: Cannot set property 'mult' of undefined

      286 |     options.name = `${adm.name}.${propName}`
      287 |     options.context = target
    > 288 |     adm.values[propName] = new ComputedValue(options)
      289 |     Object.defineProperty(target, propName, generateComputedPropConfig(propName))
      290 | }
      291 |

      at Object.defineComputedProperty (src/types/observableobject.ts:288:25)
      at Object.propertyCreator (src/api/computed.ts:29:9)
      at initializeInstance (src/utils/decorators2.ts:59:15)
      at MyMap.get (src/utils/decorators2.ts:20:13)
      at Object.<anonymous> (test/base/map.js:717:18)
```


PR checklist:

* [x] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.