### PR TITLE
extendObservable: remove constraint for existing property for mobx4

### DIFF
--- a/src/api/extendobservable.ts
+++ b/src/api/extendobservable.ts
@@ -67,10 +67,6 @@ export function extendObservable<A extends Object, B extends Object>(
         for (let key in properties) {
             const descriptor = Object.getOwnPropertyDescriptor(properties, key)!
             if (process.env.NODE_ENV !== "production") {
-                if (Object.getOwnPropertyDescriptor(target, key))
-                    fail(
-                        `'extendObservable' can only be used to introduce new properties. Use 'set' or 'decorate' instead. The property '${key}' already exists on '${target}'`
-                    )
                 if (isComputed(descriptor.value))
                     fail(
                         `Passing a 'computed' as initial property value is no longer supported by extendObservable. Use a getter or decorator instead`

--- a/test/base/extendObservable.js
+++ b/test/base/extendObservable.js
@@ -1,0 +1,162 @@
+// @ts-check
+
+import {
+    action,
+    autorun,
+    isObservable,
+    isObservableProp,
+    isComputedProp,
+    isAction,
+    extendObservable
+} from "../../src/mobx"
+
+test("extendObservable should work", function() {
+    class Box {
+        // @ts-ignore
+        uninitialized
+        height = 20
+        sizes = [2]
+        someFunc = function() {
+            return 2
+        }
+        get width() {
+            return (
+                this.undeclared *
+                this.height *
+                this.sizes.length *
+                this.someFunc() *
+                (this.uninitialized ? 2 : 1)
+            )
+        }
+        addSize() {
+            // @ts-ignore
+            this.sizes.push([3])
+            // @ts-ignore
+            this.sizes.push([4])
+        }
+        constructor() {
+            this.undeclared = 1
+        }
+    }
+
+    const box = new Box()
+
+    extendObservable(box, {
+        height: 20,
+        sizes: [2],
+        get someFunc() {
+            return 2
+        },
+        width: 40
+    })
+
+    expect(isObservableProp(box, "height")).toBe(true)
+    expect(isObservableProp(box, "sizes")).toBe(true)
+    expect(isObservable(box.sizes)).toBe(true)
+    expect(isObservableProp(box, "someFunc")).toBe(true)
+    expect(isComputedProp(box, "someFunc")).toBe(true)
+    expect(isObservableProp(box, "width")).toBe(true)
+
+    const ar = []
+
+    autorun(() => {
+        ar.push(box.width)
+    })
+
+    expect(ar.slice()).toEqual([40])
+})
+
+test("extendObservable should work with plain object", function() {
+    const box = {
+        /** @type {boolean | undefined} */
+        uninitialized: undefined,
+        height: 20,
+        sizes: [2],
+        someFunc: function() {
+            return 2
+        },
+        get width() {
+            return (
+                this.undeclared *
+                this.height *
+                this.sizes.length *
+                this.someFunc() *
+                (this.uninitialized ? 2 : 1)
+            )
+        },
+        addSize() {
+            // @ts-ignore
+            this.sizes.push([3])
+            // @ts-ignore
+            this.sizes.push([4])
+        }
+    }
+
+    box.undeclared = 1
+
+    extendObservable(box, {
+        height: 20,
+        sizes: [2],
+        get someFunc() {
+            return 2
+        },
+        width: 40
+    })
+
+    expect(isObservableProp(box, "height")).toBe(true)
+    expect(isObservableProp(box, "sizes")).toBe(true)
+    expect(isObservable(box.sizes)).toBe(true)
+    expect(isObservableProp(box, "someFunc")).toBe(true)
+    expect(isComputedProp(box, "someFunc")).toBe(true)
+    expect(isObservableProp(box, "width")).toBe(true)
+
+    const ar = []
+
+    autorun(() => {
+        ar.push(box.width)
+    })
+
+    expect(ar.slice()).toEqual([40])
+})
+
+test("extendObservable should apply specified decorators", function() {
+    const box = {
+        /** @type {boolean | undefined} */
+        uninitialized: undefined,
+        height: 20,
+        sizes: [2],
+        someFunc: function() {
+            return 2
+        },
+        get width() {
+            return (
+                this.undeclared *
+                this.height *
+                this.sizes.length *
+                this.someFunc() *
+                (this.uninitialized ? 2 : 1)
+            )
+        },
+        addSize() {
+            // @ts-ignore
+            this.sizes.push([3])
+            // @ts-ignore
+            this.sizes.push([4])
+        }
+    }
+
+    box.undeclared = 1
+
+    extendObservable(
+        box,
+        {
+            someFunc: function() {
+                return 2
+            }
+        },
+        { someFunc: action }
+    )
+
+    expect(isAction(box.someFunc)).toBe(true)
+    expect(box.someFunc()).toEqual(2)
+})

--- a/test/base/makereactive.js
+++ b/test/base/makereactive.js
@@ -228,7 +228,11 @@ test("observable5", function() {
         return 3
     }
     x.nonReactive = three
-    expect(b.toArray()).toEqual([[17, f, 17], [18, f, 18], [18, three, 3]])
+    expect(b.toArray()).toEqual([
+        [17, f, 17],
+        [18, f, 18],
+        [18, three, 3]
+    ])
 })
 
 test("flat array", function() {
@@ -645,11 +649,6 @@ test("double declare property", () => {
     mobx.extendObservable(o, {
         a: 5
     })
-    expect(() => {
-        mobx.extendObservable(o, {
-            a: 3
-        })
-    }).toThrow(/can only be used to introduce new properties/)
     expect(() => {
         mobx.extendObservable(
             o,

--- a/test/base/observables.js
+++ b/test/base/observables.js
@@ -1344,7 +1344,11 @@ test("atom events #427", () => {
     let stop = 0
     let runs = 0
 
-    const a = mobx.createAtom("test", () => start++, () => stop++)
+    const a = mobx.createAtom(
+        "test",
+        () => start++,
+        () => stop++
+    )
     expect(a.reportObserved()).toEqual(false)
 
     expect(start).toBe(0)
@@ -1693,12 +1697,18 @@ test("computed equals function only invoked when necessary", () => {
 
         // Another value change will cause a comparison
         right.set("F")
-        expect(comparisons).toEqual([{ from: "ab", to: "cb" }, { from: "de", to: "df" }])
+        expect(comparisons).toEqual([
+            { from: "ab", to: "cb" },
+            { from: "de", to: "df" }
+        ])
 
         // Becoming unobserved, then observed won't cause a comparison
         disposeAutorun()
         disposeAutorun = mobx.autorun(() => values.push(combinedToLowerCase.get()))
-        expect(comparisons).toEqual([{ from: "ab", to: "cb" }, { from: "de", to: "df" }])
+        expect(comparisons).toEqual([
+            { from: "ab", to: "cb" },
+            { from: "de", to: "df" }
+        ])
 
         expect(values).toEqual(["ab", "cb", "de", "df", "df"])
 
@@ -1765,23 +1775,6 @@ test("Issue 1120 - isComputed should return false for a non existing property", 
     expect(mobx.isComputedProp(observable({}), "x")).toBe(false)
 })
 
-test("It should not be possible to redefine a computed property", () => {
-    const a = observable({
-        width: 10,
-        get surface() {
-            return this.width
-        }
-    })
-
-    expect(() => {
-        mobx.extendObservable(a, {
-            get surface() {
-                return this.width * 2
-            }
-        })
-    }).toThrow(/'extendObservable' can only be used to introduce new properties/)
-})
-
 test("extendObservable should not be able to set a computed property", () => {
     expect(() => {
         observable({
@@ -1828,7 +1821,10 @@ test("computed comparer works with decorate (plain)", () => {
     time.minute = 0
     expect(changes).toEqual([{ hour: 9, minute: 0 }])
     time.hour = 10
-    expect(changes).toEqual([{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    expect(changes).toEqual([
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 }
+    ])
     time.minute = 30
     expect(changes).toEqual([
         { hour: 9, minute: 0 },
@@ -1867,7 +1863,10 @@ test("computed comparer works with decorate (plain) - 2", () => {
     time.minute = 0
     expect(changes).toEqual([{ hour: 9, minute: 0 }])
     time.hour = 10
-    expect(changes).toEqual([{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    expect(changes).toEqual([
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 }
+    ])
     time.minute = 30
     expect(changes).toEqual([
         { hour: 9, minute: 0 },
@@ -1902,7 +1901,10 @@ test("computed comparer works with decorate (plain) - 3", () => {
     time.minute = 0
     expect(changes).toEqual([{ hour: 9, minute: 0 }])
     time.hour = 10
-    expect(changes).toEqual([{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    expect(changes).toEqual([
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 }
+    ])
     time.minute = 30
     expect(changes).toEqual([
         { hour: 9, minute: 0 },
@@ -2084,7 +2086,10 @@ test("tuples", () => {
     const myStuff = tuple(1, 3)
     const events = []
 
-    mobx.reaction(() => myStuff[0], val => events.push(val))
+    mobx.reaction(
+        () => myStuff[0],
+        val => events.push(val)
+    )
     myStuff[1] = 17 // should not react
     myStuff[0] = 2 // should react
     expect(events).toEqual([2])

--- a/test/base/typescript-tests.ts
+++ b/test/base/typescript-tests.ts
@@ -212,22 +212,6 @@ const state: any = observable({
     authToken: null
 })
 
-test("issue8", () => {
-    t.throws(() => {
-        class LoginStoreTest {
-            loggedIn2: boolean = false
-            constructor() {
-                extendObservable(this, {
-                    get loggedIn2() {
-                        return true
-                    }
-                })
-            }
-        }
-        const store = new LoginStoreTest()
-    }, /'extendObservable' can only be used to introduce new properties/)
-})
-
 test("box", () => {
     class Box {
         @observable uninitialized: any
@@ -1206,7 +1190,10 @@ test("@computed.equals (TS)", () => {
     time.minute = 0
     t.deepEqual(changes, [{ hour: 9, minute: 0 }])
     time.hour = 10
-    t.deepEqual(changes, [{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    t.deepEqual(changes, [
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 }
+    ])
     time.minute = 30
     t.deepEqual(changes, [
         { hour: 9, minute: 0 },
@@ -1242,7 +1229,10 @@ test("computed comparer works with decorate (TS)", () => {
     time.minute = 0
     t.deepEqual(changes, [{ hour: 9, minute: 0 }])
     time.hour = 10
-    t.deepEqual(changes, [{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    t.deepEqual(changes, [
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 }
+    ])
     time.minute = 30
     t.deepEqual(changes, [
         { hour: 9, minute: 0 },
@@ -1278,7 +1268,10 @@ test("computed comparer works with decorate (TS)", () => {
     time.minute = 0
     t.deepEqual(changes, [{ hour: 9, minute: 0 }])
     time.hour = 10
-    t.deepEqual(changes, [{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    t.deepEqual(changes, [
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 }
+    ])
     time.minute = 30
     t.deepEqual(changes, [
         { hour: 9, minute: 0 },
@@ -1323,7 +1316,10 @@ test("computed comparer works with decorate (TS) - 2", () => {
     time.minute = 0
     t.deepEqual(changes, [{ hour: 9, minute: 0 }])
     time.hour = 10
-    t.deepEqual(changes, [{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    t.deepEqual(changes, [
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 }
+    ])
     time.minute = 30
     t.deepEqual(changes, [
         { hour: 9, minute: 0 },
@@ -1358,7 +1354,10 @@ test("computed comparer works with decorate (TS) - 3", () => {
     time.minute = 0
     t.deepEqual(changes, [{ hour: 9, minute: 0 }])
     time.hour = 10
-    t.deepEqual(changes, [{ hour: 9, minute: 0 }, { hour: 10, minute: 0 }])
+    t.deepEqual(changes, [
+        { hour: 9, minute: 0 },
+        { hour: 10, minute: 0 }
+    ])
     time.minute = 30
     t.deepEqual(changes, [
         { hour: 9, minute: 0 },
@@ -1465,7 +1464,10 @@ test("unread computed reads should trow with requiresReaction enabled", () => {
         a.y
     }).toThrow(/is read outside a reactive context/)
 
-    const d = mobx.reaction(() => a.y, () => {})
+    const d = mobx.reaction(
+        () => a.y,
+        () => {}
+    )
     expect(() => {
         a.y
     }).not.toThrow()


### PR DESCRIPTION
Same as https://github.com/mobxjs/mobx/pull/2252 but for mobx4.