### PR TITLE
Use onBecomeUnobserved for ObservableMap._hasMap garbage collection

### DIFF
--- a/test/base/map.js
+++ b/test/base/map.js
@@ -227,7 +227,28 @@ test("cleanup", function() {
     disposer()
     expect(aValue).toBe(2)
     expect(observable.observers.size).toBe(0)
-    expect(x._hasMap.get("a").observers.size).toBe(0)
+    expect(x._hasMap.has("a")).toBe(false)
+})
+
+test("getAtom encapsulation leak test", function() {
+    const x = map({})
+
+    let disposer = autorun(function() {
+        x.has("a")
+    })
+
+    let atom = mobx.getAtom(x, "a")
+
+    disposer()
+
+    expect(x._hasMap.get("a")).toBe(undefined)
+
+    disposer = autorun(function() {
+        x.has("a")
+        atom && atom.reportObserved()
+    })
+
+    expect(x._hasMap.get("a")).not.toBe(atom)
 })
 
 test("strict", function() {


### PR DESCRIPTION
fixes #2031

* [x] Added unit tests
* [ ] Updated changelog
* ~Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated~
* ~Added typescript typings~
* [ ] Verified that there is no significant performance drop (`npm run perf`)
