### PR TITLE
fix typo in docs summary

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -30,7 +30,7 @@
   * [createAtom](refguide/extending.md)
   * [intercept & observe](refguide/observe.md)
   * [mobxUtils.fromPromise](https://github.com/mobxjs/mobx-utils#frompromise)
-  * [mobxUtis.fromResource](https://github.com/mobxjs/mobx-utils#fromresource)
+  * [mobxUtils.fromResource](https://github.com/mobxjs/mobx-utils#fromresource)
   * [mobxUtils.toStream](https://github.com/mobxjs/mobx-utils#tostream)
   * [mobxUtils.fromStream](https://github.com/mobxjs/mobx-utils#fromstream)
   * [mobxUtils.now](https://github.com/mobxjs/mobx-utils#now)


### PR DESCRIPTION
Thanks for this great library!

A small typo in the docs' side-bar has caught my eye:
![typo](https://user-images.githubusercontent.com/761962/43995706-5d751f50-9db3-11e8-899b-3251c14a9d0e.png)
