### PR TITLE
Add support for obs. arrays on `keys`. Fixes #1600

### DIFF
--- a/src/api/object-api.ts
+++ b/src/api/object-api.ts
@@ -15,6 +15,7 @@ import {
 } from "../internal"
 
 export function keys<K>(map: ObservableMap<K, any>): ReadonlyArray<K>
+export function keys<T>(ar: IObservableArray<T>): ReadonlyArray<number>
 export function keys<T extends Object>(obj: T): ReadonlyArray<string>
 export function keys(obj: any): any {
     if (isObservableObject(obj)) {
@@ -23,9 +24,12 @@ export function keys(obj: any): any {
     if (isObservableMap(obj)) {
         return Array.from(obj.keys())
     }
+    if (isObservableArray(obj)) {
+        return obj.map((_, index) => index)
+    }
     return fail(
         process.env.NODE_ENV !== "production" &&
-            "'keys()' can only be used on observable objects and maps"
+            "'keys()' can only be used on observable objects, arrays and maps"
     )
 }
 

--- a/test/base/object-api.js
+++ b/test/base/object-api.js
@@ -224,6 +224,22 @@ test("array - set, remove, entries are reactive", () => {
     ])
 })
 
+test("array - set, remove, keys are reactive", () => {
+    const todos = observable.array()
+    const snapshots = []
+
+    reaction(() => keys(todos), keys => snapshots.push(keys))
+
+    set(todos, 0, 2)
+    set(todos, "1", 4)
+    set(todos, 3, 4)
+    set(todos, 1, 3)
+    remove(todos, 2)
+    remove(todos, "0")
+
+    expect(snapshots).toEqual([[0], [0, 1], [0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2], [0, 1]])
+})
+
 test("observe & intercept", () => {
     let events = []
     const todos = observable(


### PR DESCRIPTION
I went ahead and just did it, feel free to refute it if you believe that the change shouldn't be made.
If you're willing to accept it, should I add an entry to the changelog?

PR checklist:
* [x] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [x] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)