### PR TITLE
Type tests for the action callback arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@typescript-eslint/eslint-plugin": "^1.4.2",
     "babel-jest": "^24.5.0",
     "chalk": "^1.1.3",
+    "conditional-type-checks": "^1.0.4",
     "coveralls": "^3.0.3",
     "eslint": "^5.15.2",
     "flow-bin": "^0.59.0",

--- a/test/base/typescript-tests.ts
+++ b/test/base/typescript-tests.ts
@@ -28,6 +28,7 @@ import {
     runInAction
 } from "../../src/mobx"
 import * as mobx from "../../src/mobx"
+import { assert, IsExact } from "conditional-type-checks"
 
 const v = observable.box(3)
 observe(v, () => {})
@@ -1175,7 +1176,7 @@ test("803 - action.bound and action preserve type info", () => {
         return { x: "3" } as Object
     }) as () => void
 
-    const bound2 = action(function() {}) as (() => void)
+    const bound2 = action(function() {}) as () => void
 })
 
 test("@computed.equals (TS)", () => {
@@ -1657,7 +1658,6 @@ test("type of flows that return promises", async () => {
 
     const n: number = await f()
     expect(n).toBe(5)
-
 })
 
 test("#2159 - computed property keys", () => {
@@ -1686,4 +1686,76 @@ test("#2159 - computed property keys", () => {
         "new string value", // new string
         "original string value" // original string
     ])
+})
+
+test("type inference of the action callback", () => {
+    function test1arg(fn: (a: number) => any) {}
+
+    function test2args(fn: (a: string, b: number) => any) {}
+
+    function test7args(
+        fn: (a: object, b: number, c: number, d: string, e: string, f: number, g: string) => any
+    ) {}
+
+    // Nameless actions
+    test1arg(
+        action(a1 => {
+            assert<IsExact<typeof a1, number>>(true)
+        })
+    )
+    test2args(
+        action((a1, a2) => {
+            assert<IsExact<typeof a1, string>>(true)
+            assert<IsExact<typeof a2, number>>(true)
+        })
+    )
+    test7args(
+        action((a1, a2, a3, a4, a5, a6, a7) => {
+            assert<IsExact<typeof a1, object>>(true)
+            assert<IsExact<typeof a2, number>>(true)
+            assert<IsExact<typeof a3, number>>(true)
+            assert<IsExact<typeof a4, string>>(true)
+            assert<IsExact<typeof a5, string>>(true)
+            assert<IsExact<typeof a6, number>>(true)
+            assert<IsExact<typeof a7, string>>(true)
+        })
+    )
+
+    // Named actions
+    test1arg(
+        action("named action", a1 => {
+            assert<IsExact<typeof a1, number>>(true)
+        })
+    )
+    test2args(
+        action("named action", (a1, a2) => {
+            assert<IsExact<typeof a1, string>>(true)
+            assert<IsExact<typeof a2, number>>(true)
+        })
+    )
+    test7args(
+        action("named action", (a1, a2, a3, a4, a5, a6, a7) => {
+            assert<IsExact<typeof a1, object>>(true)
+            assert<IsExact<typeof a2, number>>(true)
+            assert<IsExact<typeof a3, number>>(true)
+            assert<IsExact<typeof a4, string>>(true)
+            assert<IsExact<typeof a5, string>>(true)
+            assert<IsExact<typeof a6, number>>(true)
+            assert<IsExact<typeof a7, string>>(true)
+        })
+    )
+
+    // Promises
+    Promise.resolve(1).then(
+        action(arg => {
+            assert<IsExact<typeof arg, number>>(true)
+        })
+    )
+
+    // Promises with names actions
+    Promise.resolve(1).then(
+        action("named action", arg => {
+            assert<IsExact<typeof arg, number>>(true)
+        })
+    )
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,6 +2171,11 @@ concat-stream@1.6.2, concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+conditional-type-checks@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/conditional-type-checks/-/conditional-type-checks-1.0.4.tgz#491e2752006e1e049a11c8c26592b1b8535efbf9"
+  integrity sha512-3oKsfmRWuVLZ8WBmhHkCqLsa01mdX+H4aUkxesOXGYPAA2xJtrrlEfM5imvsz4Wv55RPaiSofgYEXikUQEW96g==
+
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"


### PR DESCRIPTION
* [x] Added unit tests
* [ ] Updated changelog
* [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
* [x] Added typescript typings
* [x] Verified that there is no significant performance drop (`npm run perf`)

As discussed in https://github.com/mobxjs/mobx/pull/2213 we decided to add TS type tests to prevent typing regressions in the future. Currently, tests are failing because types of the action callback arguments are inferred incorrectly: they are all converted to 'unknown' type. This fix https://github.com/mobxjs/mobx/pull/2213 will make tests pass.