### PR TITLE
support setting arbitrary array properties

### DIFF
--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -104,6 +104,10 @@ const arrayTraps = {
             arrayExtensions.set.call(target, parseInt(name), value)
             return true
         }
+        if (target.hasOwnProperty(name)) {
+            target[name] = value
+            return true
+        }
         return false
     },
     preventExtensions(target) {
@@ -166,15 +170,17 @@ class ObservableArrayAdministration
         fireImmediately = false
     ): Lambda {
         if (fireImmediately) {
-            listener(<IArraySplice<any>>{
-                object: this.proxy as any,
-                type: "splice",
-                index: 0,
-                added: this.values.slice(),
-                addedCount: this.values.length,
-                removed: [],
-                removedCount: 0
-            })
+            listener(
+                <IArraySplice<any>>{
+                    object: this.proxy as any,
+                    type: "splice",
+                    index: 0,
+                    added: this.values.slice(),
+                    addedCount: this.values.length,
+                    removed: [],
+                    removedCount: 0
+                }
+            )
         }
         return registerListener(this, listener)
     }
@@ -424,9 +430,9 @@ const arrayExtensions = {
                 return adm.dehanceValue(adm.values[index])
             }
             console.warn(
-                `[mobx.array] Attempt to read an array index (${index}) that is out of bounds (${
-                    adm.values.length
-                }). Please check length first. Out of bound indices will not be tracked by MobX`
+                `[mobx.array] Attempt to read an array index (${index}) that is out of bounds (${adm
+                    .values
+                    .length}). Please check length first. Out of bound indices will not be tracked by MobX`
             )
         }
         return undefined

--- a/test/base/array.js
+++ b/test/base/array.js
@@ -474,6 +474,22 @@ test("can define properties on arrays", () => {
     expect("" + ar).toBe("hoi")
 })
 
+test("can define settable properties on arrays", () => {
+    const ar = observable.array([1, 2])
+    let value = true
+    Object.defineProperty(ar, "isTest", {
+        get() {
+            return value
+        },
+        set(v) {
+            value = v
+        }
+    })
+    expect(ar.isTest).toBe(true)
+    ar.isTest = false
+    expect(ar.isTest).toBe(false)
+})
+
 test("concats correctly #1667", () => {
     const x = observable({ data: [] })
 


### PR DESCRIPTION
Since a proxy should behave like the original array it should also support setting properties just like a array will.

Without this the below code raises a `proxy: trap returned falsish for property "foo"`
```js
const ary = observable.array([])
Object.defineProperty(ary, 'foo', {
  set() { 
    // do something wonderful
  }
})
ary.foo = 'bar'
```

I agree it's pretty ugly to define arbitrary properties on built-in objects, but it works fine for "real" arrays so it seems like it should also be supported on Proxys.

Note that setting without a defined property such as the below example will still throw the exception but won't with a real array.   If we want to support that I can remove the 'hasOwnProperty` check and just set the property, then return true.
```js
const ary = observable.array([])
ary.foo = 'bar' // throws proxy: trap returned falsish for property "foo"
```

----

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [x] Added unit tests
~* [ ] Updated changelog~ (I don't think this should be publicized)
~* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated~
* [x] Added typescript typings (not needed)
* [x] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.