### PR TITLE
Fix broken mixed-versions test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,14 @@ jobs:
                   paths:
                       - ./coverage
 
+    test-mixed:
+        executor: my-executor
+        steps:
+            - attach_workspace:
+                  at: .
+
+            - run: yarn test:mixed-versions
+
     test-size:
         executor: my-executor
         steps:
@@ -124,6 +132,9 @@ workflows:
                   requires:
                       - build
             - test-coverage:
+                  requires:
+                      - build
+            - test-mixed:
                   requires:
                       - build
             - test-size:

--- a/test/mixed-versions/mixed-versions.js
+++ b/test/mixed-versions/mixed-versions.js
@@ -9,7 +9,7 @@ try {
     child_process.execSync("yarn small-build", { stdio: "inherit" })
 }
 
-test.only("two versions should not work together by default", () => {
+test("two versions should not work together by default", () => {
     expect(global.__mobxInstanceCount).toBe(2)
     expect(global.__mobxGlobals).not.toBe(undefined)
 

--- a/test/mixed-versions/state-sharing.js
+++ b/test/mixed-versions/state-sharing.js
@@ -19,7 +19,7 @@ function testOutput(cmd, expected) {
     })
 }
 
-describe.skip("it should handle multiple instances with the correct warnings", () => {
+describe("it should handle multiple instances with the correct warnings", () => {
     testOutput(
         'require("../../");global.__mobxGlobals.version = -1; require("../../lib/mobx.umd.js")',
         "There are multiple, different versions of MobX active. Make sure MobX is loaded only once"


### PR DESCRIPTION
As part of combining V4 as V5 into a "master" branch, I've found out that these tests weren't part of the CI before and are failing now. Hopefully, someone can make some sense of it and come up with a fix.