### PR TITLE
do not extend Error for FlowCancellationError

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -530,6 +530,7 @@ declare export function flow<T, A, B, C, D, E, F, G, H>(
 ): (A, B, C, D, E, F, G, H) => CancellablePromise<T>
 
 declare export function isFlowCancellationError(error: Error): boolean
+declare export class FlowCancellationError extends Error {}
 
 declare export function keys<K>(map: ObservableMap<K, any>): K[]
 declare export function keys(obj: any): string[]

--- a/src/api/flow.ts
+++ b/src/api/flow.ts
@@ -2,11 +2,10 @@ import { action, fail, noop } from "../internal"
 
 let generatorId = 0
 
-export class FlowCancellationError extends Error {
-    constructor() {
-        super("FLOW_CANCELLED")
-    }
+export function FlowCancellationError() {
+    this.message = "FLOW_CANCELLED"
 }
+FlowCancellationError.prototype = Object.create(Error.prototype)
 
 export function isFlowCancellationError(error: Error) {
     return error instanceof FlowCancellationError


### PR DESCRIPTION
in some environments, `isFlowCancellationError()` will return false even if it should return true. This change is already present in the mobx 4 branch, as seen here https://github.com/mobxjs/mobx/pull/2190/files because the tests were failing without it. On master, different impl is used, as mentioned in https://github.com/mobxjs/mobx/pull/2172#issuecomment-551166733.

Also added forgotten typings for FB's Flow 