### PR TITLE
replace function does not exists for ObservableMap

### DIFF
--- a/docs/refguide/map.md
+++ b/docs/refguide/map.md
@@ -27,7 +27,6 @@ The following functions are not in the ES6 spec but are available in MobX:
 * `intercept(interceptor)`. Registers an interceptor that will be triggered before any changes are applied to the map. See [observe & intercept](observe.md).
 * `observe(listener, fireImmediately?)`. Registers a listener that fires upon each change in this map, similarly to the events that are emitted for [Object.observe](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/observe). See [observe & intercept](observe.md) for more details.
 * `merge(values)`. Copies all entries from the provided object into this map. `values` can be a plain object, array of entries or string-keyed ES6 Map.
-* `replace(values)`. Replaces the entire contents of this map with the provided values. Short hand for `.clear().merge(values)`
 
 ## `observable.map(values, { deep: false })`
 


### PR DESCRIPTION
replace function does not exists for ObservableMap

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
