### PR TITLE
fix: add a configure env variable to mute minification warning (fix #1548)

### DIFF
--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -38,7 +38,8 @@ try {
     function testCodeMinification() {}
     if (
         testCodeMinification.name !== "testCodeMinification" &&
-        process.env.NODE_ENV !== "production"
+        process.env.NODE_ENV !== "production" &&
+        process.env.IGNORE_MOBX_MINIFY_WARNING !== "true"
     ) {
         console.warn(
             // Template literal(backtick) is used for fix issue with rollup-plugin-commonjs https://github.com/rollup/rollup-plugin-commonjs/issues/344


### PR DESCRIPTION
Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)

To fix #1548, I add a simple env variable to force mute the warning in this PR. I wonder is it necessary to add it's usage to docs (as it may be rarely used) 😆