### PR TITLE
gh-pages: Fix an error in example code

### DIFF
--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -134,7 +134,7 @@ Example:
 
 ```javascript
 import {observable, computed} from "mobx";
-var name = observable("John");
+var name = observable.box("John");
 
 var upperCaseName = computed(() =>
 	name.get().toUpperCase()


### PR DESCRIPTION
The code was broken, it obviously needed a `.box`;
