### PR TITLE
fix Flow typings for flow()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+-   Fixed flow typings for Facebook's Flow. A new `CancellablePromise` is exported.
+
 # 5.14.2
 
 -   Fixed installation issue trying to run `postinstall` hook for a website [#2165](https://github.com/mobxjs/mobx/issues/2165).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
--   Fixed flow typings for Facebook's Flow. A new `CancellablePromise` is exported.
+-   Fixed flow typings for Facebook's Flow. A new `CancellablePromise` Flow type is exported.
 
 # 5.14.2
 

--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -479,10 +479,6 @@ export type CancellablePromise<T> = Promise<T> & { cancel: () => void }
 declare export function flow<T>(
     fn: (...args: any[]) => Generator<any, T | Promise<T>, any>
 ): (...args: any[]) => CancellablePromise<T>
-declare export function flow<T>(
-    name: string,
-    fn: (...args: any[]) => Generator<any, T | Promise<T>, any>
-): (...args: any[]) => CancellablePromise<T>
 
 declare export function keys<K>(map: ObservableMap<K, any>): K[]
 declare export function keys(obj: any): string[]

--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -475,11 +475,12 @@ declare export function createAtom(
 
 declare export function decorate<T>(target: T, decorators: any): T
 
-declare export function flow<T>(fn: (...args: any[]) => T): (...args: any[]) => Promise<T>
+export type CancellablePromise<T> = Promise<T> & { cancel: () => void }
+declare export function flow<T>(fn: (...args: any[]) => Generator<any, T | Promise<T>, any>): (...args: any[]) => CancellablePromise<T>
 declare export function flow<T>(
     name: string,
-    fn: (...args: any[]) => T
-): (...args: any[]) => Promise<T>
+    fn: (...args: any[]) => Generator<any, T | Promise<T>, any>
+): (...args: any[]) => CancellablePromise<T>
 
 declare export function keys<K>(map: ObservableMap<K, any>): K[]
 declare export function keys(obj: any): string[]

--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -476,7 +476,9 @@ declare export function createAtom(
 declare export function decorate<T>(target: T, decorators: any): T
 
 export type CancellablePromise<T> = Promise<T> & { cancel: () => void }
-declare export function flow<T>(fn: (...args: any[]) => Generator<any, T | Promise<T>, any>): (...args: any[]) => CancellablePromise<T>
+declare export function flow<T>(
+    fn: (...args: any[]) => Generator<any, T | Promise<T>, any>
+): (...args: any[]) => CancellablePromise<T>
 declare export function flow<T>(
     name: string,
     fn: (...args: any[]) => Generator<any, T | Promise<T>, any>

--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -476,9 +476,58 @@ declare export function createAtom(
 declare export function decorate<T>(target: T, decorators: any): T
 
 export type CancellablePromise<T> = Promise<T> & { cancel: () => void }
+
 declare export function flow<T>(
-    fn: (...args: any[]) => Generator<any, T | Promise<T>, any>
-): (...args: any[]) => CancellablePromise<T>
+    fn: () => Generator<any, T | Promise<T>, any> | AsyncGenerator<any, T | Promise<T>, any>
+): () => CancellablePromise<T>
+declare export function flow<T, A>(
+    fn: (A) => Generator<any, T | Promise<T>, any> | AsyncGenerator<any, T | Promise<T>, any>
+): A => CancellablePromise<T>
+declare export function flow<T, A, B>(
+    fn: (A, B) => Generator<any, T | Promise<T>, any> | AsyncGenerator<any, T | Promise<T>, any>
+): (A, B) => CancellablePromise<T>
+declare export function flow<T, A, B, C>(
+    fn: (A, B, C) => Generator<any, T | Promise<T>, any> | AsyncGenerator<any, T | Promise<T>, any>
+): (A, B, C) => CancellablePromise<T>
+declare export function flow<T, A, B, C, D>(
+    fn: (
+        A,
+        B,
+        C,
+        D
+    ) => Generator<any, T | Promise<T>, any> | AsyncGenerator<any, T | Promise<T>, any>
+): (A, B, C, D) => CancellablePromise<T>
+declare export function flow<T, A, B, C, D, E>(
+    fn: (
+        A,
+        B,
+        C,
+        D,
+        E
+    ) => Generator<any, T | Promise<T>, any> | AsyncGenerator<any, T | Promise<T>, any>
+): (A, B, C, D, E) => CancellablePromise<T>
+declare export function flow<T, A, B, C, D, E, F>(
+    fn: (
+        A,
+        B,
+        C,
+        D,
+        E,
+        F
+    ) => Generator<any, T | Promise<T>, any> | AsyncGenerator<any, T | Promise<T>, any>
+): (A, B, C, D, E, F) => CancellablePromise<T>
+declare export function flow<T, A, B, C, D, E, F, G, H>(
+    fn: (
+        A,
+        B,
+        C,
+        D,
+        E,
+        F,
+        G,
+        H
+    ) => Generator<any, T | Promise<T>, any> | AsyncGenerator<any, T | Promise<T>, any>
+): (A, B, C, D, E, F, G, H) => CancellablePromise<T>
 
 declare export function keys<K>(map: ObservableMap<K, any>): K[]
 declare export function keys(obj: any): string[]


### PR DESCRIPTION
This fixes flow typings for flow() which are now fundamentally broken. Flow() returns a cancellable promise (fixed) and a signature that is not valid was removed. 

usage,  if the suggestion from https://github.com/mobxjs/mobx/pull/2164#issuecomment-544466503 is accepted

```js
// @flow
import { flow, type CancellablePromise } from 'mobx';

export class FlowTest {
  promise: CancellablePromise<string>;

  constructor() {
    this.promise = this.fetchSomeString(2);
    this.promise.cancel();
  }

  fetchSomeString = flow<string, number>(function*(pageNumber: number) {
    try {
      const projects = yield this.fetchStringSomehow(pageNumber);
      return projects;
    } catch (error) {
      return '123';
    }
  });

  fetchStringSomehow = (pageNumber: mixed): Promise<string> => {
    console.log(pageNumber);
    return Promise.resolve('123');
  };
}

```

PR checklist - I think none of these apply for this PR. 

* [ ] Added unit tests
* [ ] Updated changelog
* [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
