### PR TITLE
Update README -- Googlebot now runs Chrome 74!

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _Tip: Consider using the faster and smaller ES6 build if targetting a modern env
 
 | MobX version | Actively supported | Supported browsers                                                                                                                                                                | GitHub branch    |
 | ------------ | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| 5.\*         | Yes                | Any browser that supports [ES6 Proxies](https://kangax.github.io/compat-table/es6/#test-Proxy) (non polyfillable). _NOT:_ IE 11 and lower, Node 5 and lower, Google's crawler bot | `master`         |
+| 5.\*         | Yes                | Any browser that supports [ES6 Proxies](https://kangax.github.io/compat-table/es6/#test-Proxy) (non polyfillable). _NOT:_ IE 11 and lower, Node 5 and lower | `master`         |
 | 4.\*         | Yes (LTS)          | Any ES5 compliant browser                                                                                                                                                         | `mobx4-master`   |
 | 1-3.\*       | No                 | Any ES5 compliant browser                                                                                                                                                         | No active branch |
 


### PR DESCRIPTION
See [Google announcement](https://webmasters.googleblog.com/2019/05/the-new-evergreen-googlebot.html?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+blogspot%2FamDG+%28Official+Google+Webmaster+Central+Blog%29)
