### PR TITLE
Polyfill symbols in set, map and array alike

### DIFF
--- a/src/types/observablearray.ts
+++ b/src/types/observablearray.ts
@@ -28,7 +28,8 @@ import {
     invariant,
     makeNonEnumerable,
     createInstanceofPredicate,
-    isObject
+    isObject,
+    toStringTagSymbol
 } from "../internal"
 
 const MAX_SPLICE_SIZE = 10000 // See e.g. https://github.com/mobxjs/mobx/issues/859
@@ -611,13 +612,7 @@ Object.defineProperty(ObservableArray.prototype, "length", {
     }
 })
 
-if (typeof Symbol !== "undefined" && Symbol.toStringTag) {
-    addHiddenProp(
-        ObservableArray.prototype,
-        typeof Symbol !== "undefined" ? Symbol.toStringTag : ("@@toStringTag" as any),
-        "Array"
-    )
-}
+addHiddenProp(ObservableArray.prototype, toStringTagSymbol(), "Array")
 
 // Internet Explorer on desktop doesn't support this.....
 // So, let's don't do this to avoid different semantics

--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -26,6 +26,7 @@ import {
     spyReportEnd,
     globalState,
     iteratorSymbol,
+    toStringTagSymbol,
     makeIterable,
     untracked,
     registerListener,
@@ -81,17 +82,14 @@ export class ObservableMap<K = any, V = any>
     $mobx = ObservableMapMarker
     private _data: Map<K, ObservableValue<V>>
     private _hasMap: Map<K, ObservableValue<boolean>> // hasMap, not hashMap >-).
-    private _keys: IObservableArray<K> = <any>new ObservableArray(
-        undefined,
-        referenceEnhancer,
-        `${this.name}.keys()`,
-        true
+    private _keys: IObservableArray<K> = <any>(
+        new ObservableArray(undefined, referenceEnhancer, `${this.name}.keys()`, true)
     )
     interceptors
     changeListeners
     dehancer: any;
-    [Symbol.iterator];
-    [Symbol.toStringTag]
+    [iteratorSymbol()];
+    [toStringTagSymbol()]
 
     constructor(
         initialData?: IObservableMapInitialValues<K, V>,
@@ -391,11 +389,7 @@ declareIterator(ObservableMap.prototype, function() {
     return this.entries()
 })
 
-addHiddenFinalProp(
-    ObservableMap.prototype,
-    typeof Symbol !== "undefined" ? Symbol.toStringTag : ("@@toStringTag" as any),
-    "Map"
-)
+addHiddenFinalProp(ObservableMap.prototype, toStringTagSymbol(), "Map")
 
 /* 'var' fixes small-build issue */
 export var isObservableMap = createInstanceofPredicate("ObservableMap", ObservableMap) as (

--- a/src/types/observableset.ts
+++ b/src/types/observableset.ts
@@ -23,7 +23,9 @@ import {
     untracked,
     makeIterable,
     transaction,
-    isES6Set
+    isES6Set,
+    iteratorSymbol,
+    toStringTagSymbol
 } from "../internal"
 
 const ObservableSetMarker = {}
@@ -256,11 +258,11 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
         return this.name + "[ " + Array.from(this).join(", ") + " ]"
     }
 
-    [Symbol.iterator]() {
+    [iteratorSymbol()]() {
         return this.values()
     }
 
-    [Symbol.toStringTag]: "Set" = "Set"
+    [toStringTagSymbol()]: "Set" = "Set"
 }
 
 export const isObservableSet = createInstanceofPredicate("ObservableSet", ObservableSet) as (

--- a/src/utils/iterable.ts
+++ b/src/utils/iterable.ts
@@ -19,6 +19,10 @@ export function makeIterable<T>(iterator: Iterator<T>): IterableIterator<T> {
     return iterator as any
 }
 
+export function toStringTagSymbol() {
+    return (typeof Symbol === "function" && Symbol.toStringTag) || "@@toStringTag"
+}
+
 function self() {
     return this
 }


### PR DESCRIPTION
Fixes #1878, an omission in Set backport. Reuses existing utils. Should restore IE11 compatibility.

* [x] <del>Added unit tests</del> Can't, tests use modern Node which has an okay Symbol.
* [x] <del>Updated changelog</del> Not creating a new version myself. Or should I write log anyway?
* [x] Updated docs (either in the description of this PR as markdown <- this, <del>or as separate PR on the `gh-pages` branch. Please refer to this PR</del>). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [x] <del>Added typescript typings</del> Regression fix, no API change.
* [x] Verified that there is no significant performance drop (<del>`npm run perf`</del> `npm run test:performance`) 