### PR TITLE
Сlarify React Native runtime support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,14 @@ MobX 5 is the first MobX version fully leveraging Proxies. This has two big adva
 
 ### The system requirements to run MobX has been upped
 
-* MobX 5 can only be used on environments that support `Proxies`. In practice this means, no Internet Explorer (Edge is fine). No nodejs < 6. React Native on Android only when JavaScript core is [upgraded](https://github.com/react-community/jsc-android-buildscripts#how-to-use-it-with-my-react-native-app). All modern browsers are supported.
+* MobX 5 can only be used on environments that support `Proxies`. In practice this means:
+    - no Internet Explorer (Edge is fine)
+    - Node.js >= 6  
+React Native:
+    - iOS >= 10
+    - Android from RN 0.59 (or with manual JavaScript core [upgrade](https://github.com/react-community/jsc-android-buildscripts#how-to-use-it-with-my-react-native-app))
+    - Hermes runtime is [not supported](https://github.com/facebook/hermes/issues/28)  
+All modern browsers are supported.
 * Since MobX no longer runs on older browsers, the compilation target has been upgraded to ES2015 syntax supporting browsers. This means that MobX is not loadable on older browsers without down compilation to ES5.
 * If for whatever reason your project cannot meet this requirements, please stick to MobX 4. It will be actively maintained. All current features of MobX 5 are expressable in MobX 4 as well, but it means that for example to use dynamic objects some [additional APIs](https://mobx.js.org/refguide/object-api.html) are needed.
 * The performance footprint of MobX 5 should be pretty similar to MobX 4. In our performance tests we saw some minor improvements in memory footprint, but overall it should be pretty comparable.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,14 @@ _Tip: Consider using the faster and smaller ES6 build if targetting a modern env
 | 4.\*         | Yes (LTS)          | Any ES5 compliant browser                                                                                                                                   | `mobx4-master`   |
 | 1-3.\*       | No                 | Any ES5 compliant browser                                                                                                                                   | No active branch |
 
--   MobX >=5 runs on any browser with [ES6 proxy support](https://kangax.github.io/compat-table/es6/#test-Proxy). It will throw an error on startup on older environments such as IE11, Node.js <6 or React Native Android on old JavaScriptCore [how-to-upgrade](https://github.com/react-community/jsc-android-buildscripts#how-to-use-it-with-my-react-native-app).
+-   MobX >=5 runs on any browser with [ES6 proxy support](https://kangax.github.io/compat-table/es6/#test-Proxy). In practice this means:
+    - no Internet Explorer (Edge is fine)
+    - Node.js >= 6  
+React Native:
+    - iOS >= 10
+    - Android from RN 0.59 (or with manual JavaScript core [upgrade](https://github.com/react-community/jsc-android-buildscripts#how-to-use-it-with-my-react-native-app))
+    - Hermes runtime is [not supported](https://github.com/facebook/hermes/issues/28)  
+All modern browsers are supported.
 -   MobX 4 runs on any ES5 browser and will be actively maintained. The MobX 4 and 5 api's are the same and semantically can achieve the same, but MobX 4 has some [limitations](#mobx-4-vs-mobx-5).
 
 ## Translations


### PR DESCRIPTION
Notes about iOS 9, RN 0.59 and new Hermes runtime.