### PR TITLE
Add  "never", "always" and "observed" to enforceActions

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -3,7 +3,7 @@
 export type IObservableMapInitialValues<K, V> = IMapEntries<K, V> | KeyValueMap<V> | IMap<K, V>
 
 export interface IMobxConfigurationOptions {
-    +enforceActions?: boolean | "strict",
+    +enforceActions?: boolean | "strict" | "never" | "always" | "observed",
     computedRequiresReaction?: boolean,
     isolateGlobalState?: boolean,
     disableErrorBoundaries?: boolean,


### PR DESCRIPTION
Add  "never", "always" and "observed" possible values to enforceActions configuration parameter.
It's because true, false and "strict" now deprecated.