### PR TITLE
[test] flow should support returning Promise.reject

### DIFF
--- a/test/base/flow.js
+++ b/test/base/flow.js
@@ -78,7 +78,23 @@ test("it should support throw from async generator", done => {
         )
 })
 
-test("it should support throw from yielded promise generator", done => {
+test("it should support returning Promise.reject() from async generator", done => {
+    mobx
+        .flow(function*() {
+            return Promise.reject(7)
+        })()
+        .then(
+            () => {
+                done.fail("should fail")
+            },
+            e => {
+                expect(e).toBe(7)
+                done()
+            }
+        )
+})
+
+test("it should support promise rejection from yielded promise generator", done => {
     mobx
         .flow(function*() {
             return yield delay(10, 7, true)


### PR DESCRIPTION
this is to accompany https://github.com/mobxjs/mobx/pull/1754 , feel free to ignore if you think it is redundant. For me, since this was not covered in docs, the tests were the place to go looking.

I'd do this all in one PR, but one cannot target multiple branches in one PR...


not quite sure why adding a test should fail seemingly unrelated snapshots but I'll fix it, if you guys intend to merge this