### PR TITLE
add FlowCancellationError to Flow typings

### DIFF
--- a/flow-typed/mobx.js
+++ b/flow-typed/mobx.js
@@ -531,6 +531,7 @@ declare export function flow<T, A, B, C, D, E, F, G, H>(
 ): (A, B, C, D, E, F, G, H) => CancellablePromise<T>
 
 declare export function isFlowCancellationError(error: Error): boolean
+declare export class FlowCancellationError extends Error {}
 
 declare export function keys<K>(map: ObservableMap<K, any>): K[]
 declare export function keys(obj: any): string[]


### PR DESCRIPTION
I somehow forgot to add this in https://github.com/mobxjs/mobx/pull/2190/files

this is the same as https://github.com/mobxjs/mobx/pull/2203 but the change how `FlowCancellationError` is implemented is not needed in mobx 4 branch, since it's already done this way in mobx 4.