### PR TITLE
Remove ObservableArray `defineProperty` trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Remove ObservableArray `defineProperty` trap so that $mobx and $treenode can be properly defined in mobx-state-tree
+
 # 5.0.2
 
 * Fixed issue where iterators where not compiled to ES5, breaking the ES5 based builds.

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -106,12 +106,6 @@ const arrayTraps = {
         }
         return false
     },
-    defineProperty(target, key, descriptor) {
-        fail(
-            `Defining properties on observable arrays is not supported, directly assign them instead`
-        )
-        return false
-    },
     preventExtensions(target) {
         fail(`Observable arrays cannot be frozen`)
         return false


### PR DESCRIPTION
@mweststrate this is a follow-up to the discussion @ https://github.com/mobxjs/mobx/pull/1380#issuecomment-393780380

This is necessary to get mobx-state-tree running, it looks like it just didn't make it into the PR. I have mobx-state-tree working and ready when this is merged 👍 

* [NA] Added unit tests
* [x] Updated changelog
* [NA] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [NA] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
