### PR TITLE
Revert mobx 4 symbol support

### DIFF
--- a/src/api/computed.ts
+++ b/src/api/computed.ts
@@ -20,7 +20,7 @@ export const computedDecorator = createPropDecorator(
     false,
     (
         instance: any,
-        propertyName: PropertyKey,
+        propertyName: string,
         descriptor: any,
         decoratorTarget: any,
         decoratorArgs: any[]

--- a/src/api/object-api.ts
+++ b/src/api/object-api.ts
@@ -20,7 +20,7 @@ import {
 export function keys<K>(map: ObservableMap<K, any>): ReadonlyArray<K>
 export function keys<T>(ar: IObservableArray<T>): ReadonlyArray<number>
 export function keys<T>(set: ObservableSet<T>): ReadonlyArray<T>
-export function keys<T extends Object>(obj: T): ReadonlyArray<PropertyKey>
+export function keys<T extends Object>(obj: T): ReadonlyArray<string>
 export function keys(obj: any): any {
     if (isObservableObject(obj)) {
         return ((obj as any) as IIsObservableObject).$mobx.getKeys()
@@ -86,12 +86,12 @@ export function entries(obj: any): any {
     )
 }
 
-export function set<V>(obj: ObservableMap<PropertyKey, V>, values: { [key: string]: V })
+export function set<V>(obj: ObservableMap<string, V>, values: { [key: string]: V })
 export function set<K, V>(obj: ObservableMap<K, V>, key: K, value: V)
 export function set<T>(obj: ObservableSet<T>, value: T)
 export function set<T>(obj: IObservableArray<T>, index: number, value: T)
 export function set<T extends Object>(obj: T, values: { [key: string]: any })
-export function set<T extends Object>(obj: T, key: PropertyKey, value: any)
+export function set<T extends Object>(obj: T, key: string, value: any)
 export function set(obj: any, key: any, value?: any): void {
     if (arguments.length === 2 && !isObservableSet(obj)) {
         startBatch()

--- a/src/api/observabledecorator.ts
+++ b/src/api/observabledecorator.ts
@@ -4,8 +4,7 @@ import {
     IEnhancer,
     createPropDecorator,
     BabelDescriptor,
-    defineObservableProperty,
-    stringifyKey
+    defineObservableProperty
 } from "../internal"
 
 export type IObservableDecorator = {
@@ -18,7 +17,7 @@ export function createDecoratorForEnhancer(enhancer: IEnhancer<any>): IObservabl
         true,
         (
             target: any,
-            propertyName: PropertyKey,
+            propertyName: string,
             descriptor: BabelDescriptor,
             _decoratorTarget,
             decoratorArgs: any[]
@@ -26,9 +25,7 @@ export function createDecoratorForEnhancer(enhancer: IEnhancer<any>): IObservabl
             if (process.env.NODE_ENV !== "production") {
                 invariant(
                     !descriptor || !descriptor.get,
-                    `@observable cannot be used on getter (property "${stringifyKey(
-                        propertyName
-                    )}"), use @computed instead.`
+                    `@observable cannot be used on getter (property "${propertyName}"), use @computed instead.`
                 )
             }
             const initialValue = descriptor

--- a/src/api/tojs.ts
+++ b/src/api/tojs.ts
@@ -4,8 +4,7 @@ import {
     isObservableValue,
     keys,
     isObservableSet,
-    isObservableMap,
-    getPlainObjectKeys
+    isObservableMap
 } from "../internal"
 
 export type ToJSOptions = {
@@ -89,9 +88,9 @@ function toJSHelper(source, options: ToJSOptions, __alreadySeen: Map<any, any>) 
 
     // Fallback to the situation that source is an ObservableObject or a plain object
     const res = cache(__alreadySeen, source, {}, options)
-    getPlainObjectKeys(source).forEach(key => {
+    for (let key in source) {
         res[key] = toJSHelper(source[key], options!, __alreadySeen)
-    })
+    }
 
     return res
 }

--- a/src/types/observablemap.ts
+++ b/src/types/observablemap.ts
@@ -21,7 +21,6 @@ import {
     isSpyEnabled,
     hasListeners,
     spyReportStart,
-    stringifyKey,
     transaction,
     notifyListeners,
     spyReportEnd,
@@ -33,8 +32,7 @@ import {
     registerListener,
     IInterceptor,
     registerInterceptor,
-    declareIterator,
-    getPlainObjectKeys
+    declareIterator
 } from "../internal"
 
 export interface IKeyValueMap<V = any> {
@@ -301,7 +299,7 @@ export class ObservableMap<K = any, V = any>
         }
         transaction(() => {
             if (isPlainObject(other))
-                getPlainObjectKeys(other).forEach(key => this.set((key as any) as K, other[key]))
+                Object.keys(other).forEach(key => this.set((key as any) as K, other[key]))
             else if (Array.isArray(other)) other.forEach(([key, value]) => this.set(key, value))
             else if (isES6Map(other)) {
                 if (other.constructor !== Map)
@@ -394,6 +392,11 @@ export class ObservableMap<K = any, V = any>
     intercept(handler: IInterceptor<IMapWillChange<K, V>>): Lambda {
         return registerInterceptor(this, handler)
     }
+}
+
+function stringifyKey(key: any): string {
+    if (key && key.toString) return key.toString()
+    else return new String(key).toString()
 }
 
 declareIterator(ObservableMap.prototype, function() {

--- a/src/utils/decorators2.ts
+++ b/src/utils/decorators2.ts
@@ -9,7 +9,7 @@ export type BabelDescriptor = PropertyDescriptor & { initializer?: () => any }
 
 export type PropertyCreator = (
     instance: any,
-    propertyName: PropertyKey,
+    propertyName: string,
     descriptor: BabelDescriptor | undefined,
     decoratorTarget: any,
     decoratorArgs: any[]

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -120,17 +120,15 @@ export function addHiddenFinalProp(object: any, propName: string, value: any) {
     })
 }
 
-export function isPropertyConfigurable(object: any, prop: PropertyKey): boolean {
+export function isPropertyConfigurable(object: any, prop: string): boolean {
     const descriptor = Object.getOwnPropertyDescriptor(object, prop)
     return !descriptor || (descriptor.configurable !== false && descriptor.writable !== false)
 }
 
-export function assertPropertyConfigurable(object: any, prop: PropertyKey) {
+export function assertPropertyConfigurable(object: any, prop: string) {
     if (process.env.NODE_ENV !== "production" && !isPropertyConfigurable(object, prop))
         fail(
-            `Cannot make property '${stringifyKey(
-                prop
-            )}' observable, it is not configurable and writable in the target object`
+            `Cannot make property '${prop}' observable, it is not configurable and writable in the target object`
         )
 }
 
@@ -163,25 +161,6 @@ export function isES6Map(thing): boolean {
 
 export function isES6Set(thing): thing is Set<any> {
     return thing instanceof Set
-}
-
-/**
- * Returns the following: own keys, prototype keys & own symbol keys, if they are enumerable.
- */
-export function getPlainObjectKeys(object) {
-    const enumerables = new Set<PropertyKey>()
-    for (let key in object) enumerables.add(key) // *all* enumerables
-    Object.getOwnPropertySymbols(object).forEach(k => {
-        if (Object.getOwnPropertyDescriptor(object, k)!.enumerable) enumerables.add(k)
-    }) // *own* symbols
-    // Note: this implementation is missing enumerable, inherited, symbolic property names! That would however pretty expensive to add,
-    // as there is no efficient iterator that returns *all* properties
-    return Array.from(enumerables)
-}
-
-export function stringifyKey(key: any): string {
-    if (key && key.toString) return key.toString()
-    else return new String(key).toString()
 }
 
 export function getMapLikeKeys<K, V>(map: ObservableMap<K, V>): ReadonlyArray<K>

--- a/test/base/object-api.js
+++ b/test/base/object-api.js
@@ -66,28 +66,6 @@ test("object - set, remove, values are reactive", () => {
     expect(snapshots).toEqual([[3], [3, 4], [5, 4], [5]])
 })
 
-test("object with symbol keys - set, remove, values are reactive", () => {
-    const todos = observable({})
-    const snapshots = []
-    const x = Symbol()
-    const y = Symbol()
-    const z = Symbol("z")
-
-    reaction(() => values(todos), values => snapshots.push(values))
-
-    expect(has(todos, x)).toBe(false)
-    expect(get(todos, x)).toBe(undefined)
-    set(todos, x, 3)
-    expect(has(todos, x)).toBe(true)
-    expect(get(todos, x)).toBe(3)
-    remove(todos, y)
-    set(todos, z, 4)
-    set(todos, x, 5)
-    remove(todos, z)
-
-    expect(snapshots).toEqual([[3], [3, 4], [5, 4], [5]])
-})
-
 test("object - set, remove, entries are reactive", () => {
     const todos = observable({})
     const snapshots = []
@@ -107,28 +85,6 @@ test("object - set, remove, entries are reactive", () => {
     expect(snapshots).toEqual([[["x", 3]], [["x", 3], ["z", 4]], [["x", 5], ["z", 4]], [["x", 5]]])
 })
 
-test("object with symbols - set, remove, entries are reactive", () => {
-    const todos = observable({})
-    const snapshots = []
-    const x = Symbol()
-    const y = Symbol()
-    const z = Symbol("z")
-
-    reaction(() => entries(todos), entries => snapshots.push(entries))
-
-    expect(has(todos, x)).toBe(false)
-    expect(get(todos, x)).toBe(undefined)
-    set(todos, x, 3)
-    expect(has(todos, x)).toBe(true)
-    expect(get(todos, x)).toBe(3)
-    remove(todos, y)
-    set(todos, z, 4)
-    set(todos, x, 5)
-    remove(todos, z)
-
-    expect(snapshots).toEqual([[[x, 3]], [[x, 3], [z, 4]], [[x, 5], [z, 4]], [[x, 5]]])
-})
-
 test("object - set, remove, keys are reactive", () => {
     const todos = observable({ a: 3 })
     const snapshots = []
@@ -143,26 +99,6 @@ test("object - set, remove, keys are reactive", () => {
     remove(todos, "a")
 
     expect(snapshots).toEqual([["a", "x"], ["a", "x", "z"], ["a", "x"], ["x"]])
-})
-
-test("object with symbol keys - set, remove, keys are reactive", () => {
-    const snapshots = []
-    const x = Symbol()
-    const y = Symbol()
-    const z = Symbol("z")
-    const a = Symbol()
-    const todos = observable({ [a]: 3 })
-
-    reaction(() => keys(todos), keys => snapshots.push(keys))
-
-    set(todos, x, 3)
-    remove(todos, y)
-    set(todos, z, 4)
-    set(todos, x, 5)
-    remove(todos, z)
-    remove(todos, a)
-
-    expect(snapshots).toEqual([[a, x], [a, x, z], [a, x], [x]])
 })
 
 test("map - set, remove, values are reactive", () => {
@@ -180,28 +116,6 @@ test("map - set, remove, values are reactive", () => {
     set(todos, "z", 4)
     set(todos, "x", 5)
     remove(todos, "z")
-
-    expect(snapshots).toEqual([[3], [3, 4], [5, 4], [5]])
-})
-
-test("map with symbol keys - set, remove, values are reactive", () => {
-    const todos = observable.map({})
-    const snapshots = []
-    const x = Symbol()
-    const y = Symbol()
-    const z = Symbol("z")
-
-    reaction(() => values(todos), values => snapshots.push(values))
-
-    expect(has(todos, x)).toBe(false)
-    expect(get(todos, x)).toBe(undefined)
-    set(todos, x, 3)
-    expect(has(todos, x)).toBe(true)
-    expect(get(todos, x)).toBe(3)
-    remove(todos, y)
-    set(todos, z, 4)
-    set(todos, x, 5)
-    remove(todos, z)
 
     expect(snapshots).toEqual([[3], [3, 4], [5, 4], [5]])
 })
@@ -225,28 +139,6 @@ test("map - set, remove, entries are reactive", () => {
     expect(snapshots).toEqual([[["x", 3]], [["x", 3], ["z", 4]], [["x", 5], ["z", 4]], [["x", 5]]])
 })
 
-test("map with symbol keys - set, remove, entries are reactive", () => {
-    const todos = observable.map({})
-    const snapshots = []
-    const x = Symbol()
-    const y = Symbol()
-    const z = Symbol("z")
-
-    reaction(() => entries(todos), entries => snapshots.push(entries))
-
-    expect(has(todos, x)).toBe(false)
-    expect(get(todos, x)).toBe(undefined)
-    set(todos, x, 3)
-    expect(has(todos, x)).toBe(true)
-    expect(get(todos, x)).toBe(3)
-    remove(todos, y)
-    set(todos, z, 4)
-    set(todos, x, 5)
-    remove(todos, z)
-
-    expect(snapshots).toEqual([[[x, 3]], [[x, 3], [z, 4]], [[x, 5], [z, 4]], [[x, 5]]])
-})
-
 test("map - set, remove, keys are reactive", () => {
     const todos = observable.map({ a: 3 })
     const snapshots = []
@@ -261,26 +153,6 @@ test("map - set, remove, keys are reactive", () => {
     remove(todos, "a")
 
     expect(snapshots).toEqual([["a", "x"], ["a", "x", "z"], ["a", "x"], ["x"]])
-})
-
-test("map with symbol keys - set, remove, keys are reactive", () => {
-    const snapshots = []
-    const x = Symbol()
-    const y = Symbol()
-    const z = Symbol("z")
-    const a = Symbol()
-    const todos = observable.map({ [a]: 3 })
-
-    reaction(() => keys(todos), keys => snapshots.push(keys))
-
-    set(todos, x, 3)
-    remove(todos, y)
-    set(todos, z, 4)
-    set(todos, x, 5)
-    remove(todos, z)
-    remove(todos, a)
-
-    expect(snapshots).toEqual([[a, x], [a, x, z], [a, x], [x]])
 })
 
 test("array - set, remove, values are reactive", () => {

--- a/test/base/tojs.js
+++ b/test/base/tojs.js
@@ -220,23 +220,6 @@ test("toJS handles dates", () => {
     expect(a.d === b.d).toBe(true)
 })
 
-test("toJS handles symbol keys in objects and maps", () => {
-    var key = Symbol("key")
-    var a = observable({
-        [key]: 42
-    })
-
-    var b = mobx.toJS(a)
-    expect(b[key]).toBe(42)
-
-    var x = observable.map({
-        [key]: 43
-    })
-
-    var y = mobx.toJS(x)
-    expect(y[key]).toBe(43)
-})
-
 test("json cycles", function() {
     const a = observable({
         b: 1,


### PR DESCRIPTION
I backported symbol support from MobX 5 to MobX 4, without thinking it really through. Although symbols could potentially be used in practice, this probably misses the point that mobx 4 is used in more backward compatible modi, and didn't require polyfills as of yet. 

This PR reverts symbol support. A downside of this PR is that this increases the semantical difference between mobx 4 and 5

Fixes #1986, #1987 