### PR TITLE
fix: onBecome(Un)Observed didn't trigger when using number as key of …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-
-# 5.13.1 / 4.13.1
-* onBecome(Un)Observed didn't trigger when using number as key of observable map. Fixes [#2067](https://github.com/mobxjs/mobx/issues/2067).
-
 # 5.13.1 / 4.13.1
 
 * Don't use `global` and `self` keywords unless defined. Fixes [#2070](https://github.com/mobxjs/mobx/issues/2070).
+
+* onBecome(Un)Observed didn't trigger when using number as key of observable map. Fixes [#2067](https://github.com/mobxjs/mobx/issues/2067).
+
 
 # 5.13.0 / 4.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+# 5.13.1 / 4.13.1
+* onBecome(Un)Observed didn't trigger when using number as key of observable map. Fixes [#2067](https://github.com/mobxjs/mobx/issues/2067).
+
 # 5.13.1 / 4.13.1
 
 * Don't use `global` and `self` keywords unless defined. Fixes [#2070](https://github.com/mobxjs/mobx/issues/2070).

--- a/src/api/become-observed.ts
+++ b/src/api/become-observed.ts
@@ -47,8 +47,8 @@ export function onBecomeUnobserved(thing, arg2, arg3?): Lambda {
 
 function interceptHook(hook: "onBecomeObserved" | "onBecomeUnobserved", thing, arg2, arg3) {
     const atom: IObservable =
-        typeof arg2 === "string" ? getAtom(thing, arg2) : (getAtom(thing) as any)
-    const cb = typeof arg2 === "string" ? arg3 : arg2
+        typeof arg3 === "function" ? getAtom(thing, arg2) : (getAtom(thing) as any)
+    const cb = typeof arg3 === "function" ? arg3 : arg2
     const listenersKey = `${hook}Listeners` as
         | "onBecomeObservedListeners"
         | "onBecomeUnobservedListeners"

--- a/test/base/become-observed.js
+++ b/test/base/become-observed.js
@@ -1,0 +1,13 @@
+import { autorun, onBecomeObserved, observable } from "../../src/mobx"
+
+describe("become-observed", () => {
+    it("work on map with number as key", () => {
+        const oMap = observable.map()
+        const key = 1
+        oMap.set(key, observable.box("value"))
+        const cb = jest.fn()
+        onBecomeObserved(oMap, key, cb)
+        autorun(() => oMap.get(key))
+        expect(cb).toBeCalled()
+    })
+})


### PR DESCRIPTION
* [x] Added unit tests
* [x] Updated changelog
