### PR TITLE
fix: map.replace #2253 (interceptors) #1980 (key order V5) 

### DIFF
--- a/src/v4/types/observablemap.ts
+++ b/src/v4/types/observablemap.ts
@@ -33,7 +33,8 @@ import {
     declareIterator,
     onBecomeUnobserved,
     convertToMap,
-    iteratorToArray
+    iteratorToArray,
+    forOf
 } from "../internal"
 
 export interface IKeyValueMap<V = any> {
@@ -332,26 +333,78 @@ export class ObservableMap<K = any, V = any>
     }
 
     replace(values: ObservableMap<K, V> | IKeyValueMap<V> | any): ObservableMap<K, V> {
+        // Implementation requirements:
+        // - respect ordering of replacement map
+        // - allow interceptors to run and potentially prevent individual operations
+        // - don't recreate observables that already exist in original map (so we don't destroy existing subscriptions)
+        // - don't _keysAtom.reportChanged if the keys of resulting map are indentical (order matters!)
+        // - note that result map may differ from replacement map due to the interceptors
         transaction(() => {
+            // Convert to map so we can do quick key lookups
             const replacementMap = convertToMap(values)
             const orderedData = new Map()
-            const oldKeys = iteratorToArray(this.keys())
-            const newKeys: Array<any> = iteratorToArray(replacementMap.keys())
-            for (let i = 0; i < oldKeys.length; i++) {
-                const oldKey = oldKeys[i]
-                // key order change
-                if (oldKeys.length === newKeys.length && oldKey !== newKeys[i]) {
-                    this._keysAtom.reportChanged()
+            // Used for optimization
+            let keysReportChangedCalled = false
+            // Delete keys that don't exist in replacement map
+            // if the key deletion is prevented by interceptor
+            // add entry at the beginning of the result map
+            forOf(this._data.keys(), key => {
+                // Concurrently iterating/deleting keys
+                // iterator should handle this correctly
+                if (!replacementMap.has(key)) {
+                    const deleted = this.delete(key)
+                    // Was the key removed?
+                    if (deleted) {
+                        // _keysAtom.reportChanged() was already called
+                        keysReportChangedCalled = true
+                    } else {
+                        // Delete prevented by interceptor
+                        const value = this._data.get(key)
+                        orderedData.set(key, value)
+                    }
                 }
-                // deleted key
-                if (!replacementMap.has(oldKey)) {
-                    this.delete(oldKey)
+            })
+            // Merge entries
+            forOf(replacementMap.entries(), ([key, value]) => {
+                // We will want to know whether a new key is added
+                const keyExisted = this._data.has(key)
+                // Add or update value
+                this.set(key, value)
+                // The addition could have been prevent by interceptor
+                if (this._data.has(key)) {
+                    // The update could have been prevented by interceptor
+                    // and also we want to preserve existing values
+                    // so use value from _data map (instead of replacement map)
+                    const value = this._data.get(key)
+                    orderedData.set(key, value)
+                    // Was a new key added?
+                    if (!keyExisted) {
+                        // _keysAtom.reportChanged() was already called
+                        keysReportChangedCalled = true
+                    }
+                }
+            })
+            // Check for possible key order change
+            if (!keysReportChangedCalled) {
+                if (this._data.size !== orderedData.size) {
+                    // If size differs, keys are definitely modified
+                    this._keysAtom.reportChanged()
+                } else {
+                    const iter1 = this._data.keys()
+                    const iter2 = orderedData.keys()
+                    let next1 = iter1.next()
+                    let next2 = iter2.next()
+                    while (!next1.done) {
+                        if (next1.value !== next2.value) {
+                            this._keysAtom.reportChanged()
+                            break
+                        }
+                        next1 = iter1.next()
+                        next2 = iter2.next()
+                    }
                 }
             }
-            replacementMap.forEach((value, key) => {
-                this.set(key, value)
-                orderedData.set(key, this._data.get(key))
-            })
+            // Use correctly ordered map
             this._data = orderedData
         })
         return this

--- a/src/v4/utils/utils.ts
+++ b/src/v4/utils/utils.ts
@@ -1,11 +1,4 @@
-import {
-    ObservableMap,
-    globalState,
-    IObservableArray,
-    isObservableArray,
-    IKeyValueMap,
-    isObservableMap
-} from "../internal"
+import { globalState, IObservableArray, isObservableArray, isObservableMap } from "../internal"
 
 declare const Symbol: any
 

--- a/src/v4/utils/utils.ts
+++ b/src/v4/utils/utils.ts
@@ -108,13 +108,17 @@ export function isPlainObject(value) {
     return proto === Object.prototype || proto === null
 }
 
-export function convertToMap(dataStructure) {
+export function convertToMap(dataStructure: any): Map<any, any> {
     if (isES6Map(dataStructure) || isObservableMap(dataStructure)) {
         return dataStructure
     } else if (Array.isArray(dataStructure)) {
         return new Map(dataStructure)
     } else if (isPlainObject(dataStructure)) {
-        return new Map(Object.entries(dataStructure))
+        const map = new Map()
+        for (const key in dataStructure) {
+            map.set(key, dataStructure[key])
+        }
+        return map
     } else {
         return fail(`Cannot convert to map from '${dataStructure}'`)
     }
@@ -187,15 +191,6 @@ export function isES6Set(thing): thing is Set<any> {
     return thing instanceof Set
 }
 
-export function getMapLikeKeys<K, V>(map: ObservableMap<K, V>): ReadonlyArray<K>
-export function getMapLikeKeys<V>(map: IKeyValueMap<V> | any): ReadonlyArray<string>
-export function getMapLikeKeys(map: any): any {
-    if (isPlainObject(map)) return Object.keys(map)
-    if (Array.isArray(map)) return map.map(([key]) => key)
-    if (isES6Map(map) || isObservableMap(map)) return iteratorToArray(map.keys())
-    return fail(`Cannot get keys from '${map}'`)
-}
-
 // use Array.from in Mobx 5
 export function iteratorToArray<T>(it: Iterator<T>): Array<T> {
     const res: T[] = []
@@ -214,4 +209,13 @@ export function primitiveSymbol() {
 
 export function toPrimitive(value) {
     return value === null ? null : typeof value === "object" ? "" + value : value
+}
+
+// Use "for of" in V5
+export function forOf<T>(iter: Iterator<T>, callback: (entry: T) => void): void {
+    let next = iter.next()
+    while (!next.done) {
+        callback(next.value)
+        next = iter.next()
+    }
 }

--- a/src/v5/types/observablemap.ts
+++ b/src/v5/types/observablemap.ts
@@ -11,7 +11,6 @@ import {
     createInstanceofPredicate,
     deepEnhancer,
     fail,
-    getMapLikeKeys,
     getNextId,
     getPlainObjectKeys,
     hasInterceptors,
@@ -32,7 +31,8 @@ import {
     transaction,
     untracked,
     onBecomeUnobserved,
-    globalState
+    globalState,
+    convertToMap
 } from "../internal"
 
 export interface IKeyValueMap<V = any> {
@@ -332,15 +332,79 @@ export class ObservableMap<K = any, V = any>
     }
 
     replace(values: ObservableMap<K, V> | IKeyValueMap<V> | any): ObservableMap<K, V> {
+        // Implementation requirements:
+        // - respect ordering of replacement map
+        // - allow interceptors to run and potentially prevent individual operations
+        // - don't recreate observables that already exist in original map (so we don't destroy existing subscriptions)
+        // - don't _keysAtom.reportChanged if the keys of resulting map are indentical (order matters!)
+        // - note that result map may differ from replacement map due to the interceptors
         transaction(() => {
-            // grab all the keys that are present in the new map but not present in the current map
-            // and delete them from the map, then merge the new map
-            // this will cause reactions only on changed values
-            const newKeys = (getMapLikeKeys(values) as any) as K[]
-            const oldKeys = Array.from(this.keys())
-            const missingKeys = oldKeys.filter(k => newKeys.indexOf(k) === -1)
-            missingKeys.forEach(k => this.delete(k))
-            this.merge(values)
+            // Convert to map so we can do quick key lookups
+            const replacementMap = convertToMap(values)
+            const orderedData = new Map()
+            // Used for optimization
+            let keysReportChangedCalled = false
+            // Delete keys that don't exist in replacement map
+            // if the key deletion is prevented by interceptor
+            // add entry at the beginning of the result map
+            for (const key of this._data.keys()) {
+                // Concurrently iterating/deleting keys
+                // iterator should handle this correctly
+                if (!replacementMap.has(key)) {
+                    const deleted = this.delete(key)
+                    // Was the key removed?
+                    if (deleted) {
+                        // _keysAtom.reportChanged() was already called
+                        keysReportChangedCalled = true
+                    } else {
+                        // Delete prevented by interceptor
+                        const value = this._data.get(key)
+                        orderedData.set(key, value)
+                    }
+                }
+            }
+            // Merge entries
+            for (const [key, value] of replacementMap.entries()) {
+                // We will want to know whether a new key is added
+                const keyExisted = this._data.has(key)
+                // Add or update value
+                this.set(key, value)
+                // The addition could have been prevent by interceptor
+                if (this._data.has(key)) {
+                    // The update could have been prevented by interceptor
+                    // and also we want to preserve existing values
+                    // so use value from _data map (instead of replacement map)
+                    const value = this._data.get(key)
+                    orderedData.set(key, value)
+                    // Was a new key added?
+                    if (!keyExisted) {
+                        // _keysAtom.reportChanged() was already called
+                        keysReportChangedCalled = true
+                    }
+                }
+            }
+            // Check for possible key order change
+            if (!keysReportChangedCalled) {
+                if (this._data.size !== orderedData.size) {
+                    // If size differs, keys are definitely modified
+                    this._keysAtom.reportChanged()
+                } else {
+                    const iter1 = this._data.keys()
+                    const iter2 = orderedData.keys()
+                    let next1 = iter1.next()
+                    let next2 = iter2.next()
+                    while (!next1.done) {
+                        if (next1.value !== next2.value) {
+                            this._keysAtom.reportChanged()
+                            break
+                        }
+                        next1 = iter1.next()
+                        next2 = iter2.next()
+                    }
+                }
+            }
+            // Use correctly ordered map
+            this._data = orderedData
         })
         return this
     }

--- a/src/v5/utils/utils.ts
+++ b/src/v5/utils/utils.ts
@@ -1,11 +1,4 @@
-import {
-    IKeyValueMap,
-    IObservableArray,
-    ObservableMap,
-    globalState,
-    isObservableArray,
-    isObservableMap
-} from "../internal"
+import { IObservableArray, globalState, isObservableArray, isObservableMap } from "../internal"
 
 export const OBFUSCATED_ERROR =
     "An invariant failed, however the error is obfuscated because this is a production build."

--- a/src/v5/utils/utils.ts
+++ b/src/v5/utils/utils.ts
@@ -88,6 +88,22 @@ export function isPlainObject(value) {
     return proto === Object.prototype || proto === null
 }
 
+export function convertToMap(dataStructure: any): Map<any, any> {
+    if (isES6Map(dataStructure) || isObservableMap(dataStructure)) {
+        return dataStructure
+    } else if (Array.isArray(dataStructure)) {
+        return new Map(dataStructure)
+    } else if (isPlainObject(dataStructure)) {
+        const map = new Map()
+        for (const key in dataStructure) {
+            map.set(key, dataStructure[key])
+        }
+        return map
+    } else {
+        return fail(`Cannot convert to map from '${dataStructure}'`)
+    }
+}
+
 export function makeNonEnumerable(object: any, propNames: PropertyKey[]) {
     for (let i = 0; i < propNames.length; i++) {
         addHiddenProp(object, propNames[i], object[propNames[i]])
@@ -167,15 +183,6 @@ export function getPlainObjectKeys(object) {
 export function stringifyKey(key: any): string {
     if (key && key.toString) return key.toString()
     else return new String(key).toString()
-}
-
-export function getMapLikeKeys<K, V>(map: ObservableMap<K, V>): ReadonlyArray<K>
-export function getMapLikeKeys<V>(map: IKeyValueMap<V> | any): ReadonlyArray<string>
-export function getMapLikeKeys(map: any): any {
-    if (isPlainObject(map)) return Object.keys(map)
-    if (Array.isArray(map)) return map.map(([key]) => key)
-    if (isES6Map(map) || isObservableMap(map)) return Array.from(map.keys())
-    return fail(`Cannot get keys from '${map}'`)
 }
 
 export function toPrimitive(value) {

--- a/test/v4/base/map.js
+++ b/test/v4/base/map.js
@@ -325,12 +325,12 @@ test("map modifier with modifier", () => {
     x.set("b", { d: 4 })
     expect(mobx.isObservableObject(x.get("b"))).toBe(true)
 
-    x = mobx.observable.shallowMap({ a: { c: 3 } })
+    x = mobx.observable.map({ a: { c: 3 } }, { deep: false })
     expect(mobx.isObservableObject(x.get("a"))).toBe(false)
     x.set("b", { d: 4 })
     expect(mobx.isObservableObject(x.get("b"))).toBe(false)
 
-    x = mobx.observable({ a: mobx.observable.shallowMap({ b: {} }) })
+    x = mobx.observable({ a: mobx.observable.map({ b: {} }, { deep: false }) })
     expect(mobx.isObservableObject(x)).toBe(true)
     expect(mobx.isObservableMap(x.a)).toBe(true)
     expect(mobx.isObservableObject(x.a.get("b"))).toBe(false)
@@ -502,7 +502,6 @@ test("798, cannot return observable map from computed prop", () => {
 
     expect(() => {
         Object.assign({}, cs.customerSearchType)
-        // console.log(x)
     }).not.toThrow()
 })
 
@@ -642,7 +641,7 @@ test("#1980 .replace should not breaks entities order!", () => {
     }
 })
 
-test("#1980 .replace should should invoke autorun", () => {
+test("#1980 .replace should invoke autorun", () => {
     const original = mobx.observable.map({ a: "a", b: "b" })
     const replacement = { b: "b", a: "a" }
     let numOfInvokes = 0
@@ -1064,4 +1063,60 @@ test("noop mutations do NOT reportChanges", () => {
     map.replace([[1, 1], [2, 2], [3, 3]])
 
     expect(autorunInvocationCount).toBe(1)
+})
+
+test(".replace() calls and respects interceptors", () => {
+    const map = mobx.observable.map([[0, 0], [1, 1], [2, 2], [3, 3]])
+    const replacementMap = [[3, 33], [4, 44], [5, 55], [0, 0]]
+    const expectedMap = [[2, 2], [3, 3], [5, 55], [0, 0]]
+
+    mobx.intercept(map, change => {
+        // cancel delete 2
+        if (change.type === "delete" && change.name === 2) {
+            return null
+        }
+        // cancel update 3
+        if (change.type === "update" && change.name === 3) {
+            return null
+        }
+        // cancel add 4
+        if (change.type === "add" && change.name === 4) {
+            return null
+        }
+        return change
+    })
+
+    map.replace(replacementMap)
+
+    expect(Array.from(map)).toEqual(expectedMap)
+})
+
+test(".replace() should reportChanged on key order change", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    const replacementMap = [[4, 44], [3, 33], [2, 22]]
+    const expectedMap = [[1, 1], [3, 33], [2, 22]]
+    let autorunInvocationCount = 0
+
+    mobx.intercept(map, change => {
+        // cancel delete 1
+        if (change.type === "delete" && change.name === 1) {
+            return null
+        }
+        // cancel add 4
+        if (change.type === "add" && change.name === 4) {
+            return null
+        }
+        return change
+    })
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.keys()) {
+        }
+    })
+
+    map.replace(replacementMap)
+
+    expect(Array.from(map)).toEqual(expectedMap)
+    expect(autorunInvocationCount).toBe(2)
 })

--- a/test/v5/base/map.js
+++ b/test/v5/base/map.js
@@ -502,7 +502,6 @@ test("798, cannot return observable map from computed prop", () => {
 
     expect(() => {
         Object.assign({}, cs.customerSearchType)
-        // console.log(x)
     }).not.toThrow()
 })
 
@@ -626,9 +625,52 @@ test("issue 1243, .replace should not trigger change on unchanged values", () =>
 
     expect(() => {
         m.replace("not-an-object")
-    }).toThrow(/Cannot get keys from 'not-an-object'/)
+    }).toThrow("[mobx] Cannot convert to map from 'not-an-object'")
 
     d()
+})
+
+test("#1980 .replace should not breaks entities order!", () => {
+    const original = mobx.observable.map([["a", "first"], ["b", "second"]])
+    const replacement = new Map([["b", "first"], ["a", "second"]])
+    original.replace(replacement)
+    const newKeys = Array.from(replacement)
+    const originalKeys = Array.from(replacement)
+    for (let i = 0; i < newKeys.length; i++) {
+        expect(newKeys[i]).toEqual(originalKeys[i])
+    }
+})
+
+test("#1980 .replace should invoke autorun", () => {
+    const original = mobx.observable.map({ a: "a", b: "b" })
+    const replacement = { b: "b", a: "a" }
+    let numOfInvokes = 0
+    autorun(() => {
+        numOfInvokes = numOfInvokes + 1
+        return original.entries().next()
+    })
+    original.replace(replacement)
+    const orgKeys = Array.from(original.keys())
+    const newKeys = Object.keys(replacement)
+    for (let i = 0; i < newKeys.length; i++) {
+        expect(newKeys[i]).toEqual(orgKeys[i])
+    }
+    expect(numOfInvokes).toBe(2)
+})
+
+test("#1980 .replace should not report changed unnecessarily", () => {
+    const mapArray = [["swappedA", "swappedA"], ["swappedB", "swappedB"], ["removed", "removed"]]
+    const replacementArray = [mapArray[1], mapArray[0], ["added", "added"]]
+    const map = mobx.observable.map(mapArray)
+    let autorunInvocationCount = 0
+    autorun(() => {
+        map.get("swappedA")
+        map.get("swappedB")
+        autorunInvocationCount++
+    })
+    map.replace(replacementArray)
+    expect(Array.from(map.entries())).toEqual(replacementArray)
+    expect(autorunInvocationCount).toBe(1)
 })
 
 test("#1258 cannot replace maps anymore", () => {
@@ -1021,4 +1063,60 @@ test("noop mutations do NOT reportChanges", () => {
     map.replace([[1, 1], [2, 2], [3, 3]])
 
     expect(autorunInvocationCount).toBe(1)
+})
+
+test(".replace() calls and respects interceptors", () => {
+    const map = mobx.observable.map([[0, 0], [1, 1], [2, 2], [3, 3]])
+    const replacementMap = [[3, 33], [4, 44], [5, 55], [0, 0]]
+    const expectedMap = [[2, 2], [3, 3], [5, 55], [0, 0]]
+
+    mobx.intercept(map, change => {
+        // cancel delete 2
+        if (change.type === "delete" && change.name === 2) {
+            return null
+        }
+        // cancel update 3
+        if (change.type === "update" && change.name === 3) {
+            return null
+        }
+        // cancel add 4
+        if (change.type === "add" && change.name === 4) {
+            return null
+        }
+        return change
+    })
+
+    map.replace(replacementMap)
+
+    expect(Array.from(map)).toEqual(expectedMap)
+})
+
+test(".replace() should reportChanged on key order change", () => {
+    const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+    const replacementMap = [[4, 44], [3, 33], [2, 22]]
+    const expectedMap = [[1, 1], [3, 33], [2, 22]]
+    let autorunInvocationCount = 0
+
+    mobx.intercept(map, change => {
+        // cancel delete 1
+        if (change.type === "delete" && change.name === 1) {
+            return null
+        }
+        // cancel add 4
+        if (change.type === "add" && change.name === 4) {
+            return null
+        }
+        return change
+    })
+
+    autorun(() => {
+        autorunInvocationCount++
+        for (const _ of map.keys()) {
+        }
+    })
+
+    map.replace(replacementMap)
+
+    expect(Array.from(map)).toEqual(expectedMap)
+    expect(autorunInvocationCount).toBe(2)
 })


### PR DESCRIPTION
Fixed #2253 
Fixed #1980 for V5 (it was fixed for V4)
Synced V4/V5 map tests.
Fixed deprecation warnings in V4 test.
Removed invalid use of `Object.entries` in V4 (`convertToMap`)