### PR TITLE
Allow overwriting computed values if configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx",
-  "version": "4.12.0",
+  "version": "4.11.0",
   "description": "Simple, scalable state management.",
   "main": "lib/mobx.js",
   "umd:main": "lib/mobx.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "description": "Simple, scalable state management.",
   "main": "lib/mobx.js",
   "umd:main": "lib/mobx.umd.js",

--- a/src/api/configure.ts
+++ b/src/api/configure.ts
@@ -10,6 +10,7 @@ import {
 export function configure(options: {
     enforceActions?: boolean | "strict" | "never" | "always" | "observed"
     computedRequiresReaction?: boolean
+    computedConfigurable?: boolean
     isolateGlobalState?: boolean
     disableErrorBoundaries?: boolean
     arrayBuffer?: number
@@ -18,6 +19,7 @@ export function configure(options: {
     const {
         enforceActions,
         computedRequiresReaction,
+        computedConfigurable,
         disableErrorBoundaries,
         arrayBuffer,
         reactionScheduler
@@ -54,6 +56,9 @@ export function configure(options: {
     }
     if (computedRequiresReaction !== undefined) {
         globalState.computedRequiresReaction = !!computedRequiresReaction
+    }
+    if (computedConfigurable !== undefined) {
+        globalState.computedConfigurable = !!computedConfigurable
     }
     if (disableErrorBoundaries !== undefined) {
         if (disableErrorBoundaries === true)

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -101,6 +101,12 @@ export class MobXGlobals {
      */
     computedRequiresReaction = false
 
+    /**
+     * Allows overwriting of computed properties, useful in tests but not prod as it can cause
+     * memory leaks. See https://github.com/mobxjs/mobx/issues/1867
+     */
+    computedConfigurable = false
+
     /*
      * Don't catch and rethrow exceptions. This is useful for inspecting the state of
      * the stack when an exception occurs while debugging.

--- a/src/types/observableobject.ts
+++ b/src/types/observableobject.ts
@@ -333,7 +333,7 @@ export function generateComputedPropConfig(propName) {
     return (
         computedPropertyConfigs[propName] ||
         (computedPropertyConfigs[propName] = {
-            configurable: false, // See https://github.com/mobxjs/mobx/issues/1867, for computeds, we don't want reconfiguration, as this will potentially leak memory!
+            configurable: globalState.computedConfigurable,
             enumerable: false,
             get() {
                 return getAdministrationForComputedPropOwner(this).read(this, propName)

--- a/test/base/strict-mode.js
+++ b/test/base/strict-mode.js
@@ -249,3 +249,24 @@ test("#1869", function() {
     }).toThrow("Since strict-mode is enabled")
     mobx._resetGlobalState() // should preserve strict mode
 })
+
+test("allow overwriting computed if configured", function() {
+    try {
+        mobx.configure({ computedConfigurable: true })
+        const x = mobx.observable({
+            v: 2,
+            @mobx.computed
+            get multiplied() {
+                return this.v * 2
+            }
+        })
+        expect(() => {
+            Object.defineProperty(x, "multiplied", {
+                value: 12
+            })
+        }).not.toThrow()
+        expect(x.multiplied).toBe(12)
+    } finally {
+        mobx.configure({ computedConfigurable: false })
+    }
+})


### PR DESCRIPTION
We ran into a problem where we couldn't overwrite computed properties in tests. Some of our computed properties are very complicated and it would be easier to just overwrite them in tests rather than overwrite the depending properties. 

This fixes https://github.com/mobxjs/mobx/issues/1888 and https://github.com/mobxjs/mobx/issues/1867)

PR FOR MOBX 5

* [x] Added unit tests
* [x] Updated changelog https://github.com/mobxjs/mobx/pull/2013
* [x] Updated docs https://github.com/mobxjs/mobx/pull/2012 
* [ ] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)
