### PR TITLE
Observable decorator on computed symbol keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 -   Fixed flow typings for Facebook's Flow. A new `CancellablePromise` Flow type is exported.
 
+-   Added support for symbol keys on observable properties.
+
 # 5.14.2
 
 -   Fixed installation issue trying to run `postinstall` hook for a website [#2165](https://github.com/mobxjs/mobx/issues/2165).

--- a/src/api/observable.ts
+++ b/src/api/observable.ts
@@ -79,7 +79,7 @@ function getEnhancerFromOptions(options: CreateObservableOptions): IEnhancer<any
  */
 function createObservable(v: any, arg2?: any, arg3?: any) {
     // @observable someProp;
-    if (typeof arguments[1] === "string") {
+    if (typeof arguments[1] === "string" || typeof arguments[1] === "symbol") {
         return deepDecorator.apply(null, arguments as any)
     }
 

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -57,8 +57,10 @@ export function initializeInstance(target: DecoratorTarget) {
     const decorators = target[mobxPendingDecorators]
     if (decorators) {
         addHiddenProp(target, mobxDidRunLazyInitializersSymbol, true)
-        for (let key in decorators) {
-            const d = decorators[key]
+        // Build property key array from both strings and symbols
+        const keys = [...Object.getOwnPropertySymbols(decorators), ...Object.keys(decorators)]
+        for (const key of keys) {
+            const d = decorators[key as any]
             d.propertyCreator(target, d.prop, d.descriptor, d.decoratorTarget, d.decoratorArguments)
         }
     }

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -113,7 +113,8 @@ export function createPropDecorator(
 
 export function quacksLikeADecorator(args: IArguments): boolean {
     return (
-        ((args.length === 2 || args.length === 3) && typeof args[1] === "string") ||
+        ((args.length === 2 || args.length === 3) &&
+            (typeof args[1] === "string" || typeof args[1] === "symbol")) ||
         (args.length === 4 && args[3] === true)
     )
 }

--- a/test/base/typescript-tests.ts
+++ b/test/base/typescript-tests.ts
@@ -1669,9 +1669,9 @@ test("#2159 - computed property keys", () => {
     })
 
     t.deepEqual(events, [
-        "new symbol value", // original symbol
-        "original symbol value", // new symbol
-        "new string value", // old string
-        "original string value" // new string
+        "new symbol value", // new symbol
+        "original symbol value", // original symbol
+        "new string value", // new string
+        "original string value" // original string
     ])
 })

--- a/test/base/typescript-tests.ts
+++ b/test/base/typescript-tests.ts
@@ -1669,9 +1669,9 @@ test("#2159 - computed property keys", () => {
     })
 
     t.deepEqual(events, [
-        "new symbol value", // old total
-        "original symbol value", // new total
-        "new string value", // old price
-        "original string value" // new price
+        "new symbol value", // original symbol
+        "original symbol value", // new symbol
+        "new string value", // old string
+        "original string value" // new string
     ])
 })

--- a/test/base/typescript-tests.ts
+++ b/test/base/typescript-tests.ts
@@ -1647,3 +1647,31 @@ test("verify #1528", () => {
 
     expect(appState.timer).toBe(0)
 })
+
+test("#2159 - computed property keys", () => {
+    const testSymbol = Symbol("test symbol")
+    const testString = "testString"
+
+    class TestClass {
+        @observable [testSymbol] = "original symbol value";
+        @observable [testString] = "original string value"
+    }
+
+    const o = new TestClass()
+
+    const events: any[] = []
+    observe(o, testSymbol, ev => events.push(ev.newValue, ev.oldValue))
+    observe(o, testString, ev => events.push(ev.newValue, ev.oldValue))
+
+    runInAction(() => {
+        o[testSymbol] = "new symbol value"
+        o[testString] = "new string value"
+    })
+
+    t.deepEqual(events, [
+        "new symbol value", // old total
+        "original symbol value", // new total
+        "new string value", // old price
+        "original string value" // new price
+    ])
+})


### PR DESCRIPTION
Resolves #2159 

1. I added a new test in `typescript-tests` that tries to use computed property keys... see test `#2159 - computed property keys`. Please validate this test is a supported use case (I think it is). It was failing before this change (see original issue for details). By the way, I verified the test passes if the key isn't a computed symbol to make sure the test itself is true.

2. Changed `decorators.ts` and `observable.ts` to apply their logic to symbol keyed properties in addition to string keyed properties.

PR checklist:

* [X] Added unit tests
* [X] Updated changelog
* [X] ~Updated `/docs`. For new functionality, at least `API.md` should be updated~
I don't think this fix needs any doc updates.
* [X] ~Added typescript typings~
As all changes were made in TS files, no need.
* [X] Verified that there is no significant performance drop (`npm run perf`)
Note: I didn't see `npm run perf` but I tried out `npm run test:performance`
Current develop branch: 66.22 real        67.58 user
This PR: 62.46 real        63.76 user