### PR TITLE
idea: new reaction with delayed dependency check

### DIFF
--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -1,4 +1,4 @@
-import { IDerivation, IObservable, Reaction, fail } from "../internal"
+import { IDerivation, IObservable, IScheduledReaction, fail } from "../internal"
 
 /**
  * These values will persist if global state is reset
@@ -59,7 +59,7 @@ export class MobXGlobals {
     /**
      * List of scheduled, not yet executed, reactions.
      */
-    pendingReactions: Reaction[] = []
+    pendingReactions: IScheduledReaction[] = []
 
     /**
      * Are we currently processing reactions?

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -51,6 +51,7 @@ export {
     IObservable,
     IDepTreeNode,
     Reaction,
+    ReactionEx,
     IReactionPublic,
     IReactionDisposer,
     IDerivation,


### PR DESCRIPTION
see issue #1805

The problem of unnecessary evaluations is early shouldCompute call. While reaction can be delayed via scheduler or onInvalidate - shouldCompute is always called immediatelly. But what if we delay this call?

New reaction class can be used in React observers this way:

```js
this[mobxReaction] = new ReactionEx(`${initialName}#${rootNodeID}.render()`, () => this.setState({}));

// ...

shouldComponentUpdate: function(nextProps, nextState) {
    return !shallowEqual(this.state, nextState) 
        || !shallowEqual(this.props, nextProps)
        || this[mobxReaction].shouldCompute()
}
```