### PR TITLE
Makes different collection types non-equal in shallow and structural comparers

### DIFF
--- a/src/utils/eq.ts
+++ b/src/utils/eq.ts
@@ -27,9 +27,6 @@ function eq(a: any, b: any, depth: number, aStack?: any[], bStack?: any[]) {
     const type = typeof a
     if (type !== "function" && type !== "object" && typeof b != "object") return false
 
-    // Unwrap any wrapped objects.
-    a = unwrap(a)
-    b = unwrap(b)
     // Compare `[[Class]]` names.
     const className = toString.call(a)
     if (className !== toString.call(b)) return false
@@ -58,6 +55,9 @@ function eq(a: any, b: any, depth: number, aStack?: any[], bStack?: any[]) {
                 typeof Symbol !== "undefined" && Symbol.valueOf.call(a) === Symbol.valueOf.call(b)
             )
     }
+    // Unwrap any wrapped objects.
+    a = unwrap(a)
+    b = unwrap(b)
 
     const areArrays = className === "[object Array]"
     if (!areArrays) {

--- a/test/base/extras.js
+++ b/test/base/extras.js
@@ -512,4 +512,18 @@ test("comparer.shallow should work", () => {
     expect(sh([1, 2, 3, 4], [1, 2, 3])).toBe(false)
     expect(sh([1, 2, 3], [1, 2, 3, 4])).toBe(false)
     expect(sh([{}, 2, 3], [{}, 2, 3])).toBe(false)
+
+    // Different types should not be equal.
+    expect(sh({}, [])).toBe(false)
+    expect(sh({}, new Set())).toBe(false)
+    expect(sh({}, new Map())).toBe(false)
+    expect(sh([], {})).toBe(false)
+    expect(sh([], new Set())).toBe(false)
+    expect(sh([], new Map())).toBe(false)
+    expect(sh(new Set(), {})).toBe(false)
+    expect(sh(new Set(), [])).toBe(false)
+    expect(sh(new Set(), new Map())).toBe(false)
+    expect(sh(new Map(), {})).toBe(false)
+    expect(sh(new Map(), [])).toBe(false)
+    expect(sh(new Map(), new Set())).toBe(false)
 })


### PR DESCRIPTION
https://github.com/mobxjs/mobx/issues/2239

* [x] Added unit tests
* [ ] Updated changelog
* [ ] Verified that there is no significant performance drop (`npm run perf`)
