### PR TITLE
Remove obsolete donation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ _Tip: Consider using the faster and smaller ES6 build if targetting a modern env
 
 -   All modern browsers are supported.
 -   MobX >=5 runs on any browser with [ES6 proxy support](https://kangax.github.io/compat-table/es6/#test-Proxy). In practice this means:
-    - no Internet Explorer (Edge is fine)
-    - Node.js >= 6  
+    -   no Internet Explorer (Edge is fine)
+    -   Node.js >= 6
 -   React Native:
-    - iOS >= 10
-    - Android from RN 0.59 (or with manual JavaScript core [upgrade](https://github.com/react-community/jsc-android-buildscripts#how-to-use-it-with-my-react-native-app))
-    - Hermes runtime is [not supported](https://github.com/facebook/hermes/issues/28) (Use MobX 4 instead)
+    -   iOS >= 10
+    -   Android from RN 0.59 (or with manual JavaScript core [upgrade](https://github.com/react-community/jsc-android-buildscripts#how-to-use-it-with-my-react-native-app))
+    -   Hermes runtime is [not supported](https://github.com/facebook/hermes/issues/28) (Use MobX 4 instead)
 -   MobX 4 runs on any ES5 browser and will be actively maintained. The MobX 4 and 5 api's are the same and semantically can achieve the same, but MobX 4 has some [limitations](#mobx-4-vs-mobx-5).
 -   The latest versions of libraries like mobx-react, mobx-react-lite, mobx-state-tree etc are kept compatible with both MobX 4 and 5.
 
@@ -429,10 +429,6 @@ Support us with a monthly donation and help us continue our activities. [[Become
 <a href="https://opencollective.com/mobx/backer/57/website" target="_blank"><img src="https://opencollective.com/mobx/backer/57/avatar.svg"></a>
 <a href="https://opencollective.com/mobx/backer/58/website" target="_blank"><img src="https://opencollective.com/mobx/backer/58/avatar.svg"></a>
 <a href="https://opencollective.com/mobx/backer/59/website" target="_blank"><img src="https://opencollective.com/mobx/backer/59/avatar.svg"></a>
-
-One time donations through paypal are welcome as well and are recorded in the [sponsors](sponsors.md) list.
-
-[![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://mobxjs.github.io/mobx/donate.html)
 
 ### Sponsors
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -420,10 +420,6 @@ Support us with a monthly donation and help us continue our activities. [[Become
 <a href="https://opencollective.com/mobx/backer/58/website" target="_blank"><img src="https://opencollective.com/mobx/backer/58/avatar.svg"></a>
 <a href="https://opencollective.com/mobx/backer/59/website" target="_blank"><img src="https://opencollective.com/mobx/backer/59/avatar.svg"></a>
 
-One time donations through paypal are welcome as well and are recorded in the [sponsors](sponsors.md) list.
-
-[![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://mobxjs.github.io/mobx/donate.html)
-
 ### Sponsors
 
 Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/mobx#sponsor)]


### PR DESCRIPTION
The obsolete section about card donations leading to a non-existing page. Since OpenCollective is preferred, let's keep it less confusing :)

@mweststrate I also wonder, those list of backers/sponsors is generated somehow? If not, there might be some people missing, right?