### PR TITLE
Fix array dehance (#1839)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.7.1 / 4.7.1
+* Fixed [#1839](https://github.com/mobxjs/mobx/issues/1839), ObservableArrayAdministration.dehanceValues does not dehance last value.
+
 # 5.7.0 / 4.7.0
 
 * Upgraded typings to TypeScript 3

--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -154,7 +154,7 @@ class ObservableArrayAdministration
     }
 
     dehanceValues(values: any[]): any[] {
-        if (this.dehancer !== undefined && this.values.length > 0)
+        if (this.dehancer !== undefined && values.length > 0)
             return values.map(this.dehancer) as any
         return values
     }

--- a/test/base/array.js
+++ b/test/base/array.js
@@ -1,6 +1,7 @@
 "use strict"
+
 var mobx = require("../../src/mobx.ts")
-const { observable, $mobx, when } = mobx
+const { observable, $mobx, when, _getAdministration } = mobx
 var iterall = require("iterall")
 
 function buffer() {
@@ -491,4 +492,20 @@ test("concats correctly #1667", () => {
     expect(Array.isArray(x.data)).toBe(true)
     expect(x.data[0]).toBe(first)
     expect(x.data.length).toBe(11000)
+})
+
+test("dehances last value on shift/pop", () => {
+    const x1 = observable([3, 5])
+    _getAdministration(x1).dehancer = value => {
+        return value * 2
+    }
+    expect(x1.shift()).toBe(6)
+    expect(x1.shift()).toBe(10)
+
+    const x2 = observable([3, 5])
+    _getAdministration(x2).dehancer = value => {
+        return value * 2
+    }
+    expect(x2.pop()).toBe(10)
+    expect(x2.pop()).toBe(6)
 })


### PR DESCRIPTION
This PR fixes #[1839](https://github.com/mobxjs/mobx/issues/1839).
There is also a [PR](https://github.com/mobxjs/mobx/pull/1840) for mobx@4.

* [x] Added unit tests
* [x] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

No need for docs, typings, performance.
