### PR TITLE
Getting Started: Fixed that "get next item" just returns first item!

### DIFF
--- a/website/static/getting-started.html
+++ b/website/static/getting-started.html
@@ -102,7 +102,8 @@ class TodoStore {
 	report() {
 		if (this.todos.length === 0)
 			return "<none>";
-		return `Next todo: "${this.todos.find(todo => todo.completed === false).task}". ` +
+		const nextTodo = this.todos.find(todo => todo.completed === false);
+		return `Next todo: "${nextTodo ? nextTodo.task : "<none>"}". ` +
 			`Progress: ${this.completedTodosCount}/${this.todos.length}`;
 	}
 
@@ -177,7 +178,8 @@ class ObservableTodoStore {
 	@computed get report() {
 		if (this.todos.length === 0)
 			return "<none>";
-		return `Next todo: "${this.todos.find(todo => todo.completed === false).task}". ` +
+		const nextTodo = this.todos.find(todo => todo.completed === false);
+		return `Next todo: "${nextTodo ? nextTodo.task : "<none>"}". ` +
 			`Progress: ${this.completedTodosCount}/${this.todos.length}`;
 	}
 

--- a/website/static/getting-started.html
+++ b/website/static/getting-started.html
@@ -102,7 +102,7 @@ class TodoStore {
 	report() {
 		if (this.todos.length === 0)
 			return "<none>";
-		return `Next todo: "${this.todos[0].task}". ` +
+		return `Next todo: "${this.todos.find(todo => todo.completed === false).task}". ` +
 			`Progress: ${this.completedTodosCount}/${this.todos.length}`;
 	}
 
@@ -177,7 +177,7 @@ class ObservableTodoStore {
 	@computed get report() {
 		if (this.todos.length === 0)
 			return "<none>";
-		return `Next todo: "${this.todos[0].task}". ` +
+		return `Next todo: "${this.todos.find(todo => todo.completed === false).task}". ` +
 			`Progress: ${this.completedTodosCount}/${this.todos.length}`;
 	}
 


### PR DESCRIPTION
The "getting started" documentation page has the example code just return the first todo, whenever it logs the "next item". Instead, it should search for the first todo item that is not yet completed.

Screenshot of old behavior (which doesn't make sense, in code or in what is displayed):
![](https://i.imgur.com/k2mBPPC.png)