### PR TITLE
Prevent rollup from breaking on `process.env.NODE_ENV`

### DIFF
--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -41,7 +41,7 @@ try {
         process.env.NODE_ENV !== "production"
     ) {
         console.warn(
-            "[mobx] you are running a minified build, but 'process.env.NODE_ENV' was not set to 'production' in your bundler. This results in an unnecessarily large and slow bundle"
+            '[mobx] you are running a minified build, but "process.env.NODE_ENV" was not set to "production" in your bundler. This results in an unnecessarily large and slow bundle'
         )
     }
 })()

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -41,7 +41,7 @@ try {
         process.env.NODE_ENV !== "production"
     ) {
         console.warn(
-            '[mobx] you are running a minified build, but "process.env.NODE_ENV" was not set to "production" in your bundler. This results in an unnecessarily large and slow bundle'
+            "[mobx] you are running a minified build, but" + ["process", "env", "NODE_ENV"].join(".") + "was not set to 'production' in your bundler. This results in an unnecessarily large and slow bundle"
         )
     }
 })()

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -41,7 +41,7 @@ try {
         process.env.NODE_ENV !== "production"
     ) {
         console.warn(
-            "[mobx] you are running a minified build, but" + ["process", "env", "NODE_ENV"].join(".") + "was not set to 'production' in your bundler. This results in an unnecessarily large and slow bundle"
+            `[mobx] you are running a minified build, but 'process.env.NODE_ENV' was not set to 'production' in your bundler. This results in an unnecessarily large and slow bundle`
         )
     }
 })()

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -41,6 +41,7 @@ try {
         process.env.NODE_ENV !== "production"
     ) {
         console.warn(
+            // Template literal(backtick) is used for fix issue with rollup-plugin-commonjs https://github.com/rollup/rollup-plugin-commonjs/issues/344
             `[mobx] you are running a minified build, but 'process.env.NODE_ENV' was not set to 'production' in your bundler. This results in an unnecessarily large and slow bundle`
         )
     }


### PR DESCRIPTION
update for prevent error when rollup-plugin-commonjs is used

