### PR TITLE
fix: earlier onBecome(Un)Observed disposer will not dispose later listener (fix #1537)

### DIFF
--- a/src/api/become-observed.ts
+++ b/src/api/become-observed.ts
@@ -38,12 +38,14 @@ function interceptHook(hook: "onBecomeObserved" | "onBecomeUnobserved", thing, a
     const atom: IObservable =
         typeof arg2 === "string" ? getAtom(thing, arg2) : (getAtom(thing) as any)
     const cb = typeof arg2 === "string" ? arg3 : arg2
-    const listenersKey = `${hook}Listeners`
+    const listenersKey = `${hook}Listeners` as
+        | "onBecomeObservedListeners"
+        | "onBecomeUnobservedListeners"
 
-    if (!atom[listenersKey]) {
-        atom[listenersKey] = new Set<Lambda>([cb])
+    if (atom[listenersKey]) {
+        atom[listenersKey]!.add(cb)
     } else {
-        ;(atom[listenersKey] as Set<Lambda>).add(cb)
+        atom[listenersKey] = new Set<Lambda>([cb])
     }
 
     const orig = atom[hook]
@@ -51,7 +53,7 @@ function interceptHook(hook: "onBecomeObserved" | "onBecomeUnobserved", thing, a
         return fail(process.env.NODE_ENV !== "production" && "Not an atom that can be (un)observed")
 
     return function() {
-        const hookListeners = atom[listenersKey] as Set<Lambda> | undefined
+        const hookListeners = atom[listenersKey]
         if (hookListeners) {
             hookListeners.delete(cb)
             if (hookListeners.size === 0) {

--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -124,9 +124,20 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
         propagateMaybeChanged(this)
     }
 
-    onBecomeUnobserved() {}
+    public onBecomeObservedListeners: Set<Lambda> | undefined
+    public onBecomeUnobservedListeners: Set<Lambda> | undefined
 
-    onBecomeObserved() {}
+    public onBecomeObserved() {
+        if (this.onBecomeObservedListeners) {
+            this.onBecomeObservedListeners.forEach(listener => listener())
+        }
+    }
+
+    public onBecomeUnobserved() {
+        if (this.onBecomeUnobservedListeners) {
+            this.onBecomeUnobservedListeners.forEach(listener => listener())
+        }
+    }
 
     /**
      * Returns the current value of this computed value.

--- a/src/core/observable.ts
+++ b/src/core/observable.ts
@@ -1,4 +1,5 @@
 import {
+    Lambda,
     ComputedValue,
     IDependencyTree,
     IDerivation,
@@ -31,6 +32,9 @@ export interface IObservable extends IDepTreeNode {
 
     onBecomeUnobserved(): void
     onBecomeObserved(): void
+
+    onBecomeUnobservedListeners: Set<Lambda> | undefined
+    onBecomeObservedListeners: Set<Lambda> | undefined
 }
 
 export function hasObservers(observable: IObservable): boolean {

--- a/test/base/extras.js
+++ b/test/base/extras.js
@@ -399,6 +399,59 @@ test("onBecome(Un)Observed - less simple", () => {
     expect(events.length).toBe(0)
 })
 
+test("onBecomeObserved correctly disposes second listener #1537", () => {
+    const x = mobx.observable.box(3)
+    const events = []
+    const d1 = mobx.onBecomeObserved(x, "a", () => {
+        events.push("a observed")
+    })
+    const d2 = mobx.onBecomeObserved(x, "b", () => {
+        events.push("b observed")
+    })
+    d1()
+    mobx.reaction(() => x.get(), () => {})
+    expect(events.length).toBe(1)
+    expect(events).toEqual(["b observed"])
+})
+
+test("onBecomeObserved correctly disposes second listener #1537", () => {
+    const x = mobx.observable.box(3)
+    const events = []
+    const d1 = mobx.onBecomeObserved(x, "a", () => {
+        events.push("a observed")
+    })
+    const d2 = mobx.onBecomeObserved(x, "b", () => {
+        events.push("b observed")
+    })
+    d1()
+    const d3 = mobx.reaction(() => x.get(), () => {})
+    d3()
+    expect(events.length).toBe(1)
+    expect(events).toEqual(["b observed"])
+    d2()
+    const d4 = mobx.reaction(() => x.get(), () => {})
+    expect(events).toEqual(["b observed"])
+})
+
+test("onBecomeUnobserved correctly disposes second listener #1537", () => {
+    const x = mobx.observable.box(3)
+    const events = []
+    const d1 = mobx.onBecomeUnobserved(x, "a", () => {
+        events.push("a unobserved")
+    })
+    const d2 = mobx.onBecomeUnobserved(x, "b", () => {
+        events.push("b unobserved")
+    })
+    d1()
+    const d3 = mobx.reaction(() => x.get(), () => {})
+    d3()
+    expect(events.length).toBe(1)
+    expect(events).toEqual(["b unobserved"])
+    d2()
+    const d4 = mobx.reaction(() => x.get(), () => {})
+    expect(events).toEqual(["b unobserved"])
+})
+
 test("deepEquals should yield correct results for complex objects #1118 - 1", () => {
     const d2016jan1 = new Date("2016-01-01")
     const d2016jan1_2 = new Date("2016-01-01")


### PR DESCRIPTION
Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [x] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)

This PR is to fix #1537, in `become-observed.ts`, there is a shared object to store the `onBecomeObserved` and `onBecomeUnobserved` for each Atom instance by name. Each Set of the hook of an atom will be initialized only when `onBecomeUnobserved` or `onBecomeUnobserved` invoked. So I think there's no harm to the performance.

Looking forward to your opinion 😆

Special thanks to #1771
