### PR TITLE
correct spellings

### DIFF
--- a/docs/best/react.md
+++ b/docs/best/react.md
@@ -37,11 +37,11 @@ In memory that looks as follows. The green boxes indicate _observable_ propertie
 
 ![MobX reacts to changing references](../images/observed-refs.png)
 
-Now what MobX basically does is recording which _arrows_ you use in your function. After that, it will re-run whenever one of this _arrows_ changes; when they start to refer to something else.
+Now what MobX basically does is recording which _arrows_ you use in your function. After that, it will re-run whenever one of these _arrows_ changes; when they start to refer to something else.
 
 ## Examples
 
-Lets show that with a bunch of examples (based on the `message` variable defined above):
+Let's show that with a bunch of examples (based on the `message` variable defined above):
 
 #### Correct: dereference inside the tracked function
 
@@ -342,7 +342,7 @@ In general this is quite obvious and rarely causes issues.
 
 ## MobX only tracks data accessed for `observer` components if they are directly accessed by `render`
 
-A common mistake made with `observer` is that it doesnt track data that syntactically seems parent of the `observer` component,
+A common mistake made with `observer` is that it doesn't track data that syntactically seems parent of the `observer` component,
 but in practice is actually rendered out by a different component. This often happens when render callbacks of components are passed in first class to another component.
 
 Take for example the following contrived example:


### PR DESCRIPTION
Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [X] Added unit tests
* [X] Updated changelog
* [X] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [X] Added typescript typings
* [X] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
****
I forked mobx just before to contribute many thing forward.
I fixed spellings.
I don't know if you need or not, but I think better it has right spelling.
Thanks.


