### PR TITLE
Fix flow definition for Flow 103

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -127,12 +127,12 @@ export interface IObservableArray<T> extends Array<T> {
     clear(): T[];
     replace(newItems: T[]): T[];
     find(
-        predicate: (item: T, index: number, array: Array<T>) => boolean,
+        predicate: (item: T, index: number, array: Array<T>) => mixed,
         thisArg?: any,
         fromIndex?: number
     ): T | any;
     findIndex(
-        predicate: (item: T, index: number, array: Array<T>) => boolean,
+        predicate: (item: T, index: number, array: Array<T>) => mixed,
         thisArg?: any,
         fromIndex?: number
     ): number;


### PR DESCRIPTION
Flow 103 throws an error on the current mobx types (see #2048). This is a simple fix (we just mirror the change Flow made).

I'd like to get this released sooner than later because this issue is a blocker for every Mobx user that also has Flow as a dependency 🙏 

PR checklist:

* [ ] Updated changelog
