### PR TITLE
Fix 2165 use prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.14.2 / 4.14.2
+
+-   Changed website dependency install to `prepare` step from `postinstall` [#2165](https://github.com/mobxjs/mobx/issues/2165).
+
 # 5.14.1 / 4.14.1
 
 -   Fixed a possible issue with action stack errors and multiple mobx versions installed at the same time [#2135](https://github.com/mobxjs/mobx/issues/2135).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "description": "Simple, scalable state management.",
   "main": "lib/mobx.js",
   "umd:main": "lib/mobx.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx",
-  "version": "5.14.2",
+  "version": "5.14.1",
   "description": "Simple, scalable state management.",
   "main": "lib/mobx.js",
   "umd:main": "lib/mobx.umd.js",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "docs:build": "yarn --cwd website build",
     "docs:start": "yarn --cwd website start",
     "docs:publish": "yarn --cwd website publish-gh-pages",
-    "postinstall": "yarn --cwd website install",
+    "prepare": "yarn --cwd website install",
     "dedup": "npx yarn-deduplicate -s fewer yarn.lock"
   },
   "repository": {


### PR DESCRIPTION
Changes `postinstall` to `prepare` for website dependency install. Bumps to 5.14.2 so this can be republished, and added changelog entry.

* [x] Updated changelog

Fixes #2165 