### PR TITLE
support cjs and esm version for browser builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "lib/mobx.js",
   "umd:main": "lib/mobx.umd.js",
   "module": "lib/mobx.module.js",
+  "browser": {
+    "./lib/mobx.js": "./lib/mobx.js",
+    "./lib/mobx.module.js": "./lib/mobx.module.js"
+  },
   "unpkg": "lib/mobx.umd.min.js",
   "jsnext:main": "lib/mobx.module.js",
   "react-native": "lib/mobx.module.js",


### PR DESCRIPTION
I've been running into issues with basic usage of mobx, where in a complete esm environment, a `import * as mobx from 'mobx'` webpack would still require the cjs version of mobx, though, a `module` entry is there and also defined within the `package.json`. This caused a lot of headache, as there was no reason to do so.

However, due to some weird behaviour, webpack 4 refuses to load the module version of mobx, until I've added the `browser` field to `package.json`. 

Everything should still work correctly within a commonjs environment, as a require call to mobx within the browser still requires the cjs version. Thanks a lot to https://github.com/stereobooster/main-module-browser-test for the idea behind this.

This works reliable for me, so it would be great to get this merged in!
