### PR TITLE
fix: ObservableMap.delete should respect strict mode

### DIFF
--- a/src/v5/types/observablemap.ts
+++ b/src/v5/types/observablemap.ts
@@ -148,6 +148,7 @@ export class ObservableMap<K = any, V = any>
     }
 
     delete(key: K): boolean {
+        checkIfStateModificationsAreAllowed(this._keysAtom)
         if (hasInterceptors(this)) {
             const change = interceptChange<IMapWillChange<K, V>>(this, {
                 type: "delete",

--- a/test/v5/base/map.js
+++ b/test/v5/base/map.js
@@ -573,6 +573,14 @@ test("issue 940, should not be possible to change maps outside strict mode", () 
             m.set("x", 1)
         }).toThrowError(/Since strict-mode is enabled/)
 
+        expect(() => {
+            m.set("x", 2)
+        }).toThrowError(/Since strict-mode is enabled/)
+
+        expect(() => {
+            m.delete("x")
+        }).toThrowError(/Since strict-mode is enabled/)
+
         d()
     } finally {
         mobx.configure({ enforceActions: "never" })


### PR DESCRIPTION
Oversight in fix for #940, delete wasn't reporting in strict mode.