### PR TITLE
Fixes #2230 - computedvalue: throw error object instead of string when options is e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.15.2 / 4.15.2
+
+-   Fixes #2230 - computedvalue: throw error object instead of string when options is empty [#2243](https://github.com/mobxjs/mobx/pull/2243)
+
 # 5.15.1 / 4.15.1
 
 -   Make initial values of observable set accept readonly array [#2202](https://github.com/mobxjs/mobx/pull/2202)

--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -105,8 +105,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
      * This is useful for working with vectors, mouse coordinates etc.
      */
     constructor(options: IComputedValueOptions<T>) {
-        if (process.env.NODE_ENV !== "production" && !options.get)
-            throw "[mobx] missing option for computed: get"
+        invariant(options.get, "missing option for computed: get")
         this.derivation = options.get!
         this.name = options.name || "ComputedValue@" + getNextId()
         if (options.set) this.setter = createAction(this.name + "-setter", options.set) as any


### PR DESCRIPTION
…mpty

Fixes #2230 

PR checklist:

* [ ] Added unit tests
* [X] Updated changelog
* [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)
