### PR TITLE
CRA 2.1 came with decorator support OOTB.

### DIFF
--- a/docs/best/decorators.md
+++ b/docs/best/decorators.md
@@ -161,7 +161,7 @@ Note that the `legacy` mode is important (as is putting the decorators proposal 
 
 ## Decorator syntax and Create React App (v2)
 
-* decorators are not supported out of the box in `create-react-app@2.*`. To fix this, you can either use the `decorate` utility, eject, or use the [customize-cra](https://github.com/arackaf/customize-cra) package.
+* Decorators are only supported out of the box in `create-react-app@^2.1.1`. In older versions fix this by using either the `decorate` utility, eject, or the [customize-cra](https://github.com/arackaf/customize-cra) package.
 
 ---
 

--- a/docs/best/decorators.md
+++ b/docs/best/decorators.md
@@ -161,7 +161,7 @@ Note that the `legacy` mode is important (as is putting the decorators proposal 
 
 ## Decorator syntax and Create React App (v2)
 
-* Decorators are only supported out of the box when using TypeScript in `create-react-app@^2.1.1`. In older versions use either the `decorate` utility, eject, or the [customize-cra](https://github.com/arackaf/customize-cra) package.
+* Decorators are only supported out of the box when using TypeScript in `create-react-app@^2.1.1`. In older versions or when using vanilla JavaScript use either the `decorate` utility, eject, or the [customize-cra](https://github.com/arackaf/customize-cra) package.
 
 ---
 

--- a/docs/best/decorators.md
+++ b/docs/best/decorators.md
@@ -161,7 +161,7 @@ Note that the `legacy` mode is important (as is putting the decorators proposal 
 
 ## Decorator syntax and Create React App (v2)
 
-* Decorators are only supported out of the box in `create-react-app@^2.1.1`. In older versions fix this by using either the `decorate` utility, eject, or the [customize-cra](https://github.com/arackaf/customize-cra) package.
+* Decorators are only supported out of the box when using TypeScript in `create-react-app@^2.1.1`. In older versions use either the `decorate` utility, eject, or the [customize-cra](https://github.com/arackaf/customize-cra) package.
 
 ---
 


### PR DESCRIPTION
Was kinda broken till 2.1.1.

Reference:

https://stackoverflow.com/questions/53096300/how-can-i-enable-decorators-support-when-running-tests-with-cra-2-1

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [x] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
