### PR TITLE
improved typings for flows in ts 3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "size-limit": "^1.3.3",
     "tape": "^4.10.1",
     "ts-jest": "^24.0.0",
-    "tslib": "^1.9.3",
-    "typescript": "^3.3.3333"
+    "tslib": "^1.10.0",
+    "typescript": "^3.6.2"
   },
   "dependencies": {},
   "keywords": [

--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -72,7 +72,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
     newObserving = null // during tracking it's an array with new observed observers
     isBeingObserved = false
     isPendingUnobservation: boolean = false
-    observers = new Set()
+    observers = new Set<IDerivation>()
     diffValue = 0
     runId = 0
     lastAccessedBy = 0
@@ -173,7 +173,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
             invariant(
                 !this.isRunningSetter,
                 `The setter of computed value '${
-                    this.name
+                this.name
                 }' is trying to update itself. Did you intend to update an _observable_ value, instead of the computed property?`
             )
             this.isRunningSetter = true
@@ -186,9 +186,9 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
             invariant(
                 false,
                 process.env.NODE_ENV !== "production" &&
-                    `[ComputedValue '${
-                        this.name
-                    }'] It is not possible to assign a new value to a computed value.`
+                `[ComputedValue '${
+                this.name
+                }'] It is not possible to assign a new value to a computed value.`
             )
     }
 
@@ -275,14 +275,14 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
         if (this.isTracing !== TraceMode.NONE) {
             console.log(
                 `[mobx.trace] '${
-                    this.name
+                this.name
                 }' is being read outside a reactive context. Doing a full recompute`
             )
         }
         if (globalState.computedRequiresReaction) {
             console.warn(
                 `[mobx] Computed value ${
-                    this.name
+                this.name
                 } is being read outside a reactive context. Doing a full recompute`
             )
         }

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -34,8 +34,8 @@ try {
     g.process.env = {}
 }
 
