### PR TITLE
Import `decorate` in example in decorators.md

### DIFF
--- a/docs/best/decorators.md
+++ b/docs/best/decorators.md
@@ -41,7 +41,7 @@ class Timer {
 Using the `decorate` utility:
 
 ```javascript
-import { observable, computed, action } from "mobx";
+import { observable, computed, action, decorate } from "mobx";
 
 class Timer {
   start = Date.now();


### PR DESCRIPTION
Fix an oversight in the example of how to use the `decorate` utility.