### PR TITLE
allow mobx to run in web worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+-   Allow mobx to run in web worker
 -   Fixed flow typings for Facebook's Flow. A new `CancellablePromise` Flow type is exported.
 
 # 5.14.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
--   Allow mobx to run in web worker
+-   Fix running mobx in web worker [#2184](https://github.com/mobxjs/mobx/pull/2184/files)
 -   Fixed flow typings for Facebook's Flow. A new `CancellablePromise` Flow type is exported.
 
 # 5.14.2

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -200,6 +200,7 @@ export function resetGlobalState() {
 }
 
 declare const window: any
+declare const self: any
 
 const mockGlobal = {}
 
@@ -209,6 +210,9 @@ export function getGlobal() {
     }
     if (typeof global !== "undefined") {
         return global
+    }
+    if (typeof self !== "undefined") {
+        return self
     }
     return mockGlobal
 }

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -141,6 +141,24 @@ export class MobXGlobals {
     suppressReactionErrors = false
 }
 
+declare const window: any
+declare const self: any
+
+const mockGlobal = {}
+
+export function getGlobal() {
+    if (typeof window !== "undefined") {
+        return window
+    }
+    if (typeof global !== "undefined") {
+        return global
+    }
+    if (typeof self !== "undefined") {
+        return self
+    }
+    return mockGlobal
+}
+
 let canMergeGlobalState = true
 let isolateCalled = false
 
@@ -197,22 +215,4 @@ export function resetGlobalState() {
     for (let key in defaultGlobals)
         if (persistentKeys.indexOf(key as any) === -1) globalState[key] = defaultGlobals[key]
     globalState.allowStateChanges = !globalState.enforceActions
-}
-
-declare const window: any
-declare const self: any
-
-const mockGlobal = {}
-
-export function getGlobal() {
-    if (typeof window !== "undefined") {
-        return window
-    }
-    if (typeof global !== "undefined") {
-        return global
-    }
-    if (typeof self !== "undefined") {
-        return self
-    }
-    return mockGlobal
 }


### PR DESCRIPTION
currently `getGlobal` is first invoked from an iife which initializes `globalState`, which means `mockGlobal` is not yet initialized.

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