-;(() => {
-    function testCodeMinification() {}
+; (() => {
+    function testCodeMinification() { }
     if (
         testCodeMinification.name !== "testCodeMinification" &&
         process.env.NODE_ENV !== "production" &&
@@ -150,7 +150,8 @@ export {
     isComputingDerivation as _isComputingDerivation,
     onReactionError,
     interceptReads as _interceptReads,
-    IComputedValueOptions
+    IComputedValueOptions,
+    _await
 } from "./internal"
 
 // Devtools support

--- a/test/base/api.js
+++ b/test/base/api.js
@@ -1,7 +1,7 @@
 import * as fs from "fs"
 const mobx = require("../../src/mobx.ts")
 
-test("correct api should be exposed", function() {
+test("correct api should be exposed", function () {
     expect(
         Object.keys(mobx)
             .filter(key => mobx[key] !== undefined)
@@ -64,7 +64,8 @@ test("correct api should be exposed", function() {
             "untracked",
             "values",
             "entries",
-            "when"
+            "when",
+            "_await"
         ].sort()
     )
 })

--- a/test/base/typescript-tests.ts
+++ b/test/base/typescript-tests.ts
@@ -25,16 +25,18 @@ import {
     decorate,
     IAtom,
     createAtom,
-    runInAction
+    runInAction,
+    flow,
+    _await
 } from "../../src/mobx"
 import * as mobx from "../../src/mobx"
 
 const v = observable.box(3)
-observe(v, () => {})
+observe(v, () => { })
 
 const a = observable([1, 2, 3])
 
-const testFunction = function(a: any) {}
+const testFunction = function (a: any) { }
 
 // lazy wrapper around yest
 
@@ -144,7 +146,7 @@ test("annotations", () => {
     t.deepEqual(order1totals, [6, 3, 9])
 
     t.equal(order1.aFunction, testFunction)
-    const x = function() {
+    const x = function () {
         return 3
     }
     order1.aFunction = x
@@ -169,7 +171,7 @@ test("scope", () => {
         y: number
     }
 
-    const Thing = function(this: any) {
+    const Thing = function (this: any) {
         extendObservable(this, {
             y: 3,
             // this will work here
@@ -233,7 +235,7 @@ test("box", () => {
         @observable height = 20
         @observable sizes = [2]
         @observable
-        someFunc = function() {
+        someFunc = function () {
             return 2
         }
         @computed
@@ -397,7 +399,7 @@ test("issue 165", () => {
     }
 
     class Card {
-        constructor(public game: Game, public id: number) {}
+        constructor(public game: Game, public id: number) { }
 
         @computed
         get isWrong() {
@@ -425,7 +427,7 @@ test("issue 165", () => {
             return report(
                 "Computing isMatchWrong",
                 this.secondCardSelected !== null &&
-                    this.firstCardSelected!.id !== this.secondCardSelected.id
+                this.firstCardSelected!.id !== this.secondCardSelected.id
             )
         }
     }
@@ -484,7 +486,7 @@ function normalizeSpyEvents(events: any[]) {
 
 test("action decorator (typescript)", () => {
     class Store {
-        constructor(private multiplier: number) {}
+        constructor(private multiplier: number) { }
 
         @action
         add(a: number, b: number): number {
@@ -514,7 +516,7 @@ test("action decorator (typescript)", () => {
 
 test("custom action decorator (typescript)", () => {
     class Store {
-        constructor(private multiplier: number) {}
+        constructor(private multiplier: number) { }
 
         @action("zoem zoem")
         add(a: number, b: number): number {
@@ -562,7 +564,7 @@ test("custom action decorator (typescript)", () => {
 
 test("action decorator on field (typescript)", () => {
     class Store {
-        constructor(private multiplier: number) {}
+        constructor(private multiplier: number) { }
 
         @action
         add = (a: number, b: number) => {
@@ -594,7 +596,7 @@ test("action decorator on field (typescript)", () => {
 
 test("custom action decorator on field (typescript)", () => {
     class Store {
-        constructor(private multiplier: number) {}
+        constructor(private multiplier: number) { }
 
         @action("zoem zoem")
         add = (a: number, b: number) => {
@@ -705,10 +707,10 @@ test("unbound methods", () => {
     class A {
         // shared across all instances
         @action
-        m1() {}
+        m1() { }
 
         // per instance
-        @action m2 = () => {}
+        @action m2 = () => { }
     }
 
     const a1 = new A()
@@ -804,8 +806,8 @@ test("enumerability", () => {
             return this.a
         } // non-enumerable, (and, ideally, on proto)
         @action
-        m() {} // non-enumerable, on proto
-        @action m2 = () => {} // non-enumerable, on self
+        m() { } // non-enumerable, on proto
+        @action m2 = () => { } // non-enumerable, on self
     }
 
     const a = new A()
@@ -1037,7 +1039,7 @@ test("484 - isObservableObject type guard includes type T", () => {
 })
 
 test("484 - isObservableObject type guard includes type IObservableObject", () => {
-    const requires_observable_object = (o: IObservableObject): void => {}
+    const requires_observable_object = (o: IObservableObject): void => { }
     const o = observable({ stuff: "things" })
 
     if (isObservableObject(o)) {
@@ -1158,7 +1160,7 @@ test("action.bound binds (TS)", () => {
 })
 
 test("803 - action.bound and action preserve type info", () => {
-    function thingThatAcceptsCallback(cb: (elem: { x: boolean }) => void) {}
+    function thingThatAcceptsCallback(cb: (elem: { x: boolean }) => void) { }
 
     thingThatAcceptsCallback(elem => {
         // console.log(elem.x) // x is boolean
@@ -1175,7 +1177,7 @@ test("803 - action.bound and action preserve type info", () => {
         return { x: "3" } as Object
     }) as () => void
 
-    const bound2 = action(function() {}) as (() => void)
+    const bound2 = action(function () { }) as (() => void)
 })
 
 test("@computed.equals (TS)", () => {
@@ -1219,7 +1221,7 @@ test("@computed.equals (TS)", () => {
 test("computed comparer works with decorate (TS)", () => {
     const sameTime = (from: Time, to: Time) => from.hour === to.hour && from.minute === to.minute
     class Time {
-        constructor(public hour: number, public minute: number) {}
+        constructor(public hour: number, public minute: number) { }
 
         get time() {
             return { hour: this.hour, minute: this.minute }
@@ -1255,7 +1257,7 @@ test("computed comparer works with decorate (TS)", () => {
 test("computed comparer works with decorate (TS)", () => {
     const sameTime = (from: Time, to: Time) => from.hour === to.hour && from.minute === to.minute
     class Time {
-        constructor(public hour: number, public minute: number) {}
+        constructor(public hour: number, public minute: number) { }
 
         get time() {
             return { hour: this.hour, minute: this.minute }
@@ -1374,7 +1376,7 @@ test("1072 - @observable without initial value and observe before first access",
     }
 
     const user = new User()
-    observe(user, "loginCount", () => {})
+    observe(user, "loginCount", () => { })
 })
 
 test("typescript - decorate works with classes", () => {
@@ -1429,7 +1431,7 @@ test("issue #1122", done => {
             },
             () => {
                 // console.log("Value getting unobserved.")
-                runInAction(() => {}) // <-- INFINITE RECURSION
+                runInAction(() => { }) // <-- INFINITE RECURSION
             }
         )
         get value() {
@@ -1464,7 +1466,7 @@ test("unread computed reads should trow with requiresReaction enabled", () => {
         a.y
     }).toThrow(/is read outside a reactive context/)
 
-    const d = mobx.reaction(() => a.y, () => {})
+    const d = mobx.reaction(() => a.y, () => { })
     expect(() => {
         a.y
     }).not.toThrow()
@@ -1491,11 +1493,11 @@ test("actions are reassignable", () => {
     // See #1398 and #1545, make actions reassignable to support stubbing
     class A {
         @action
-        m1() {}
-        @action m2 = () => {}
+        m1() { }
+        @action m2 = () => { }
         @action.bound
-        m3() {}
-        @action.bound m4 = () => {}
+        m3() { }
+        @action.bound m4 = () => { }
     }
 
     const a = new A()
@@ -1503,13 +1505,13 @@ test("actions are reassignable", () => {
     expect(isAction(a.m2)).toBe(true)
     expect(isAction(a.m3)).toBe(true)
     expect(isAction(a.m4)).toBe(true)
-    a.m1 = () => {}
+    a.m1 = () => { }
     expect(isAction(a.m1)).toBe(false)
-    a.m2 = () => {}
+    a.m2 = () => { }
     expect(isAction(a.m2)).toBe(false)
-    a.m3 = () => {}
+    a.m3 = () => { }
     expect(isAction(a.m3)).toBe(false)
-    a.m4 = () => {}
+    a.m4 = () => { }
     expect(isAction(a.m4)).toBe(false)
 })
 
@@ -1572,7 +1574,7 @@ test("it should support asyncAction as decorator (ts)", async () => {
 
 test("flow support async generators", async () => {
     if (!(Symbol as any).asyncIterator) {
-        ;(Symbol as any).asyncIterator = Symbol.for("Symbol.asyncIterator")
+        ; (Symbol as any).asyncIterator = Symbol.for("Symbol.asyncIterator")
     }
 
     async function* someNumbers() {
@@ -1584,7 +1586,7 @@ test("flow support async generators", async () => {
         yield 3
     }
 
-    const start = mobx.flow(async function*() {
+    const start = mobx.flow(async function* () {
         let total = 0
         for await (const number of someNumbers()) {
             total += number
@@ -1599,7 +1601,7 @@ test("flow support async generators", async () => {
 
 test("flow support throwing async generators", async () => {
     if (!(Symbol as any).asyncIterator) {
-        ;(Symbol as any).asyncIterator = Symbol.for("Symbol.asyncIterator")
+        ; (Symbol as any).asyncIterator = Symbol.for("Symbol.asyncIterator")
     }
 
     async function* someNumbers() {
@@ -1609,7 +1611,7 @@ test("flow support throwing async generators", async () => {
         throw "OOPS"
     }
 
-    const start = mobx.flow(async function*() {
+    const start = mobx.flow(async function* () {
         let total = 0
         for await (const number of someNumbers()) {
             total += number
@@ -1646,4 +1648,27 @@ test("verify #1528", () => {
     })
 
     expect(appState.timer).toBe(0)
+})
+
+test("new flow typings", async () => {
+    const otherFlow = flow(function* () {
+        const x = yield* _await(Promise.resolve(3))
+        return x
+    })
+
+    const otherFlow2 = flow(function* () {
+        // should work, but it is better to enforce promises on the types
+        const x = yield* _await(5 as any as Promise<number>)
+        return x
+    })
+
+    const start = flow(function* () {
+        const a = yield* _await(Promise.resolve(2))
+        const b = yield* _await(otherFlow())
+        const c = yield* _await(otherFlow2())
+        return a + b + c
+    })
+
+    const res = await start()
+    expect(res).toBe(3 + 2 + 5)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8113,10 +8113,10 @@ ts-jest@^24.0.0:
     semver "^5.5"
     yargs-parser "10.x"
 
-tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
-  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tsutils@^3.7.0:
   version "3.10.0"
@@ -8172,10 +8172,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.3.3333:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.4.tgz#aac4a08abecab8091a75f10842ffa0631818f785"
-  integrity sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==
+typescript@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
+  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
 
 uglify-js@^3.1.4:
   version "3.5.5"
@@ -8639,7 +8639,7 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^13.0.0, yargs-parser@^13.1.0:
+yargs-parser@^13.1.0:
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.0.tgz#7016b6dd03e28e1418a510e258be4bff5a31138f"
   integrity sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==


### PR DESCRIPTION
I found a way to make flows strongly typed in TS3.6

Pros:
- proper return types, proper arguments, etc.

Cons:
- requires TS3.6, so it would be a breaking change (altenatively the multiple typings per version is leveraged, using this https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#version-selection-with-typesversions )
- requires the usage of yield* and a new _await function (though yield would still work as usual, so that one wouldn't be breaking)

e.g.
```ts
test("new flow typings", async () => {
    const otherFlow = flow(function* () {
        // x is type is number
        const x = yield* _await(Promise.resolve(3))
        return x
    })

    const otherFlow2 = flow(function* () {
        // typings could be changed to make it work, 
        // but I think it is better to enforce promises on the types
        const x = yield* _await(5 as any as Promise<number>)
        return x
    })

    const start = flow(function* () {
        // a is number
        const a = yield* _await(Promise.resolve(2))
        // b is number
        const b = yield* _await(otherFlow())
        // c is number
        const c = yield* _await(otherFlow2())
        return a + b + c
    })

    // res is number
    const res = await start()
    expect(res).toBe(3 + 2 + 5)
})
```