### PR TITLE
ObservableMap - replace _keys array with _keysAtom

### DIFF
--- a/src/v4/api/object-api.ts
+++ b/src/v4/api/object-api.ts
@@ -26,7 +26,7 @@ export function keys(obj: any): any {
         return ((obj as any) as IIsObservableObject).$mobx.getKeys()
     }
     if (isObservableMap(obj)) {
-        return (obj as any)._keys.slice()
+        return iteratorToArray(obj.keys())
     }
     if (isObservableSet(obj)) {
         return iteratorToArray(obj.keys())

--- a/src/v4/types/observablemap.ts
+++ b/src/v4/types/observablemap.ts
@@ -10,8 +10,8 @@ import {
     IInterceptable,
     IListenable,
     ObservableValue,
-    IObservableArray,
-    ObservableArray,
+    checkIfStateModificationsAreAllowed,
+    createAtom,
     referenceEnhancer,
     IEnhancer,
     deepEnhancer,
@@ -24,7 +24,6 @@ import {
     notifyListeners,
     spyReportEnd,
     globalState,
-    iteratorSymbol,
     toStringTagSymbol,
     makeIterable,
     untracked,
@@ -33,7 +32,8 @@ import {
     registerInterceptor,
     declareIterator,
     onBecomeUnobserved,
-    convertToMap
+    convertToMap,
+    iteratorToArray
 } from "../internal"
 
 export interface IKeyValueMap<V = any> {
@@ -83,9 +83,7 @@ export class ObservableMap<K = any, V = any>
     $mobx = ObservableMapMarker
     private _data: Map<K, ObservableValue<V>>
     private _hasMap: Map<K, ObservableValue<boolean>> // hasMap, not hashMap >-).
-    private _keys: IObservableArray<K> = <any>(
-        new ObservableArray(undefined, referenceEnhancer, `${this.name}.keys()`, true)
-    )
+    private _keysAtom = createAtom(`${this.name}.keys()`)
     interceptors
     changeListeners
     dehancer: any;
@@ -153,6 +151,7 @@ export class ObservableMap<K = any, V = any>
     }
 
     delete(key: K): boolean {
+        checkIfStateModificationsAreAllowed(this._keysAtom)
         if (hasInterceptors(this)) {
             const change = interceptChange<IMapWillChange<K, V>>(this, {
                 type: "delete",
@@ -176,7 +175,7 @@ export class ObservableMap<K = any, V = any>
 
             if (notifySpy) spyReportStart({ ...change, name: this.name, key })
             transaction(() => {
-                this._keys.remove(key)
+                this._keysAtom.reportChanged()
                 this._updateHasMapEntry(key, false)
                 const observable = this._data.get(key)!
                 observable.setNewValue(undefined as any)
@@ -220,6 +219,7 @@ export class ObservableMap<K = any, V = any>
     }
 
     private _addValue(key: K, newValue: V) {
+        checkIfStateModificationsAreAllowed(this._keysAtom)
         transaction(() => {
             const observable = new ObservableValue(
                 newValue,
@@ -230,7 +230,7 @@ export class ObservableMap<K = any, V = any>
             this._data.set(key, observable)
             newValue = (observable as any).value // value might have been changed
             this._updateHasMapEntry(key, true)
-            this._keys.push(key)
+            this._keysAtom.reportChanged()
         })
         const notifySpy = isSpyEnabled()
         const notify = hasListeners(this)
@@ -261,16 +261,18 @@ export class ObservableMap<K = any, V = any>
     }
 
     keys(): IterableIterator<K> {
-        return (this._keys[iteratorSymbol()] as any)()
+        this._keysAtom.reportObserved()
+        return this._data.keys()
     }
 
     values(): IterableIterator<V> {
         const self = this
         let nextIndex = 0
+        const keys = iteratorToArray(this.keys())
         return makeIterable({
             next() {
-                return nextIndex < self._keys.length
-                    ? { value: self.get(self._keys[nextIndex++])!, done: false }
+                return nextIndex < keys.length
+                    ? { value: self.get(keys[nextIndex++])!, done: false }
                     : { value: undefined as any, done: true }
             }
         })
@@ -279,10 +281,11 @@ export class ObservableMap<K = any, V = any>
     entries(): IterableIterator<IMapEntry<K, V>> {
         const self = this
         let nextIndex = 0
+        const keys = iteratorToArray(this.keys())
         return makeIterable({
             next: function() {
-                if (nextIndex < self._keys.length) {
-                    const key = self._keys[nextIndex++]
+                if (nextIndex < keys.length) {
+                    const key = keys[nextIndex++]
                     return {
                         value: [key, self.get(key)!] as [K, V],
                         done: false
@@ -294,7 +297,7 @@ export class ObservableMap<K = any, V = any>
     }
 
     forEach(callback: (value: V, key: K, object: Map<K, V>) => void, thisArg?) {
-        this._keys.forEach(key => callback.call(thisArg, this.get(key)!, key, this))
+        for (const [key, value] of this) callback.call(thisArg, value, key, this)
     }
 
     /** Merge another object into this object, returns this. */
@@ -320,7 +323,7 @@ export class ObservableMap<K = any, V = any>
     clear() {
         transaction(() => {
             untracked(() => {
-                this._keys.slice().forEach(key => this.delete(key))
+                for (const key of this.keys()) this.delete(key)
             })
         })
     }
@@ -328,37 +331,32 @@ export class ObservableMap<K = any, V = any>
     replace(values: ObservableMap<K, V> | IKeyValueMap<V> | any): ObservableMap<K, V> {
         transaction(() => {
             const replacementMap = convertToMap(values)
-            const oldKeys = this._keys
-            const newKeys: Array<any> = Array.from(replacementMap.keys())
-            let keysChanged = false
+            const orderedData = new Map()
+            const oldKeys = iteratorToArray(this.keys())
+            const newKeys: Array<any> = iteratorToArray(replacementMap.keys())
             for (let i = 0; i < oldKeys.length; i++) {
                 const oldKey = oldKeys[i]
                 // key order change
                 if (oldKeys.length === newKeys.length && oldKey !== newKeys[i]) {
-                    keysChanged = true
+                    this._keysAtom.reportChanged()
                 }
                 // deleted key
                 if (!replacementMap.has(oldKey)) {
-                    keysChanged = true
                     this.delete(oldKey)
                 }
             }
             replacementMap.forEach((value, key) => {
-                // new key
-                if (!this._data.has(key)) {
-                    keysChanged = true
-                }
                 this.set(key, value)
+                orderedData.set(key, this._data.get(key))
             })
-            if (keysChanged) {
-                this._keys.replace(newKeys)
-            }
+            this._data = orderedData
         })
         return this
     }
 
     get size(): number {
-        return this._keys.length
+        this._keysAtom.reportObserved()
+        return this._data.size
     }
 
     /**
@@ -368,9 +366,10 @@ export class ObservableMap<K = any, V = any>
      */
     toPOJO(): IKeyValueMap<V> {
         const res: IKeyValueMap<V> = {}
-        this._keys.forEach(
-            key => (res[typeof key === "symbol" ? <any>key : stringifyKey(key)] = this.get(key)!)
-        )
+        for (const [key, value] of this) {
+            // We lie about symbol key types due to https://github.com/Microsoft/TypeScript/issues/1863
+            res[typeof key === "symbol" ? <any>key : stringifyKey(key)] = value
+        }
         return res
     }
 
@@ -379,9 +378,7 @@ export class ObservableMap<K = any, V = any>
      * Note that the values migth still be observable. For a deep clone use mobx.toJS.
      */
     toJS(): Map<K, V> {
-        const res: Map<K, V> = new Map()
-        this._keys.forEach(key => res.set(key, this.get(key)!))
-        return res
+        return new Map(this)
     }
 
     toJSON(): IKeyValueMap<V> {
@@ -393,7 +390,9 @@ export class ObservableMap<K = any, V = any>
         return (
             this.name +
             "[{ " +
-            this._keys.map(key => `${stringifyKey(key)}: ${"" + this.get(key)}`).join(", ") +
+            iteratorToArray(this.keys())
+                .map(key => `${stringifyKey(key)}: ${"" + this.get(key)}`)
+                .join(", ") +
             " }]"
         )
     }

--- a/src/v4/types/observablemap.ts
+++ b/src/v4/types/observablemap.ts
@@ -369,7 +369,7 @@ export class ObservableMap<K = any, V = any>
      */
     toPOJO(): IKeyValueMap<V> {
         const res: IKeyValueMap<V> = {}
-        this._data.forEach(
+        this.forEach(
             (_, key) =>
                 (res[typeof key === "symbol" ? <any>key : stringifyKey(key)] = this.get(key)!)
         )

--- a/src/v4/types/type-utils.ts
+++ b/src/v4/types/type-utils.ts
@@ -26,7 +26,7 @@ export function getAtom(thing: any, property?: string): IDepTreeNode {
         }
         if (isObservableMap(thing)) {
             const anyThing = thing as any
-            if (property === undefined) return getAtom(anyThing._keys)
+            if (property === undefined) return anyThing._keysAtom
             const observable = anyThing._data.get(property) || anyThing._hasMap.get(property)
             if (!observable)
                 fail(

--- a/test/v4/base/map.js
+++ b/test/v4/base/map.js
@@ -573,6 +573,14 @@ test("issue 940, should not be possible to change maps outside strict mode", () 
             m.set("x", 1)
         }).toThrowError(/Since strict-mode is enabled/)
 
+        expect(() => {
+            m.set("x", 2)
+        }).toThrowError(/Since strict-mode is enabled/)
+
+        expect(() => {
+            m.delete("x")
+        }).toThrowError(/Since strict-mode is enabled/)
+
         d()
     } finally {
         mobx.configure({ enforceActions: "never" })
@@ -788,4 +796,21 @@ test("#1858 Map should not be inherited", () => {
     expect(() => {
         mobx.observable.map(map)
     }).toThrow("Cannot initialize from classes that inherit from Map: MyMap")
+})
+
+test("#2274", () => {
+    const myMap = mobx.observable.map()
+    myMap.set(1, 1)
+    myMap.set(2, 1)
+    myMap.set(3, 1)
+
+    const newMap = mobx.observable.map()
+    newMap.set(4, 1)
+    newMap.set(5, 1)
+    newMap.set(6, 1)
+
+    myMap.replace(newMap)
+
+    expect(Array.from(myMap._data.keys())).toEqual([4, 5, 6])
+    expect(myMap.has(2)).toBe(false)
 })

--- a/test/v4/base/map.js
+++ b/test/v4/base/map.js
@@ -949,7 +949,7 @@ test(".keys() does NOT subscribe for value changes", () => {
     expect(autorunInvocationCount).toBe(1)
 })
 
-test("noop mutations does NOT reportChanges", () => {
+test("noop mutations do NOT reportChanges", () => {
     const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
     let autorunInvocationCount = 0
 

--- a/test/v4/base/map.js
+++ b/test/v4/base/map.js
@@ -814,3 +814,158 @@ test("#2274", () => {
     expect(Array.from(myMap._data.keys())).toEqual([4, 5, 6])
     expect(myMap.has(2)).toBe(false)
 })
+
+test(".forEach() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.forEach(_ => {})
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".keys() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.keys()) {
+        }
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".values() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.values()) {
+        }
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".entries() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.entries()) {
+        }
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".entries() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.entries()) {
+        }
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".values() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.values()) {
+        }
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".forEach() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.forEach(_ => {})
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".keys() does NOT subscribe for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.keys()) {
+        }
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(1)
+})
+
+test("noop mutations does NOT reportChanges", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.forEach(_ => {})
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.set(3, 3)
+    map.delete("NOT IN MAP")
+    map.merge([])
+    map.merge([[1, 1], [3, 3]])
+    map.merge([[1, 1], [2, 2], [3, 3]])
+    map.replace([[1, 1], [2, 2], [3, 3]])
+
+    expect(autorunInvocationCount).toBe(1)
+})

--- a/test/v4/base/map.js
+++ b/test/v4/base/map.js
@@ -882,6 +882,54 @@ test(".entries() subscribes for key changes", () => {
     expect(autorunInvocationCount).toBe(4)
 })
 
+test(".toPOJO() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toPOJO()
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".toJS() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toJS()
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".toJSON() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toJSON()
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
 test(".entries() subscribes for value changes", () => {
     const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
     let autorunInvocationCount = 0
@@ -923,6 +971,54 @@ test(".forEach() subscribes for value changes", () => {
     autorun(() => {
         autorunInvocationCount++
         map.forEach(_ => {})
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".toPOJO() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toPOJO()
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".toJS() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toJS()
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".toJSON() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toJSON()
     })
 
     map.set(1, 11)

--- a/test/v5/base/map.js
+++ b/test/v5/base/map.js
@@ -763,3 +763,158 @@ test("#2274", () => {
     expect(Array.from(myMap._data.keys())).toEqual([4, 5, 6])
     expect(myMap.has(2)).toBe(false)
 })
+
+test(".forEach() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.forEach(_ => {})
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".keys() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.keys()) {
+        }
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".values() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.values()) {
+        }
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".entries() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.entries()) {
+        }
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".entries() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.entries()) {
+        }
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".values() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.values()) {
+        }
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".forEach() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.forEach(_ => {})
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".keys() does NOT subscribe for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.keys()) {
+        }
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(1)
+})
+
+test("noop mutations does NOT reportChanges", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.forEach(_ => {})
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.set(3, 3)
+    map.delete("NOT IN MAP")
+    map.merge([])
+    map.merge([[1, 1], [3, 3]])
+    map.merge([[1, 1], [2, 2], [3, 3]])
+    map.replace([[1, 1], [2, 2], [3, 3]])
+
+    expect(autorunInvocationCount).toBe(1)
+})

--- a/test/v5/base/map.js
+++ b/test/v5/base/map.js
@@ -831,6 +831,54 @@ test(".entries() subscribes for key changes", () => {
     expect(autorunInvocationCount).toBe(4)
 })
 
+test(".toPOJO() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toPOJO()
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".toJS() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toJS()
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".toJSON() subscribes for key changes", () => {
+    const map = mobx.observable.map()
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toJSON()
+    })
+
+    map.set(1, 1)
+    map.set(2, 2)
+    map.delete(1)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
 test(".entries() subscribes for value changes", () => {
     const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
     let autorunInvocationCount = 0
@@ -872,6 +920,54 @@ test(".forEach() subscribes for value changes", () => {
     autorun(() => {
         autorunInvocationCount++
         map.forEach(_ => {})
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".toPOJO() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toPOJO()
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".toJS() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toJS()
+    })
+
+    map.set(1, 11)
+    map.set(2, 22)
+    map.set(3, 33)
+
+    expect(autorunInvocationCount).toBe(4)
+})
+
+test(".toJSON() subscribes for value changes", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    let autorunInvocationCount = 0
+
+    autorun(() => {
+        autorunInvocationCount++
+        map.toJSON()
     })
 
     map.set(1, 11)

--- a/test/v5/base/map.js
+++ b/test/v5/base/map.js
@@ -746,3 +746,20 @@ test("#1858 Map should not be inherited", () => {
         mobx.observable.map(map)
     }).toThrow("Cannot initialize from classes that inherit from Map: MyMap")
 })
+
+test("#2274", () => {
+    const myMap = mobx.observable.map()
+    myMap.set(1, 1)
+    myMap.set(2, 1)
+    myMap.set(3, 1)
+
+    const newMap = mobx.observable.map()
+    newMap.set(4, 1)
+    newMap.set(5, 1)
+    newMap.set(6, 1)
+
+    myMap.replace(newMap)
+
+    expect(Array.from(myMap._data.keys())).toEqual([4, 5, 6])
+    expect(myMap.has(2)).toBe(false)
+})

--- a/test/v5/base/map.js
+++ b/test/v5/base/map.js
@@ -898,7 +898,7 @@ test(".keys() does NOT subscribe for value changes", () => {
     expect(autorunInvocationCount).toBe(1)
 })
 
-test("noop mutations does NOT reportChanges", () => {
+test("noop mutations do NOT reportChanges", () => {
     const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
     let autorunInvocationCount = 0
 


### PR DESCRIPTION
Replaced `Array.from`
Replaced `for of`
Contains fix/test #2275
Added few generic tests.