### PR TITLE
docs: fix minor typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ And finally kudos for all the people that believed in, tried, validated and even
 
 # MobX 4 vs MobX 5
 
-The difference between MobX 4 and MobX 5 is that the later uses Proxies to do property tracking. As a consequence MobX 5 only runs on Proxy supporting browsers, in contrast to MobX 4 that runs on any ES 5 environment.
+The difference between MobX 4 and MobX 5 is that the latter uses Proxies to do property tracking. As a consequence MobX 5 only runs on Proxy supporting browsers, in contrast to MobX 4 that runs on any ES 5 environment.
 
 The most noteable limitations of MobX 4:
   * Observable arrays are not real arrays, so they won't pass the `Array.isArray()` check. The practical consequence is that you often need to `.slice()` the array first (to get a real array shallow copy) before passing to third party libraries.


### PR DESCRIPTION
Changed

> the **later** uses Proxies

to

> the **latter** uses Proxies

I'm not a native speaker, so probably someone should take a look at this — but as far as I can tell this is the correct spelling. 🙃