### PR TITLE
Fixing stuck reactivity, increasing resilience against stale state

### DIFF
--- a/src/api/object-api.ts
+++ b/src/api/object-api.ts
@@ -65,7 +65,9 @@ export function values(obj: any): string[] {
 export function entries<K, T>(map: ObservableMap<K, T>): ReadonlyArray<[K, T]>
 export function entries<T>(set: ObservableSet<T>): ReadonlyArray<[T, T]>
 export function entries<T>(ar: IObservableArray<T>): ReadonlyArray<[number, T]>
-export function entries<T = any>(obj: T): ReadonlyArray<[string, T extends object ? T[keyof T] : any]>
+export function entries<T = any>(
+    obj: T
+): ReadonlyArray<[string, T extends object ? T[keyof T] : any]>
 export function entries(obj: any): any {
     if (isObservableObject(obj)) {
         return keys(obj).map(key => [key, obj[key]])
@@ -94,8 +96,8 @@ export function set<T extends Object>(obj: T, key: PropertyKey, value: any)
 export function set(obj: any, key: any, value?: any): void {
     if (arguments.length === 2 && !isObservableSet(obj)) {
         startBatch()
-        const values = key
         try {
+            const values = key
             for (let key in values) set(obj, key, values[key])
         } finally {
             endBatch()
@@ -118,9 +120,12 @@ export function set(obj: any, key: any, value?: any): void {
         if (typeof key !== "number") key = parseInt(key, 10)
         invariant(key >= 0, `Not a valid index: '${key}'`)
         startBatch()
-        if (key >= obj.length) obj.length = key + 1
-        obj[key] = value
-        endBatch()
+        try {
+            if (key >= obj.length) obj.length = key + 1
+            obj[key] = value
+        } finally {
+            endBatch()
+        }
     } else {
         return fail(
             process.env.NODE_ENV !== "production" &&

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -86,11 +86,14 @@ function startAction(
 }
 
 function endAction(runInfo: IActionRunInfo) {
-    allowStateChangesEnd(runInfo.prevAllowStateChanges)
-    endBatch()
-    untrackedEnd(runInfo.prevDerivation)
-    if (runInfo.notifySpy && process.env.NODE_ENV !== "production")
-        spyReportEnd({ time: Date.now() - runInfo.startTime })
+    try {
+        allowStateChangesEnd(runInfo.prevAllowStateChanges)
+    } finally {
+        endBatch()
+        untrackedEnd(runInfo.prevDerivation)
+        if (runInfo.notifySpy && process.env.NODE_ENV !== "production")
+            spyReportEnd({ time: Date.now() - runInfo.startTime })
+    }
 }
 
 export function allowStateChanges<T>(allowStateChanges: boolean, func: () => T): T {

--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -62,8 +62,11 @@ export class Atom implements IAtom {
      */
     public reportChanged() {
         startBatch()
-        propagateChanged(this)
-        endBatch()
+        try {
+            propagateChanged(this)
+        } finally {
+            endBatch()
+        }
     }
 
     toString() {

--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -149,8 +149,11 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
             if (shouldCompute(this)) {
                 this.warnAboutUntrackedRead()
                 startBatch() // See perf test 'computed memoization'
-                this.value = this.computeValue(false)
-                endBatch()
+                try {
+                    this.value = this.computeValue(false)
+                } finally {
+                    endBatch()
+                }
             }
         } else {
             reportObserved(this)

--- a/src/core/observable.ts
+++ b/src/core/observable.ts
@@ -106,7 +106,11 @@ export function startBatch() {
 }
 
 export function endBatch() {
-    if (--globalState.inBatch === 0) {
+    if (
+        --globalState.inBatch === 0 ||
+        globalState.pendingReactions.length > 0 ||
+        globalState.pendingUnobservations.length > 0
+    ) {
         runReactions()
         // the batch is actually about to finish, all unobserving should happen here.
         const list = globalState.pendingUnobservations
@@ -240,7 +244,7 @@ function logTraceInfo(derivation: IDerivation, observable: IObservable) {
 
         // prettier-ignore
         new Function(
-`debugger;
+            `debugger;
 /*
 Tracing '${derivation.name}'
 

--- a/src/types/observableobject.ts
+++ b/src/types/observableobject.ts
@@ -211,8 +211,8 @@ export class ObservableObjectAdministration
             })
             if (!change) return
         }
+        startBatch()
         try {
-            startBatch()
             const notify = hasListeners(this)
             const notifySpy = isSpyEnabled()
             const oldObservable = this.values.get(key)


### PR DESCRIPTION
We were experiencing non-deterministic issues with mobx causing the reactivity to go stale, without any errors, warning or any other information that could lead to proper debugging of the problem. While inspecting the globalState object, It was obvious all actions and unobservations were cumulated as pending, but no more reactions were scheduled after the issue occured. More information on the problem here: https://github.com/mobxjs/mobx-react/issues/714

This PR aims to fix this issue and also focuses on increasing resilience to similar issues as the existing code can't reliably ensure that for every `startBatch()` call there's a corresponding `endBatch()` call.

My understanding of MobX internals is limited and I can't be sure if this fix introduces any potential issue, but I verified that:

- Our rather complex app works as expected
- I'm not seeing any duplicated or abundant reactions
- The problem with the stuck/stale reactivity has been fixed

I also tested performance, where the results are rather interesting, each before/after were concluded 5 times on my Macbook Pro:
Before (median): ~18.5 sec.
After (median): ~17.5 sec.

Not sure if this indicates that batches are now run more often with smaller amount of actions due to the updated condition or just false positive caused by my system.

Looking forward to discuss this change.