### PR TITLE
Fix error when interception is removed in intercept (#1950)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Fixed a possible issue with action stack errors and multiple mobx versions installed at the same time [#2135](https://github.com/mobxjs/mobx/issues/2135).
 * Added `comparer.shallow` for shallow object/array comparisons [#1561](https://github.com/mobxjs/mobx/issues/1561).
+* Fixed disposing an interception within an interception throwing an error [#1950](https://github.com/mobxjs/mobx/issues/1950)
 
 # 5.14.0 / 4.14.0
 

--- a/src/types/intercept-utils.ts
+++ b/src/types/intercept-utils.ts
@@ -29,16 +29,15 @@ export function interceptChange<T>(
 ): T | null {
     const prevU = untrackedStart()
     try {
-        const interceptors = interceptable.interceptors
-        if (interceptors)
-            for (let i = 0, l = interceptors.length; i < l; i++) {
-                change = interceptors[i](change)
-                invariant(
-                    !change || (change as any).type,
-                    "Intercept handlers should return nothing or a change object"
-                )
-                if (!change) break
-            }
+        const interceptors = [...(interceptable.interceptors || [])]
+        for (let i = 0, l = interceptors.length; i < l; i++) {
+            change = interceptors[i](change)
+            invariant(
+                !change || (change as any).type,
+                "Intercept handlers should return nothing or a change object"
+            )
+            if (!change) break
+        }
         return change
     } finally {
         untrackedEnd(prevU)

--- a/src/types/intercept-utils.ts
+++ b/src/types/intercept-utils.ts
@@ -29,6 +29,7 @@ export function interceptChange<T>(
 ): T | null {
     const prevU = untrackedStart()
     try {
+        // Interceptor can modify the array, copy it to avoid concurrent modification, see #1950
         const interceptors = [...(interceptable.interceptors || [])]
         for (let i = 0, l = interceptors.length; i < l; i++) {
             change = interceptors[i](change)

--- a/test/base/intercept.js
+++ b/test/base/intercept.js
@@ -196,3 +196,32 @@ test("intercept map", () => {
     expect(a.has("b")).toBe(false)
     expect(a.get("c")).toBe(undefined)
 })
+
+test("intercept prevent dispose from breaking current execution", () => {
+    const a = m.observable.box(1)
+
+    intercept(a, c => {
+        c.newValue += 1
+        return c
+    })
+
+    const d = intercept(a, c => {
+        d()
+        expect(c.object).toBe(a)
+        c.newValue *= 2
+        return c
+    })
+
+    intercept(a, c => {
+        c.newValue += 1
+        return c
+    })
+
+    a.set(2)
+
+    expect(a.get()).toBe(7)
+
+    a.set(2)
+
+    expect(a.get()).toBe(4)
+})


### PR DESCRIPTION
Currently, when disposing an interceptor within the provided callback, mobx throws an error stating that `interceptors[i] is not a function`. With this PR it will continue the execution by cloning the interceptors array before the execution loop.
Fixes #1950 

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [x] Added unit tests
* [x] Updated changelog
* [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
