### PR TITLE
Docs: Fix typos in devtools.md

### DIFF
--- a/docs/best/devtools.md
+++ b/docs/best/devtools.md
@@ -3,7 +3,7 @@
 <a style="color: white; background:green;padding:5px;margin:5px;border-radius:2px" href="https://egghead.io/courses/manage-complex-state-in-react-apps-with-mobx">egghead.io lesson 2: devtools</a>
 
 
-MobX ships with DevTools that can be used to track the rendering behavior and data depenencies of your app.
+MobX ships with DevTools that can be used to track the rendering behavior and data dependencies of your app.
 
 ![devtools](../images/devtools.gif)
 
@@ -13,7 +13,7 @@ Install:
 
 `npm install mobx-react-devtools`
 
-To enable devtools, import and render the devtools somewhere in your code-base.
+To enable devtools, import and render the devtools somewhere in your codebase.
 
 ```JS
 import DevTools from 'mobx-react-devtools'


### PR DESCRIPTION
Fixes typos in the Devtools documentation page.

`depenencies` => `dependencies` (typo)
`code-base` => `codebase` (widely accepted spelling)