### PR TITLE
doc: Update wrong links in README.html file

### DIFF
--- a/README.html
+++ b/README.html
@@ -124,7 +124,7 @@
 <li><a href="https://www.youtube.com/watch?v=K8dr8BMU7-8">Screencast: intro to MobX</a> - 8m</li>
 <li><a href="https://www.youtube.com/watch?v=ApmSsu3qnf0&amp;feature=youtu.be">Talk: State Management Is Easy, React Amsterdam 2016 conf</a> (<a href="https://speakerdeck.com/mweststrate/state-management-is-easy-introduction-to-mobx">slides</a>)</li>
 </ul></li>
-<li><a href="http://mobxjs.github.io/mobx/faq/boilerplates.html">Boilerplates and related projects</a></li>
+<li><a href="https://github.com/mobxjs/awesome-mobx#boilerplates">Boilerplates and related projects</a></li>
 <li>More tutorials, blogs, videos, and other helpful resources can be found on the <a href="https://github.com/mobxjs/awesome-mobx#awesome-mobx">MobX awesome list</a></li>
 </ul>
 <h2><a class="anchor" aria-hidden="true" id="introduction"></a><a href="#introduction" aria-hidden="true" class="hash-link"><svg class="hash-link-icon" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>Introduction</h2>
@@ -282,11 +282,11 @@ Use them to your advantage; they will help you to structure your code better and
 <h2><a class="anchor" aria-hidden="true" id="further-resources-and-documentation"></a><a href="#further-resources-and-documentation" aria-hidden="true" class="hash-link"><svg class="hash-link-icon" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>Further resources and documentation</h2>
 <ul>
 <li><img src="assets/book.jpg" height="80px"/> <a href="https://books.google.nl/books?id=ALFmDwAAQBAJ&amp;pg=PP1&amp;lpg=PP1&amp;dq=michel+weststrate+mobx+quick+start+guide:+supercharge+the+client+state+in+your+react+apps+with+mobx&amp;source=bl&amp;ots=D460fxti0F&amp;sig=ivDGTxsPNwlOjLHrpKF1nweZFl8&amp;hl=nl&amp;sa=X&amp;ved=2ahUKEwiwl8XO--ncAhWPmbQKHWOYBqIQ6AEwAnoECAkQAQ#v=onepage&amp;q=michel%20weststrate%20mobx%20quick%20start%20guide%3A%20supercharge%20the%20client%20state%20in%20your%20react%20apps%20with%20mobx&amp;f=false">The MobX book</a> by Pavan Podila and Michel Weststrate (which despite its name is in-depth!)</li>
-<li><a href="http://mobxjs.github.io/mobx/faq/blogs.html">MobX homepage</a></li>
+<li><a href="https://mobx.js.org">MobX homepage</a></li>
 <li><a href="http://mobxjs.github.io/mobx/refguide/api.html">API overview</a></li>
-<li><a href="http://mobxjs.github.io/mobx/faq/blogs.html">Tutorials, Blogs &amp; Videos</a></li>
-<li><a href="http://mobxjs.github.io/mobx/faq/boilerplates.html">Boilerplates</a></li>
-<li><a href="http://mobxjs.github.io/mobx/faq/related.html">Related projects</a></li>
+<li><a href="https://github.com/mobxjs/awesome-mobx#tutorials">Tutorials, Blogs &amp; Videos</a></li>
+<li><a href="https://github.com/mobxjs/awesome-mobx#boilerplates">Boilerplates</a></li>
+<li><a href="https://github.com/mobxjs/awesome-mobx#related-projects-and-utilities">Related projects</a></li>
 </ul>
 <h2><a class="anchor" aria-hidden="true" id="what-others-are-saying"></a><a href="#what-others-are-saying" aria-hidden="true" class="hash-link"><svg class="hash-link-icon" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>What others are saying...</h2>
 <blockquote>


### PR DESCRIPTION
The README.html file for the website has wrong links, which on click lead to 404 error pages

![boilerplate](https://user-images.githubusercontent.com/13250741/69788341-4ff6a000-11e4-11ea-9152-121a7a753714.png)
