### PR TITLE
@computed({keepAlive: true}) no long calculates before being accessed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.3.1
+* Fixed [#1534](Fixes https://github.com/mobxjs/mobx/issues/1534):  @computed({keepAlive: true}) no long calculates before being accessed.
+
 # 4.3.0
 
 * Introduced the `entries(observable)` API, by @samjacobclift through [#1536](https://github.com/mobxjs/mobx/pull/1536)

--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -93,7 +93,9 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
     isTracing: TraceMode = TraceMode.NONE
     public scope: Object | undefined
     private equals: IEqualsComparer<any>
-    private requiresReaction
+    private requiresReaction: boolean
+    private keepAlive: boolean
+    private firstGet: boolean = true
 
     /**
      * Create a new computed value based on a function expression.
@@ -103,7 +105,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
      * The `equals` property specifies the comparer function to use to determine if a newly produced
      * value differs from the previous value. Two comparers are provided in the library; `defaultComparer`
      * compares based on identity comparison (===), and `structualComparer` deeply compares the structure.
-     * Structural comparison can be convenient if you always produce an new aggregated object and
+     * Structural comparison can be convenient if you always produce a new aggregated object and
      * don't want to notify observers if it is structurally the same.
      * This is useful for working with vectors, mouse coordinates etc.
      */
@@ -120,11 +122,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
                 : comparer.default)
         this.scope = options.context
         this.requiresReaction = !!options.requiresReaction
-        if (options.keepAlive === true) {
-            // dangerous: never exposed, so this cmputed value should not depend on observables
-            // that live globally, or it will never get disposed! (nor anything attached to it)
-            autorun(() => this.get())
-        }
+        this.keepAlive = !!options.keepAlive
     }
 
     onBecomeStale() {
@@ -140,6 +138,10 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
      * Will evaluate its computation first if needed.
      */
     public get(): T {
+        if (this.keepAlive && this.firstGet) {
+            this.firstGet = false
+            autorun(() => this.get())
+        }
         if (this.isComputing) fail(`Cycle detected in computation ${this.name}: ${this.derivation}`)
         if (globalState.inBatch === 0 && this.observers.length === 0) {
             if (shouldCompute(this)) {

--- a/test/base/observables.js
+++ b/test/base/observables.js
@@ -1888,6 +1888,30 @@ test("keeping computed properties alive works", () => {
         }
     )
 
+    expect(calcs).toBe(0)
+    expect(x.y).toBe(2)
+    expect(calcs).toBe(1)
+    expect(x.y).toBe(2)
+    expect(calcs).toBe(1) // kept alive!
+
+    x.x = 3
+    expect(calcs).toBe(2) // reactively updated
+    expect(x.y).toBe(6)
+})
+
+test("keeping computed properties alive works for objects", () => {
+    let calcs = 0
+    class Foo {
+        @observable x = 1
+        @computed({ keepAlive: true })
+        get y() {
+            calcs++
+            return this.x * 2
+        }
+    }
+    const x = new Foo()
+
+    expect(calcs).toBe(0)
     expect(x.y).toBe(2)
     expect(calcs).toBe(1)
     expect(x.y).toBe(2)


### PR DESCRIPTION
Fixes https://github.com/mobxjs/mobx/issues/1534

PR checklist:

* [x] Added unit tests
* [x] Updated changelog
* [x] Updated docs. [docs not changed, in my opinion, with this change we respect what the docs already say]
* [x] Added typescript typings. [not necessary]
* [x] Verified that there is no significant performance drop (`npm run perf`) 16.697 -> 17.049