### PR TITLE
fix(extendObservable): use regular `for` on array of keys

### DIFF
--- a/src/api/extendobservable.ts
+++ b/src/api/extendobservable.ts
@@ -67,7 +67,7 @@ export function extendObservableObjectWithProperties(
         )
         if (decorators) {
             const keys = getPlainObjectKeys(decorators)
-            for (let i in keys) {
+            for (let i = 0; i < keys.length; i++) {
                 const key = keys[i]
                 if (!(key in properties!))
                     fail(
@@ -81,7 +81,7 @@ export function extendObservableObjectWithProperties(
     startBatch()
     try {
         const keys = getPlainObjectKeys(properties)
-        for (let i in keys) {
+        for (let i = 0; i < keys.length; i++) {
             const key = keys[i]
             const descriptor = Object.getOwnPropertyDescriptor(properties, key)!
             if (process.env.NODE_ENV !== "production") {
@@ -100,8 +100,8 @@ export function extendObservableObjectWithProperties(
                 decorators && key in decorators
                     ? decorators[key]
                     : descriptor.get
-                        ? computedDecorator
-                        : defaultDecorator
+                    ? computedDecorator
+                    : defaultDecorator
             if (process.env.NODE_ENV !== "production" && typeof decorator !== "function")
                 fail(`Not a valid decorator for '${stringifyKey(key)}', got: ${decorator}`)
 

--- a/src/api/extendobservable.ts
+++ b/src/api/extendobservable.ts
@@ -67,8 +67,7 @@ export function extendObservableObjectWithProperties(
         )
         if (decorators) {
             const keys = getPlainObjectKeys(decorators)
-            for (let i = 0; i < keys.length; i++) {
-                const key = keys[i]
+            for (const key of keys) {
                 if (!(key in properties!))
                     fail(
                         `Trying to declare a decorator for unspecified property '${stringifyKey(
@@ -81,8 +80,7 @@ export function extendObservableObjectWithProperties(
     startBatch()
     try {
         const keys = getPlainObjectKeys(properties)
-        for (let i = 0; i < keys.length; i++) {
-            const key = keys[i]
+        for (const key of keys) {
             const descriptor = Object.getOwnPropertyDescriptor(properties, key)!
             if (process.env.NODE_ENV !== "production") {
                 if (Object.getOwnPropertyDescriptor(target, key))


### PR DESCRIPTION
use regular `for` on array of keys

seems that it caused bugs in v5.10 (in my case I was extending the Array prototype with enumerable properties, and those properties were iterated because of `for i in keys`. 

can add a test, not sure where is the right place or if it's required for such a small change.