### PR TITLE
Fixing import in the example

### DIFF
--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -209,7 +209,8 @@ In such cases mobx-util's [`computedFn`](https://github.com/mobxjs/mobx-utils#co
 ```typescript
 // Parameterized computed views:
 // Create computed's and store them in a cache
-import { observable, computed } from "mobx"
+import { observable } from "mobx"
+import { computedFn } from "mobx-utils"
 
 class Todos {
   @observable todos = []


### PR DESCRIPTION
Just a small update for the docs. On the page about `@computed`, they import `computed` from `mobx` but in the code below, the `computedFn` from `mobx-utils` is used instead. So I'm just fixing the imports.

PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [x] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)
