### PR TITLE
Update typings to allow flow to take async generators - async function*

### DIFF
--- a/src/api/flow.ts
+++ b/src/api/flow.ts
@@ -5,39 +5,36 @@ let generatorId = 0
 
 export type CancellablePromise<T> = Promise<T> & { cancel(): void }
 
-export function flow<R>(generator: () => IterableIterator<any>): () => CancellablePromise<R>
+export interface FlowIterator<T> {
+    next(value?: any): IteratorResult<T> | Promise<IteratorResult<T>>
+    return?(value?: any): IteratorResult<T> | Promise<IteratorResult<T>>
+    throw?(e?: any): IteratorResult<T> | Promise<IteratorResult<T>>
+}
+
+export function flow<R>(generator: () => FlowIterator<any>): () => CancellablePromise<R>
 export function flow<A1>(
-    generator: (a1: A1) => IterableIterator<any>
+    generator: (a1: A1) => FlowIterator<any>
 ): (a1: A1) => CancellablePromise<any> // Ideally we want to have R instead of Any, but cannot specify R without specifying A1 etc... 'any' as result is better then not specifying request args
 export function flow<A1, A2>(
-    generator: (a1: A1, a2: A2) => IterableIterator<any>
+    generator: (a1: A1, a2: A2) => FlowIterator<any>
 ): (a1: A1, a2: A2) => CancellablePromise<any>
 export function flow<A1, A2, A3>(
-    generator: (a1: A1, a2: A2, a3: A3) => IterableIterator<any>
+    generator: (a1: A1, a2: A2, a3: A3) => FlowIterator<any>
 ): (a1: A1, a2: A2, a3: A3) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4>(
-    generator: (a1: A1, a2: A2, a3: A3, a4: A4) => IterableIterator<any>
+    generator: (a1: A1, a2: A2, a3: A3, a4: A4) => FlowIterator<any>
 ): (a1: A1, a2: A2, a3: A3, a4: A4) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4, A5>(
-    generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => IterableIterator<any>
+    generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => FlowIterator<any>
 ): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4, A5, A6>(
-    generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => IterableIterator<any>
+    generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => FlowIterator<any>
 ): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4, A5, A6, A7>(
-    generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => IterableIterator<any>
+    generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => FlowIterator<any>
 ): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7) => CancellablePromise<any>
 export function flow<A1, A2, A3, A4, A5, A6, A7, A8>(
-    generator: (
-        a1: A1,
-        a2: A2,
-        a3: A3,
-        a4: A4,
-        a5: A5,
-        a6: A6,
-        a7: A7,
-        a8: A8
-    ) => IterableIterator<any>
+    generator: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8) => FlowIterator<any>
 ): (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6, a7: A7, a8: A8) => CancellablePromise<any>
 export function flow(generator: Function) {
     if (arguments.length !== 1)


### PR DESCRIPTION
`flow` already supports async generators yielding Promises, just changing typings to allow it.
Also changing from `IterableIterator` to `Iterator`:
`IterableIterator` implements `Iterator` with the addition of `[Symbol.iterator]` property.
Because `mobx` does not use `[Symbol.iterator]` property, it's not necessary to use `IterableIterator`.

PR to support it in Mobx 4 - https://github.com/mobxjs/mobx/pull/1655