### PR TITLE
Make initial values of observable set accept readonly array

### DIFF
--- a/src/types/observableset.ts
+++ b/src/types/observableset.ts
@@ -29,7 +29,7 @@ import {
 
 const ObservableSetMarker = {}
 
-export type IObservableSetInitialValues<T> = Set<T> | T[]
+export type IObservableSetInitialValues<T> = Set<T> | readonly T[]
 
 export type ISetDidChange<T = any> =
     | {


### PR DESCRIPTION
`ObservableSet` doesn't need to change the initial values array, so it makes sense to allow passing in a `readonly` one.