### PR TITLE
fix flow types

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -311,7 +311,7 @@ declare export function reaction<T>(
     expression: (r: IReactionPublic) => T,
     effect: (arg: T, r: IReactionPublic) => void,
     opts?: IReactionOptions
-): () => mixed
+): () => void
 
 export interface IWhenOptions {
     name?: string,
@@ -323,7 +323,7 @@ declare export function when(
     cond: () => boolean,
     effect: Lambda,
     options?: IWhenOptions
-): () => mixed
+): () => void
 declare export function when(cond: () => boolean, options?: IWhenOptions): Promise<any>
 
 declare export function computed<T>(


### PR DESCRIPTION
This improves flow types. `when` and `reaction` return a disposer function. The disposer function does not return anything: `() => void` (as seen eg [here](https://github.com/mobxjs/mobx/blob/6df2f5afe9d8b857fb13fa8d6e789a3c3eb523d1/src/core/reaction.ts#L176))

the previous definition was `() => mixed` which is better than `any` (that was there before) but it is not correct