### PR TITLE
fix TS for observable set

### DIFF
--- a/src/api/observable.ts
+++ b/src/api/observable.ts
@@ -112,6 +112,7 @@ export interface IObservableFactory {
     (value: number | string | null | undefined | boolean): never // Nope, not supported, use box
     (target: Object, key: string | symbol, baseDescriptor?: PropertyDescriptor): any // decorator
     <T = any>(value: T[], options?: CreateObservableOptions): IObservableArray<T>
+    <T = any>(value: Set<T>, options?: CreateObservableOptions): ObservableSet<T>
     <K = any, V = any>(value: Map<K, V>, options?: CreateObservableOptions): ObservableMap<K, V>
     <T extends Object>(
         value: T,


### PR DESCRIPTION
fixes TS typings for this case
```
const obsSet: ObservableSet = observable(new Set<any>())
```