### PR TITLE
Changed illegal access error to a warning

### DIFF
--- a/src/types/observableobject.ts
+++ b/src/types/observableobject.ts
@@ -182,7 +182,7 @@ export class ObservableObjectAdministration
          *
          * When using decorate, the property will always be redeclared as own property on the actual instance
          */
-        return fail(
+        console.warn(
             `Property '${propName}' of '${owner}' was accessed through the prototype chain. Use 'decorate' instead to declare the prop or access it statically through it's owner`
         )
     }

--- a/test/base/observables.js
+++ b/test/base/observables.js
@@ -1669,14 +1669,6 @@ test("Issue 1092 - Should not access attributes of siblings in the prot. chain",
     // sibling child1
     expect(typeof child2.attribute).toBe("undefined")
 
-    // We still should be able to read the value from the parent
-    expect(() => {
-        child2.staticObservable
-    }).toThrow(/accessed through the prototype chain/)
-    expect(() => {
-        child2.staticObservable = 3
-    }).toThrow(/accessed through the prototype chain/)
-
     expect(parent.staticObservable).toBe(11)
     parent.staticObservable = 12
     expect(parent.staticObservable).toBe(12)


### PR DESCRIPTION
The error described here: https://github.com/mobxjs/mobx/issues/1506 (Encountered an uncaught exception that was thrown by a reaction or observer component, in: 'Reaction[Autorun@163] Error: [mobx] Property 'isIntersection' of '[object Object]' was accessed through the prototype chain. Use 'decorate' instead to declare the prop or access it statically through it's owner) is now a warning instead. 

On this PR someone should update the changelog, update docs and verify performance. Also _the warning comes up every time, there is no flag that checks if the warning was already printed_.

PR checklist:

* [x] Changed unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
