### PR TITLE
Fixes #2230 - computedvalue: throw error object instead of string whe…

### DIFF
--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -107,8 +107,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
      * This is useful for working with vectors, mouse coordinates etc.
      */
     constructor(options: IComputedValueOptions<T>) {
-        if (process.env.NODE_ENV !== "production" && !options.get)
-            return fail("missing option for computed: get")
+        invariant(options.get, "missing option for computed: get")
         this.derivation = options.get!
         this.name = options.name || "ComputedValue@" + getNextId()
         if (options.set) this.setter = createAction(this.name + "-setter", options.set) as any


### PR DESCRIPTION
…n options is empty

Related PR: https://github.com/mobxjs/mobx/pull/2243

Fixes #2230 

PR checklist:

* [ ] Added unit tests
* [X] Updated changelog
* [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)
