### PR TITLE
decorate - compose decorators for a single prop (mobx4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ decorate(Todo, {
 })
 ```
 
+For applying multiple decorators on a single property, you can pass an array of decorators. The decorators application order is from right to left.
+```javascript
+import { decorate, observable } from "mobx"
+import { serializable, primitive } from "serializr"
+import persist from "mobx-persist";
+
+class Todo {
+    id = Math.random();
+    title = "";
+    finished = false;
+}
+decorate(Todo, {
+    title: [serializable(primitive), persist("object"), observable],
+    finished: [serializable(primitive), observable]
+})
+```
+Note: Not all decorators can be composed together, and this functionality is just best-effort. Some decorators affect the instance directly and can 'hide' the effect of other decorators that only change the prototype.
+
 ### Computed values
 
 <i><a style="color: white; background:green;padding:5px;margin:5px;border-radius:2px" href="https://egghead.io/lessons/javascript-derive-computed-values-and-manage-side-effects-with-mobx-reactions">Egghead.io lesson 3: computed values</a></i>

--- a/README.md
+++ b/README.md
@@ -100,24 +100,6 @@ decorate(Todo, {
 })
 ```
 
-For applying multiple decorators on a single property, you can pass an array of decorators. The decorators application order is from right to left.
-```javascript
-import { decorate, observable } from "mobx"
-import { serializable, primitive } from "serializr"
-import persist from "mobx-persist";
-
-class Todo {
-    id = Math.random();
-    title = "";
-    finished = false;
-}
-decorate(Todo, {
-    title: [serializable(primitive), persist("object"), observable],
-    finished: [serializable(primitive), observable]
-})
-```
-Note: Not all decorators can be composed together, and this functionality is just best-effort. Some decorators affect the instance directly and can 'hide' the effect of other decorators that only change the prototype.
-
 ### Computed values
 
 <i><a style="color: white; background:green;padding:5px;margin:5px;border-radius:2px" href="https://egghead.io/lessons/javascript-derive-computed-values-and-manage-side-effects-with-mobx-reactions">Egghead.io lesson 3: computed values</a></i>

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "rollup": "^0.41.6",
     "rollup-plugin-filesize": "^1.3.2",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "serializr": "^1.3.0",
     "size-limit": "^0.2.0",
     "tape": "^4.2.2",
     "ts-jest": "^22.0.0",

--- a/src/api/decorate.ts
+++ b/src/api/decorate.ts
@@ -2,25 +2,43 @@ import { invariant, isPlainObject } from "../utils/utils"
 
 export function decorate<T>(
     clazz: new (...args: any[]) => T,
-    decorators: { [P in keyof T]?: MethodDecorator | PropertyDecorator }
+    decorators: {
+        [P in keyof T]?:
+            | MethodDecorator
+            | PropertyDecorator
+            | Array<MethodDecorator>
+            | Array<PropertyDecorator>
+    }
 ): void
 export function decorate<T>(
     object: T,
-    decorators: { [P in keyof T]?: MethodDecorator | PropertyDecorator }
+    decorators: {
+        [P in keyof T]?:
+            | MethodDecorator
+            | PropertyDecorator
+            | Array<MethodDecorator>
+            | Array<PropertyDecorator>
+    }
 ): T
 export function decorate(thing: any, decorators: any) {
     process.env.NODE_ENV !== "production" &&
         invariant(isPlainObject(decorators), "Decorators should be a key value map")
     const target = typeof thing === "function" ? thing.prototype : thing
     for (let prop in decorators) {
-        const decorator = decorators[prop]
+        let propertyDecorators = decorators[prop]
+        if (!Array.isArray(propertyDecorators)) {
+            propertyDecorators = [propertyDecorators]
+        }
         process.env.NODE_ENV !== "production" &&
             invariant(
-                typeof decorator === "function",
-                `Decorate: expected a decorator function for '${prop}'`
+                propertyDecorators.every(decorator => typeof decorator === "function"),
+                `Decorate: expected a decorator function or array of decorator functions for '${prop}'`
             )
         const descriptor = Object.getOwnPropertyDescriptor(target, prop)
-        const newDescriptor = decorator(target, prop, descriptor)
+        const newDescriptor = propertyDecorators.reduce(
+            (accDescriptor, decorator) => decorator(target, prop, accDescriptor),
+            descriptor
+        )
         if (newDescriptor) Object.defineProperty(target, prop, newDescriptor)
     }
     return thing

--- a/yarn.lock
+++ b/yarn.lock
@@ -4982,6 +4982,10 @@ send@0.15.3:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
+serializr@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/serializr/-/serializr-1.3.0.tgz#6c7f977461d54a24bb1f17a03ed0ce61d239b010"
+
 serve-static@1.12.3:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.3.tgz#9f4ba19e2f3030c547f8af99107838ec38d5b1e2"


### PR DESCRIPTION
PR checklist:

* [x] Added unit tests
* [ ] Updated changelog
* [x] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [x] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)

Support `decorate` new functionality introduced in https://github.com/mobxjs/mobx/pull/1652 in MobX 4

## Changes
- Reduce multiple decorators to a single decorator
- Added a test for multiple decorators (@action + custom) on a function property
- Added a test for multiple decorators (@observable + @serializable) on
  a regular property
- Added a usage example (+ caveat warning) in readme under `decorate` section

Usage Example: 
```javascript
import { decorate, observable } from "mobx"
import { serializable, primitive } from "serializr"
import persist from 'mobx-persist';

class Todo {
    id = Math.random();
    title = "";
    finished = false;
}
decorate(Todo, {
    title: [serializable(primitive), persist('object'), observable],
    finished: observable
})
```
