### PR TITLE
Fix typo in docs/refguide/observer-component

### DIFF
--- a/docs/refguide/observer-component.md
+++ b/docs/refguide/observer-component.md
@@ -127,7 +127,7 @@ const Button = inject("colors")(observer(({ colors, label, onClick }) =>
       backgroundColor: colors.background
     }}
     onClick={onClick}
-  >{label}<button>
+  >{label}</button>
 ));
 
 // later..


### PR DESCRIPTION
Hey, great job with mobx! Just started using it today and am really liking it!

Just stumbled across this typo in the docs, a missing `/`.

Should I add this to the changelog as well or is it small enough not to matter?

Cheers!

---

## PR checklist:

* ~[ ] Added unit tests~
* ~[ ] Updated changelog~
* [x] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* ~[ ] Added typescript typings~
* ~[ ] Verified that there is no significant performance drop (`npm run perf`)~

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
