### PR TITLE
Make ObservableSet backport compatible with IE11

### DIFF
--- a/src/api/object-api.ts
+++ b/src/api/object-api.ts
@@ -12,6 +12,7 @@ import {
     endBatch,
     defineObservableProperty,
     invariant,
+    iteratorToArray,
     getAdministration,
     ObservableObjectAdministration
 } from "../internal"
@@ -28,7 +29,7 @@ export function keys(obj: any): any {
         return (obj as any)._keys.slice()
     }
     if (isObservableSet(obj)) {
-        return Array.from(obj.keys())
+        return iteratorToArray(obj.keys())
     }
     if (isObservableArray(obj)) {
         return obj.map((_, index) => index)
@@ -51,7 +52,7 @@ export function values(obj: any): string[] {
         return keys(obj).map(key => obj.get(key))
     }
     if (isObservableSet(obj)) {
-        return Array.from(obj.values())
+        return iteratorToArray(obj.values())
     }
     if (isObservableArray(obj)) {
         return obj.slice()
@@ -74,7 +75,7 @@ export function entries(obj: any): any {
         return keys(obj).map(key => [key, obj.get(key)])
     }
     if (isObservableSet(obj)) {
-        return Array.from(obj.entries())
+        return iteratorToArray(obj.entries())
     }
     if (isObservableArray(obj)) {
         return obj.map((key, index) => [index, key])

--- a/src/types/observableset.ts
+++ b/src/types/observableset.ts
@@ -26,7 +26,8 @@ import {
     isES6Set,
     toStringTagSymbol,
     declareIterator,
-    addHiddenFinalProp
+    addHiddenFinalProp,
+    iteratorToArray
 } from "../internal"
 
 const ObservableSetMarker = {}
@@ -192,8 +193,8 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
 
     entries() {
         let nextIndex = 0
-        const keys = Array.from(this.keys())
-        const values = Array.from(this.values())
+        const keys = iteratorToArray(this.keys())
+        const values = iteratorToArray(this.values())
         return makeIterable<[T, T]>({
             next() {
                 const index = nextIndex
@@ -213,7 +214,15 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
         this._atom.reportObserved()
         const self = this
         let nextIndex = 0
-        const observableValues = Array.from(this._data.values())
+        let observableValues: any[]
+
+        if (this._data.values !== undefined) {
+            observableValues = iteratorToArray(this._data.values())
+        } else {
+            // There is no values function in IE11
+            observableValues = []
+            this._data.forEach(e => observableValues.push(e))
+        }
         return makeIterable<T>({
             next() {
                 return nextIndex < observableValues.length
@@ -262,7 +271,7 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
     }
 
     toString(): string {
-        return this.name + "[ " + Array.from(this).join(", ") + " ]"
+        return this.name + "[ " + iteratorToArray(this.keys()).join(", ") + " ]"
     }
 }
 

--- a/src/utils/eq.ts
+++ b/src/utils/eq.ts
@@ -134,7 +134,7 @@ function deepEq(a: any, b: any, aStack?: any[], bStack?: any[]) {
 function unwrap(a: any) {
     if (isObservableArray(a)) return a.peek()
     if (isES6Map(a) || isObservableMap(a)) return iteratorToArray(a.entries())
-    if (isES6Set(a) || isObservableSet(a)) return Array.from(a.entries())
+    if (isES6Set(a) || isObservableSet(a)) return iteratorToArray(a.entries())
     return a
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -173,7 +173,7 @@ export function getMapLikeKeys(map: any): any {
 }
 
 // use Array.from in Mobx 5
-export function iteratorToArray<T>(it: Iterator<T>): ReadonlyArray<T> {
+export function iteratorToArray<T>(it: Iterator<T>): Array<T> {
     const res: T[] = []
     while (true) {
         const r: any = it.next()


### PR DESCRIPTION
The original implementation and the backport made use of Array.from.
Mobx4 appears to avoid the usage of Array.from by instead using its
internal iteratorToArray function. All Array.from calls have been
replaced by iteratorToArray calls.
Also, IE11 lacks the "values" function on Sets,
and even ObservableSet.toString ended up depending on it.
A workaround has been implemented that allows the
ObservableSet.values to work even in IE11.