### PR TITLE
Setup the lock bot

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,26 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 60
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs or questions.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
Adding a stale bot (#2015) was surely a good step. Let's take it further and add the [lock bot](https://github.com/apps/lock) as well. People tend to comment on long-closed issues. It's a bad habit as nobody else except those who participated (or watching a whole repo) can't see such a comment.

I've used pretty much default config except I've set 60 days for locking closed issues. I've excluded pulls.

All we need now is to enable the app which I don't have permission to do.


