### PR TITLE
Docs: Fix title of "@observable" page

### DIFF
--- a/docs/refguide/observable-decorator.md
+++ b/docs/refguide/observable-decorator.md
@@ -1,5 +1,5 @@
 ---
-title: @obsevable
+title: @observable
 sidebar_label: @observable
 hide_title: true
 ---


### PR DESCRIPTION
The page title for the @observable page in the "Making Things observable"-section was missing an 'r'.

Thanks for the wonderful work that you all do :raised_hands: 