### PR TITLE
Allow Symbol keys in observable maps (fixes #1925)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Allow symbol keys in `ObservableMap`, see [#1930](https://github.com/mobxjs/mobx/pull/1930) by [pimterry](https://github.com/pimterry)
+
 # 4.9.3
 
 * Fixed `observable.set` compatibility with IE 11, see [#1917](https://github.com/mobxjs/mobx/pull/1917) by [kalmi](https://github.com/kalmi)

--- a/test/base/map.js
+++ b/test/base/map.js
@@ -31,14 +31,23 @@ test("map crud", function() {
     expect(m.has(k)).toBe(true)
     expect(m.get(k)).toBe("arrVal")
 
-    expect(mobx.keys(m)).toEqual(["1", 1, k])
-    expect(mobx.values(m)).toEqual(["aa", "b", "arrVal"])
-    expect(Array.from(m)).toEqual([["1", "aa"], [1, "b"], [k, "arrVal"]])
-    expect(m.toJS()).toEqual(new Map([["1", "aa"], [1, "b"], [k, "arrVal"]]))
-    expect(m.toPOJO()).toEqual({ "1": "b", arr: "arrVal" })
+    var s = Symbol("test")
+    expect(m.has(s)).toBe(false)
+    expect(m.get(s)).toBe(undefined)
+    m.set(s, "symbol-value")
+    expect(m.get(s)).toBe("symbol-value")
+    expect(m.get(s.toString())).toBe(undefined)
+
+    expect(mobx.keys(m)).toEqual(["1", 1, k, s])
+    expect(mobx.values(m)).toEqual(["aa", "b", "arrVal", "symbol-value"])
+    expect(Array.from(m)).toEqual([["1", "aa"], [1, "b"], [k, "arrVal"], [s, "symbol-value"]])
+    expect(m.toJS()).toEqual(new Map([["1", "aa"], [1, "b"], [k, "arrVal"], [s, "symbol-value"]]))
+    expect(m.toPOJO()).toEqual({ "1": "b", arr: "arrVal", [s]: "symbol-value" })
     expect(JSON.stringify(m)).toEqual('{"1":"b","arr":"arrVal"}')
-    expect(m.toString()).toBe("ObservableMap@1[{ 1: aa, 1: b, arr: arrVal }]")
-    expect(m.size).toBe(3)
+    expect(m.toString()).toBe(
+        "ObservableMap@1[{ 1: aa, 1: b, arr: arrVal, Symbol(test): symbol-value }]"
+    )
+    expect(m.size).toBe(4)
 
     m.clear()
     expect(mobx.keys(m)).toEqual([])
@@ -56,9 +65,11 @@ test("map crud", function() {
         { object: m, name: "1", newValue: "aa", oldValue: "a", type: "update" },
         { object: m, name: 1, newValue: "b", type: "add" },
         { object: m, name: ["arr"], newValue: "arrVal", type: "add" },
+        { object: m, name: s, newValue: "symbol-value", type: "add" },
         { object: m, name: "1", oldValue: "aa", type: "delete" },
         { object: m, name: 1, oldValue: "b", type: "delete" },
-        { object: m, name: ["arr"], oldValue: "arrVal", type: "delete" }
+        { object: m, name: ["arr"], oldValue: "arrVal", type: "delete" },
+        { object: m, name: s, oldValue: "symbol-value", type: "delete" }
     ])
 })
 


### PR DESCRIPTION
* [x] Added unit tests
* [x] Updated changelog
	- Not clear what the 'right' way to do this is, seems lots of PRs ignore it? I've added an 'Unreleased' section ready to rename for the next release for now.
* [x] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
	- No changes necessary imo
* [x] Added typescript typings
	- No types have changed
* [x] Verified that there is no significant performance drop (`npm run perf`)

---

@mweststrate you mentioned `safeStringify` in #1925, I couldn't find that - looks like it's [a function in the mobx-state-tree codebase](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mobx-state-tree/src/core/type/type-checker.ts#L38-L45)?

I've written a separate key stringification function instead. Here it actually doesn't use JSON.stringify, because JSON can't represent symbols, and [they're normally omitted from JSON stringified objects](https://esdiscuss.org/topic/json-stringify-and-symbols). For the same reason, I've also preserved symbol-ness in `toPOJO` here, instead of stringifying them, which feels correct, and helpfully means we get the correct behaviour (symbol keys omitted) in `toJSON` here too.