### PR TITLE
Remove redundant code

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -58,14 +58,14 @@ export function deprecated(msg: string, thing?: string): boolean {
  */
 export function once(func: Lambda): Lambda {
     let invoked = false
-    return function() {
+    return function () {
         if (invoked) return
         invoked = true
         return (func as any).apply(this, arguments)
     }
 }
 
-export const noop = () => {}
+export const noop = () => { }
 
 export function unique<T>(list: T[]): T[] {
     const res: T[] = []
@@ -85,10 +85,7 @@ export function isPlainObject(value) {
     return proto === Object.prototype || proto === null
 }
 
-const prototypeHasOwnProperty = Object.prototype.hasOwnProperty
-export function hasOwnProperty(object: Object, propName: string) {
-    return prototypeHasOwnProperty.call(object, propName)
-}
+
 
 export function makeNonEnumerable(object: any, propNames: string[]) {
     for (let i = 0; i < propNames.length; i++) {
@@ -132,7 +129,7 @@ export function createInstanceofPredicate<T>(
 ): (x: any) => x is T {
     const propName = "isMobX" + name
     clazz.prototype[propName] = true
-    return function(x) {
+    return function (x) {
         return isObject(x) && x[propName] === true
     } as any
 }


### PR DESCRIPTION

I found that there is a tool function hasOwnProperty under utils/utils.ts that is not used to be redundant and that there is the same function in utils/eq.ts, has, should hasOwnProperty be deleted?

utils/utils.ts
const prototypeHasOwnProperty = Object.prototype.hasOwnProperty
export function hasOwnProperty(object: Object, propName: string) {
    return prototypeHasOwnProperty.call(object, propName)
}
utils/eq.ts
function has(a: any, key: string) {
    return Object.prototype.hasOwnProperty.call(a, key)
}