### PR TITLE
cancelled flow() to reject with new FlowCancellationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
--   added `FLOW_CANCELLED` export for `"FLOW_CANCELLED"` constant representing flow cancellation
+-   cancelled flows now reject with a `FlowCancellationError` instance whose error message is the same as in previous versions (`"FLOW_CANCELLED"`) so this is not breaking.
 -   Fix running mobx in web worker [#2184](https://github.com/mobxjs/mobx/pull/2184/files)
 -   Fixed flow typings for Facebook's Flow. A new `CancellablePromise` Flow type is exported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+-   added `FLOW_CANCELLED` export for `"FLOW_CANCELLED"` constant representing flow cancellation
 -   Fix running mobx in web worker [#2184](https://github.com/mobxjs/mobx/pull/2184/files)
 -   Fixed flow typings for Facebook's Flow. A new `CancellablePromise` Flow type is exported.
 

--- a/docs/best/actions.md
+++ b/docs/best/actions.md
@@ -210,4 +210,4 @@ class Store {
 
 #### Flows can be cancelled
 
-Flows are cancellable, that means that you can call `cancel()` on the returned promise. This will stop the generator immediately, but any finally clause will still be processed. The returned promise itself will reject with an instance of `FlowCancellationError` (this error is exported from the package) whose message is `FLOW_CANCELLED`.
+Flows are cancellable, that means that you can call `cancel()` on the returned promise. This will stop the generator immediately, but any finally clause will still be processed. The returned promise itself will reject with an instance of `FlowCancellationError` (this error is exported from the package) whose message is `FLOW_CANCELLED`. Also exported is a `isFlowCancellationError(error)` helper that returns true if and only if the provided argument is a `FlowCancellationError`.

--- a/docs/best/actions.md
+++ b/docs/best/actions.md
@@ -210,4 +210,4 @@ class Store {
 
 #### Flows can be cancelled
 
-Flows are cancellable, that means that you can call `cancel()` on the returned promise. This will stop the generator immediately, but any finally clause will still be processed. The returned promise itself will reject with `FLOW_CANCELLED`.
+Flows are cancellable, that means that you can call `cancel()` on the returned promise. This will stop the generator immediately, but any finally clause will still be processed. The returned promise itself will reject with `FLOW_CANCELLED` constant which is exported from the package.

--- a/docs/best/actions.md
+++ b/docs/best/actions.md
@@ -210,4 +210,4 @@ class Store {
 
 #### Flows can be cancelled
 
-Flows are cancellable, that means that you can call `cancel()` on the returned promise. This will stop the generator immediately, but any finally clause will still be processed. The returned promise itself will reject with `FLOW_CANCELLED` constant which is exported from the package.
+Flows are cancellable, that means that you can call `cancel()` on the returned promise. This will stop the generator immediately, but any finally clause will still be processed. The returned promise itself will reject with an instance of `FlowCancellationError` (this error is exported from the package) whose message is `FLOW_CANCELLED`.

--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -529,6 +529,8 @@ declare export function flow<T, A, B, C, D, E, F, G, H>(
     ) => Generator<any, T | Promise<T>, any> | AsyncGenerator<any, T | Promise<T>, any>
 ): (A, B, C, D, E, F, G, H) => CancellablePromise<T>
 
+declare export function isFlowCancellationError(error: Error): boolean
+
 declare export function keys<K>(map: ObservableMap<K, any>): K[]
 declare export function keys(obj: any): string[]
 

--- a/src/api/flow.ts
+++ b/src/api/flow.ts
@@ -8,6 +8,10 @@ export class FlowCancellationError extends Error {
     }
 }
 
+export function isFlowCancellationError(error: Error) {
+    return error instanceof FlowCancellationError
+}
+
 export type CancellablePromise<T> = Promise<T> & { cancel(): void }
 
 export interface FlowYield {

--- a/src/api/flow.ts
+++ b/src/api/flow.ts
@@ -2,6 +2,8 @@ import { action, fail, noop } from "../internal"
 
 let generatorId = 0
 
+export const FLOW_CANCELLED = "FLOW_CANCELLED"
+
 export type CancellablePromise<T> = Promise<T> & { cancel(): void }
 
 export interface FlowYield {
@@ -106,7 +108,7 @@ export function flow<R, Args extends any[]>(
                 yieldedPromise.then(noop, noop)
                 cancelPromise(yieldedPromise) // maybe it can be cancelled :)
                 // reject our original promise
-                rejector(new Error("FLOW_CANCELLED"))
+                rejector(new Error(FLOW_CANCELLED))
             } catch (e) {
                 rejector(e) // there could be a throwing finally block
             }

--- a/src/api/flow.ts
+++ b/src/api/flow.ts
@@ -2,7 +2,11 @@ import { action, fail, noop } from "../internal"
 
 let generatorId = 0
 
-export const FLOW_CANCELLED = "FLOW_CANCELLED"
+export class FlowCancellationError extends Error {
+    constructor() {
+        super("FLOW_CANCELLED")
+    }
+}
 
 export type CancellablePromise<T> = Promise<T> & { cancel(): void }
 
@@ -108,7 +112,7 @@ export function flow<R, Args extends any[]>(
                 yieldedPromise.then(noop, noop)
                 cancelPromise(yieldedPromise) // maybe it can be cancelled :)
                 // reject our original promise
-                rejector(new Error(FLOW_CANCELLED))
+                rejector(new FlowCancellationError())
             } catch (e) {
                 rejector(e) // there could be a throwing finally block
             }

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -132,7 +132,7 @@ export {
     onBecomeObserved,
     onBecomeUnobserved,
     flow,
-    FLOW_CANCELLED,
+    FlowCancellationError,
     toJS,
     trace,
     IObserverTree,

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -133,6 +133,7 @@ export {
     onBecomeUnobserved,
     flow,
     FlowCancellationError,
+    isFlowCancellationError,
     toJS,
     trace,
     IObserverTree,

--- a/src/mobx.ts
+++ b/src/mobx.ts
@@ -132,6 +132,7 @@ export {
     onBecomeObserved,
     onBecomeUnobserved,
     flow,
+    FLOW_CANCELLED,
     toJS,
     trace,
     IObserverTree,

--- a/test/base/api.js
+++ b/test/base/api.js
@@ -20,6 +20,7 @@ test("correct api should be exposed", function() {
             "decorate",
             "extendObservable",
             "flow",
+            "FLOW_CANCELLED",
             "get",
             "_getAdministration",
             "getAtom",

--- a/test/base/api.js
+++ b/test/base/api.js
@@ -20,7 +20,7 @@ test("correct api should be exposed", function() {
             "decorate",
             "extendObservable",
             "flow",
-            "FLOW_CANCELLED",
+            "FlowCancellationError",
             "get",
             "_getAdministration",
             "getAtom",

--- a/test/base/api.js
+++ b/test/base/api.js
@@ -21,6 +21,7 @@ test("correct api should be exposed", function() {
             "extendObservable",
             "flow",
             "FlowCancellationError",
+            "isFlowCancellationError",
             "get",
             "_getAdministration",
             "getAtom",

--- a/test/base/flow.js
+++ b/test/base/flow.js
@@ -1,5 +1,5 @@
 import * as mobx from "../../src/mobx.ts"
-import { flow, FlowCancellationError } from "../../src/mobx"
+import { flow, FlowCancellationError, isFlowCancellationError } from "../../src/mobx"
 
 function delay(time, value, shouldThrow = false) {
     return new Promise((resolve, reject) => {
@@ -176,6 +176,11 @@ test("FlowCancellationError sanity check", () => {
     expect(cancellationError).toBeInstanceOf(Error)
     expect(cancellationError).toBeInstanceOf(FlowCancellationError)
     expect(cancellationError.message).toBe("FLOW_CANCELLED")
+})
+
+test("isFlowCancellationError returns true iff the argument is a FlowCancellationError", () => {
+    expect(isFlowCancellationError(new FlowCancellationError())).toBe(true)
+    expect(isFlowCancellationError(new Error("some random error"))).toBe(false)
 })
 
 test("flows can be cancelled - 1 - uncaught cancellation", done => {

--- a/test/base/flow.js
+++ b/test/base/flow.js
@@ -1,5 +1,5 @@
 import * as mobx from "../../src/mobx.ts"
-import { flow } from "../../src/mobx"
+import { flow, FlowCancellationError } from "../../src/mobx"
 
 function delay(time, value, shouldThrow = false) {
     return new Promise((resolve, reject) => {
@@ -160,7 +160,25 @@ function stripEvents(events) {
     })
 }
 
-test("flows can be cancelled - 1 - uncatched cancellation", done => {
+test("flows are cancelled with an instance of FlowCancellationError", async () => {
+    const start = flow(function*() {
+        yield Promise.resolve()
+    })
+
+    const promise = start()
+
+    promise.cancel()
+    await expect(promise).rejects.toBeInstanceOf(FlowCancellationError)
+})
+
+test("FlowCancellationError sanity check", () => {
+    const cancellationError = new FlowCancellationError()
+    expect(cancellationError).toBeInstanceOf(Error)
+    expect(cancellationError).toBeInstanceOf(FlowCancellationError)
+    expect(cancellationError.message).toBe("FLOW_CANCELLED")
+})
+
+test("flows can be cancelled - 1 - uncaught cancellation", done => {
     let steps = 0
     const start = flow(function*() {
         steps = 1
@@ -209,7 +227,7 @@ test("flows can be cancelled - 2 - finally clauses are run", done => {
     promise.cancel()
 })
 
-test("flows can be cancelled - 3 - throw in finally should be catched", done => {
+test("flows can be cancelled - 3 - throw in finally should be caught", done => {
     const counter = mobx.observable({ counter: 0 })
     const d = mobx.reaction(() => counter.counter, () => {})
     mobx.configure({ enforceActions: "observed" })
@@ -244,7 +262,7 @@ test("flows can be cancelled - 4 - pending Promise will be ignored", done => {
     let steps = 0
     const start = flow(function*() {
         steps = 1
-        yield Promise.reject("This won't be catched anywhere!") // cancel will resolve this flow before this one is throw, so this promise goes uncatched
+        yield Promise.reject("This won't be caught anywhere!") // cancel will resolve this flow before this one is throw, so this promise goes uncaught
         steps = 2
     })
 


### PR DESCRIPTION
This exports FLOW_CANCELLED because it's a little unusual to have to introduce the constant to our code base instead of importing it from mobx.


