### PR TITLE
expose startAction and endAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Don't use `global` and `self` keywords unless defined. Fixes [#2070](https://github.com/mobxjs/mobx/issues/2070).
 * onBecome(Un)Observed didn't trigger when using number as key of observable map. Fixes [#2067](https://github.com/mobxjs/mobx/issues/2067).
-* Exposed `startAction` and `endAction` to be able to start and action and finish it without needing a code block. This is low level stuff you shouldn't need that's mostly useful for library creators.
+* Exposed `_startAction` and `_endAction` to be able to start and action and finish it without needing a code block. This is low level stuff you shouldn't need that's mostly useful for library creators.
 
 # 5.13.0 / 4.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Don't use `global` and `self` keywords unless defined. Fixes [#2070](https://github.com/mobxjs/mobx/issues/2070).
 * onBecome(Un)Observed didn't trigger when using number as key of observable map. Fixes [#2067](https://github.com/mobxjs/mobx/issues/2067).
-* Added `startActionWithFinisher` to be able to start and action and finish it without needing a code block. Useful for library creators.
+* Exposed `startAction` and `endAction` to be able to start and action and finish it without needing a code block. Useful for library creators.
 
 # 5.13.0 / 4.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Don't use `global` and `self` keywords unless defined. Fixes [#2070](https://github.com/mobxjs/mobx/issues/2070).
 * onBecome(Un)Observed didn't trigger when using number as key of observable map. Fixes [#2067](https://github.com/mobxjs/mobx/issues/2067).
-* Exposed `startAction` and `endAction` to be able to start and action and finish it without needing a code block. Useful for library creators.
+* Exposed `startAction` and `endAction` to be able to start and action and finish it without needing a code block. This is low level stuff you shouldn't need that's mostly useful for library creators.
 
 # 5.13.0 / 4.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Don't use `global` and `self` keywords unless defined. Fixes [#2070](https://github.com/mobxjs/mobx/issues/2070).
 * onBecome(Un)Observed didn't trigger when using number as key of observable map. Fixes [#2067](https://github.com/mobxjs/mobx/issues/2067).
-
+* Added `startActionWithFinisher` to be able to start and action and finish it without needing a code block. Useful for library creators.
 
 # 5.13.0 / 4.13.0
 

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -29,8 +29,26 @@ export function createAction(actionName: string, fn: Function, ref?: Object): Fu
     return res as any
 }
 
