### PR TITLE
An overload for flow in case of passing generator without arguments

### DIFF
--- a/src/api/flow.ts
+++ b/src/api/flow.ts
@@ -10,6 +10,9 @@ export interface FlowIterator<T> {
     throw?(e?: any): IteratorResult<T> | Promise<IteratorResult<T>>
 }
 
+export function flow<T>(
+    generator: () => FlowIterator<any>
+): () => CancellablePromise<T>
 export function flow<T, U extends any[]>(
     generator: (...args: U) => FlowIterator<any>
 ): (...args: U) => CancellablePromise<T>


### PR DESCRIPTION
Added a missing overflow for passing a generator without arguments so you can do:

`flow<OutputType>(function*(){...})`

instead of:

`flow<OutputType, undefined[]>(function*(){...})`