### PR TITLE
fix(trace): log trace info when ComputedValue real staled

### DIFF
--- a/src/core/observable.ts
+++ b/src/core/observable.ts
@@ -202,9 +202,12 @@ export function propagateChangeConfirmed(observable: IObservable) {
     observable.lowestObserverState = IDerivationState.STALE
 
     observable.observers.forEach(d => {
-        if (d.dependenciesState === IDerivationState.POSSIBLY_STALE)
+        if (d.dependenciesState === IDerivationState.POSSIBLY_STALE) {
             d.dependenciesState = IDerivationState.STALE
-        else if (
+            if (d.isTracing !== TraceMode.NONE) {
+                logTraceInfo(d, observable)
+            }
+        } else if (
             d.dependenciesState === IDerivationState.UP_TO_DATE // this happens during computing of `d`, just keep lowestObserverState up to date.
         )
             observable.lowestObserverState = IDerivationState.UP_TO_DATE
@@ -221,9 +224,6 @@ export function propagateMaybeChanged(observable: IObservable) {
     observable.observers.forEach(d => {
         if (d.dependenciesState === IDerivationState.UP_TO_DATE) {
             d.dependenciesState = IDerivationState.POSSIBLY_STALE
-            if (d.isTracing !== TraceMode.NONE) {
-                logTraceInfo(d, observable)
-            }
             d.onBecomeStale()
         }
     })


### PR DESCRIPTION
Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)

trigger `logTraceInfo` only when `ComputedValue` really changed. And makes #1803 logs as excepted.