+export function startActionWithFinisher(
+    actionName: string,
+    scope?: any,
+    args?: IArguments
+): (threw: boolean) => void {
+    const runInfo = startAction(actionName, scope, args)
+
+    return (threw: boolean) => {
+        if (threw) {
+            globalState.suppressReactionErrors = true
+            endAction(runInfo)
+            globalState.suppressReactionErrors = false
+        } else {
+            endAction(runInfo)
+        }
+    }
+}
+
 export function executeAction(actionName: string, fn: Function, scope?: any, args?: IArguments) {
-    const runInfo = startAction(actionName, fn, scope, args)
+    const runInfo = startAction(actionName, scope, args)
     let shouldSupressReactionError = true
     try {
         const res = fn.apply(scope, args)
@@ -38,7 +56,7 @@ export function executeAction(actionName: string, fn: Function, scope?: any, arg
         return res
     } finally {
         if (shouldSupressReactionError) {
-            globalState.suppressReactionErrors = shouldSupressReactionError
+            globalState.suppressReactionErrors = true
             endAction(runInfo)
             globalState.suppressReactionErrors = false
         } else {
@@ -54,12 +72,7 @@ interface IActionRunInfo {
     startTime: number
 }
 
-function startAction(
-    actionName: string,
-    fn: Function,
-    scope: any,
-    args?: IArguments
-): IActionRunInfo {
+function startAction(actionName: string, scope: any, args?: IArguments): IActionRunInfo {
     const notifySpy = isSpyEnabled() && !!actionName
     let startTime: number = 0
     if (notifySpy && process.env.NODE_ENV !== "production") {

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -29,40 +29,27 @@ export function createAction(actionName: string, fn: Function, ref?: Object): Fu
     return res as any
 }
 
-export function startActionWithFinisher(
-    actionName: string,
-    scope?: any,
-    args?: IArguments
-): (threw: boolean) => void {
-    const runInfo = startAction(actionName, scope, args)
-
-    return (threw: boolean) => {
-        runInfo.threw = threw
-        endAction(runInfo)
-    }
-}
-
 export function executeAction(actionName: string, fn: Function, scope?: any, args?: IArguments) {
     const runInfo = startAction(actionName, scope, args)
-    runInfo.threw = true
     try {
-        const res = fn.apply(scope, args)
-        runInfo.threw = false
-        return res
+        return fn.apply(scope, args)
+    } catch (err) {
+        runInfo.error = err
+        throw err
     } finally {
         endAction(runInfo)
     }
 }
 
-interface IActionRunInfo {
+export interface IActionRunInfo {
     prevDerivation: IDerivation | null
     prevAllowStateChanges: boolean
     notifySpy: boolean
     startTime: number
-    threw?: boolean
+    error?: any
 }
 
-function startAction(actionName: string, scope: any, args?: IArguments): IActionRunInfo {
+export function startAction(actionName: string, scope: any, args?: IArguments): IActionRunInfo {
     const notifySpy = isSpyEnabled() && !!actionName
     let startTime: number = 0
     if (notifySpy && process.env.NODE_ENV !== "production") {
@@ -92,7 +79,7 @@ function startAction(actionName: string, scope: any, args?: IArguments): IAction
     return runInfo
 }
 
-function endAction(runInfo: IActionRunInfo) {
+export function endAction(runInfo: IActionRunInfo) {
     if (process.env.NODE_ENV !== "production") {
         const actionStack = globalState.actionStack
         const expectedRunInfo = actionStack[actionStack.length - 1]
@@ -103,7 +90,7 @@ function endAction(runInfo: IActionRunInfo) {
         }
     }
 
-    if (runInfo.threw) {
+    if (runInfo.error !== undefined) {
         globalState.suppressReactionErrors = true
     }
     allowStateChangesEnd(runInfo.prevAllowStateChanges)

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -118,6 +118,11 @@ export class MobXGlobals {
      * they are not the cause, see: https://github.com/mobxjs/mobx/issues/1836
      */
     suppressReactionErrors = false
+
+    /*
+     * Action stack.
+     */
+    actionStack: object[] = []
 }
 
 let canMergeGlobalState = true

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -120,9 +120,14 @@ export class MobXGlobals {
     suppressReactionErrors = false
 
     /*
-     * Action stack.
+     * Current action id.
      */
-    actionStack: object[] = []
+    currentActionId = 0
+
+    /*
+     * Next action id.
+     */
+    nextActionId = 1
 }
 
 let canMergeGlobalState = true

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -151,7 +151,8 @@ export {
     isComputingDerivation as _isComputingDerivation,
     onReactionError,
     interceptReads as _interceptReads,
-    IComputedValueOptions
+    IComputedValueOptions,
+    startActionWithFinisher
 } from "./internal"
 
 // Devtools support

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -152,7 +152,9 @@ export {
     onReactionError,
     interceptReads as _interceptReads,
     IComputedValueOptions,
-    startActionWithFinisher
+    IActionRunInfo,
+    startAction,
+    endAction
 } from "./internal"
 
 // Devtools support

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -153,8 +153,8 @@ export {
     interceptReads as _interceptReads,
     IComputedValueOptions,
     IActionRunInfo,
-    startAction,
-    endAction
+    _startAction,
+    _endAction
 } from "./internal"
 
 // Devtools support

--- a/test/base/action.js
+++ b/test/base/action.js
@@ -547,3 +547,17 @@ test("error logging, #1836 - 2", () => {
 
     expect(messages).toMatchSnapshot()
 })
+
+test("startActionWithFinisher - out of order", () => {
+    const a1 = mobx.startActionWithFinisher("a1")
+    const a2 = mobx.startActionWithFinisher("a2")
+
+    expect(() => a1()).toThrow("invalid action stack")
+
+    a2()
+
+    // double finishing
+    expect(() => a2()).toThrow("invalid action stack")
+
+    a1()
+})

--- a/test/base/action.js
+++ b/test/base/action.js
@@ -549,15 +549,15 @@ test("error logging, #1836 - 2", () => {
 })
 
 test("out of order startAction / endAction", () => {
-    const a1 = mobx.startAction("a1")
-    const a2 = mobx.startAction("a2")
+    const a1 = mobx._startAction("a1")
+    const a2 = mobx._startAction("a2")
 
-    expect(() => mobx.endAction(a1)).toThrow("invalid action stack")
+    expect(() => mobx._endAction(a1)).toThrow("invalid action stack")
 
-    mobx.endAction(a2)
+    mobx._endAction(a2)
 
     // double finishing
-    expect(() => mobx.endAction(a2)).toThrow("invalid action stack")
+    expect(() => mobx._endAction(a2)).toThrow("invalid action stack")
 
-    mobx.endAction(a1)
+    mobx._endAction(a1)
 })

--- a/test/base/action.js
+++ b/test/base/action.js
@@ -548,16 +548,16 @@ test("error logging, #1836 - 2", () => {
     expect(messages).toMatchSnapshot()
 })
 
-test("startActionWithFinisher - out of order", () => {
-    const a1 = mobx.startActionWithFinisher("a1")
-    const a2 = mobx.startActionWithFinisher("a2")
+test("out of order startAction / endAction", () => {
+    const a1 = mobx.startAction("a1")
+    const a2 = mobx.startAction("a2")
 
-    expect(() => a1()).toThrow("invalid action stack")
+    expect(() => mobx.endAction(a1)).toThrow("invalid action stack")
 
-    a2()
+    mobx.endAction(a2)
 
     // double finishing
-    expect(() => a2()).toThrow("invalid action stack")
+    expect(() => mobx.endAction(a2)).toThrow("invalid action stack")
 
-    a1()
+    mobx.endAction(a1)
 })

--- a/test/base/api.js
+++ b/test/base/api.js
@@ -64,7 +64,8 @@ test("correct api should be exposed", function() {
             "untracked",
             "values",
             "entries",
-            "when"
+            "when",
+            "startActionWithFinisher"
         ].sort()
     )
 })

--- a/test/base/api.js
+++ b/test/base/api.js
@@ -65,8 +65,8 @@ test("correct api should be exposed", function() {
             "values",
             "entries",
             "when",
-            "startAction",
-            "endAction"
+            "_startAction",
+            "_endAction"
         ].sort()
     )
 })

--- a/test/base/api.js
+++ b/test/base/api.js
@@ -65,7 +65,8 @@ test("correct api should be exposed", function() {
             "values",
             "entries",
             "when",
-            "startActionWithFinisher"
+            "startAction",
+            "endAction"
         ].sort()
     )
 })


### PR DESCRIPTION
* [X] Updated changelog

Basically adds a new `startActionWithFinisher` method that allows someone to start/finish an action without needing a code block.

This is mostly useful for library creators, and probably for a future async pattern I'm investigating that doesn't rely on generators in order to get better typings in TS.

Basically on this pattern, an asyncAction would go something like this:

```ts
const myAsyncAction = asyncAction("name", async(x) => {
  // the wrapper starts the action using startActionWithFinisher
  // currentActionContextFinisher = startWithActionFinisher(...)

  // some mutating actions

  const data = await _(getDataFromBackend(x))

  // more mutating actions

  // the wrapper try/catches the whole async block, runing currentActionContextFinisher(true) if
  // throwing, (false) if not
}

// decorator version
@asyncAction
async name(x) {
  // ...
}

async function _(whateverPromise) {
  currentActionContextFinisher(false)
  currentActionContextFinisher = undefined
  try {
    const ret = await whateverPromise
  } finally {
    currentActionContextFinisher = startWithActionFinisher(...)
  }
}
```