### PR TITLE
@computed({keepAlive: true}) should calculate only when accessed

### DIFF
--- a/test/base/observables.js
+++ b/test/base/observables.js
@@ -1877,7 +1877,40 @@ test("can make non-extenible objects observable", () => {
     expect(mobx.isObservableProp(o, "x")).toBeTruthy()
 })
 
-test("keeping computed properties alive works", () => {
+test("keeping computed properties alive does not run before access", () => {
+    let calcs = 0
+    observable(
+        {
+            x: 1,
+            get y() {
+                calcs++
+                return this.x * 2
+            }
+        },
+        {
+            y: mobx.computed({ keepAlive: true })
+        }
+    )
+
+    expect(calcs).toBe(0) // initially there is no calculation done
+})
+
+test("(for objects) keeping computed properties alive does not run before access", () => {
+    let calcs = 0
+    class Foo {
+        @observable x = 1
+        @computed({ keepAlive: true })
+        get y() {
+            calcs++
+            return this.x * 2
+        }
+    }
+    new Foo()
+
+    expect(calcs).toBe(0) // initially there is no calculation done
+})
+
+test("keeping computed properties alive runs on first access", () => {
     let calcs = 0
     const x = observable(
         {
@@ -1892,18 +1925,11 @@ test("keeping computed properties alive works", () => {
         }
     )
 
-    expect(calcs).toBe(0)
-    expect(x.y).toBe(2)
+    expect(x.y).toBe(2) // perform calculation on access
     expect(calcs).toBe(1)
-    expect(x.y).toBe(2)
-    expect(calcs).toBe(1) // kept alive!
-
-    x.x = 3
-    expect(calcs).toBe(2) // reactively updated
-    expect(x.y).toBe(6)
 })
 
-test("keeping computed properties alive works for objects", () => {
+test("(for objects) keeping computed properties alive runs on first access", () => {
     let calcs = 0
     class Foo {
         @observable x = 1
@@ -1915,15 +1941,123 @@ test("keeping computed properties alive works for objects", () => {
     }
     const x = new Foo()
 
-    expect(calcs).toBe(0)
-    expect(x.y).toBe(2)
+    expect(x.y).toBe(2) // perform calculation on access
     expect(calcs).toBe(1)
-    expect(x.y).toBe(2)
-    expect(calcs).toBe(1) // kept alive!
+})
 
-    x.x = 3
-    expect(calcs).toBe(2) // reactively updated
+test("keeping computed properties alive caches values on subsequent accesses", () => {
+    let calcs = 0
+    const x = observable(
+        {
+            x: 1,
+            get y() {
+                calcs++
+                return this.x * 2
+            }
+        },
+        {
+            y: mobx.computed({ keepAlive: true })
+        }
+    )
+
+    expect(x.y).toBe(2) // first access: do calculation
+    expect(x.y).toBe(2) // second access: use cached value, no calculation
+    expect(calcs).toBe(1) // only one calculation: cached!
+})
+
+test("(for objects) keeping computed properties alive caches values on subsequent accesses", () => {
+    let calcs = 0
+    class Foo {
+        @observable x = 1
+        @computed({ keepAlive: true })
+        get y() {
+            calcs++
+            return this.x * 2
+        }
+    }
+    const x = new Foo()
+
+    expect(x.y).toBe(2) // first access: do calculation
+    expect(x.y).toBe(2) // second access: use cached value, no calculation
+    expect(calcs).toBe(1) // only one calculation: cached!
+})
+
+test("keeping computed properties alive does not recalculate when dirty", () => {
+    let calcs = 0
+    const x = observable(
+        {
+            x: 1,
+            get y() {
+                calcs++
+                return this.x * 2
+            }
+        },
+        {
+            y: mobx.computed({ keepAlive: true })
+        }
+    )
+
+    expect(x.y).toBe(2) // first access: do calculation
+    x.x = 3 // mark as dirty: no calculation
+    expect(calcs).toBe(1)
     expect(x.y).toBe(6)
+})
+
+test("(for objects) keeping computed properties alive does not recalculate when dirty", () => {
+    let calcs = 0
+    class Foo {
+        @observable x = 1
+        @computed({ keepAlive: true })
+        get y() {
+            calcs++
+            return this.x * 2
+        }
+    }
+    const x = new Foo()
+
+    expect(x.y).toBe(2) // first access: do calculation
+    x.x = 3 // mark as dirty: no calculation
+    expect(calcs).toBe(1)
+    expect(x.y).toBe(6)
+})
+
+test("keeping computed properties alive recalculates when accessing it dirty", () => {
+    let calcs = 0
+    const x = observable(
+        {
+            x: 1,
+            get y() {
+                calcs++
+                return this.x * 2
+            }
+        },
+        {
+            y: mobx.computed({ keepAlive: true })
+        }
+    )
+
+    expect(x.y).toBe(2) // first access: do calculation
+    x.x = 3 // mark as dirty: no calculation
+    expect(x.y).toBe(6) // second access: do calculation because it is dirty
+    expect(calcs).toBe(2)
+})
+
+test("(for objects) keeping computed properties alive recalculates when accessing it dirty", () => {
+    let calcs = 0
+    class Foo {
+        @observable x = 1
+        @computed({ keepAlive: true })
+        get y() {
+            calcs++
+            return this.x * 2
+        }
+    }
+    const x = new Foo()
+
+    expect(x.y).toBe(2) // first access: do calculation
+    x.x = 3 // mark as dirty: no calculation
+    expect(x.y).toBe(6) // second access: do calculation because it is dirty
+    expect(calcs).toBe(2)
 })
 
 test("tuples", () => {


### PR DESCRIPTION
First, I split the existing tests trying to keep 1 test <=> 1 requirement.
Then I added the tests that check that no calculations are performed before accessing the computed.
We need somebody to implement the solution.

References issue #1534

* [x] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)
