### PR TITLE
define the name property of function return by createAction

### DIFF
--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -27,8 +27,11 @@ export function createAction(actionName: string, fn: Function, ref?: Object): Fu
         return executeAction(actionName, fn, ref || this, arguments)
     }
     ;(res as any).isMobxAction = true
-    if (process.env.NODE_ENV !== "production" && Object.getOwnPropertyDescriptor(res, "name").configurable) {
-        Object.defineProperty(res, "name", {value: actionName});
+    if (process.env.NODE_ENV !== "production") {
+        const descriptor = Object.getOwnPropertyDescriptor(res, "name");
+        if (descriptor && descriptor.configurable) {
+            Object.defineProperty(res, "name", {value: actionName});
+        }
     }
     return res as any
 }

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -27,7 +27,9 @@ export function createAction(actionName: string, fn: Function, ref?: Object): Fu
         return executeAction(actionName, fn, ref || this, arguments)
     }
     ;(res as any).isMobxAction = true
-    Object.defineProperty(res, "name", {value: actionName});
+    if (process.env.NODE_ENV !== "production" && Object.getOwnPropertyDescriptor(res, "name").configurable) {
+        Object.defineProperty(res, "name", {value: actionName});
+    }
     return res as any
 }
 

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -27,6 +27,7 @@ export function createAction(actionName: string, fn: Function, ref?: Object): Fu
         return executeAction(actionName, fn, ref || this, arguments)
     }
     ;(res as any).isMobxAction = true
+    Object.defineProperty(res, "name", {value: actionName});
     return res as any
 }
 


### PR DESCRIPTION
currently all functions returned by createAction are named res, which is fine but isn't helpful. I'd like to define the name of the function to be the actionName.

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [ ] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
