### PR TITLE
Correct documentation for reaction equals method

### DIFF
--- a/docs/refguide/reaction.md
+++ b/docs/refguide/reaction.md
@@ -23,7 +23,7 @@ Reaction accepts a third argument as an options object with the following option
 
 * `fireImmediately`: Boolean that indicates that the effect function should immediately be triggered after the first run of the data function. `false` by default.
 * `delay`: Number in milliseconds that can be used to debounce the effect function. If zero (the default), no debouncing will happen.
-* `equals`: `comparer.default` by default. If specified, this comparer function will be used to compare the previous and next values produced by the *data* function. The *effect* function will only be invoked if this function returns true. If specified, this will override `compareStructural`.
+* `equals`: `comparer.default` by default. If specified, this comparer function will be used to compare the previous and next values produced by the *data* function. The *effect* function will only be invoked if this function returns false. If specified, this will override `compareStructural`.
 * `name`: String that is used as name for this reaction in for example [`spy`](spy.md) events.
 * `onError`: function that will handle the errors of this reaction, rather then propagating them.
 * `scheduler`: Set a custom scheduler to determine how re-running the autorun function should be scheduled


### PR DESCRIPTION
The current documentation states that if the equals options return `true` the effect will run. This is not the case. The effect runs when equals returns `false`.