### PR TITLE
Fix toStringTag return type for observable Maps and Sets

### DIFF
--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -91,7 +91,7 @@ export class ObservableMap<K = any, V = any>
     // eslint-disable-next-line
     [Symbol.iterator]: () => IterableIterator<[K, V]>; // only used for typings!
     // eslint-disable-next-line
-    [Symbol.toStringTag]: string // only used for typings!
+    [Symbol.toStringTag]: 'Map' // only used for typings!
 
     constructor(
         initialData?: IObservableMapInitialValues<K, V>,

--- a/src/types/observableset.ts
+++ b/src/types/observableset.ts
@@ -69,7 +69,7 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
     // eslint-disable-next-line
     [Symbol.iterator]: () => IterableIterator<T>; // only used for typings!
     // eslint-disable-next-line
-    [Symbol.toStringTag]: string // only used for typings!
+    [Symbol.toStringTag]: 'Set' // only used for typings!
 
     constructor(
         initialData?: IObservableSetInitialValues<T>,


### PR DESCRIPTION
This PR fixes (restores) the return type of the `Symbol.toStringTag` method of observable maps and sets to return either `"Map"` or `"Set"`.

This fixes the following TypeScript errors:

```
error TS2416: Property '[Symbol.toStringTag]' in type 'ObservableMap<K, V>' is not assignable to the same property in base type 'Map<K, V>'.
  Type 'string' is not assignable to type '"Map"'.
```

```
error TS2416: Property '[Symbol.toStringTag]' in type 'ObservableSet<T>' is not assignable to the same property in base type 'Set<T>'.
  Type 'string' is not assignable to type '"Set"'.
```

See https://github.com/mobxjs/mobx/commit/4a65b504eb67a79f9935985201f57438dfbeb972 for parts of changes causing this error.

Current workaround is to use `4.9.1` where this regression was not present.