### PR TITLE
Improve map.values/entries perf + add test for #2112

### DIFF
--- a/src/v4/types/observablemap.ts
+++ b/src/v4/types/observablemap.ts
@@ -268,33 +268,30 @@ export class ObservableMap<K = any, V = any>
 
     values(): IterableIterator<V> {
         const self = this
-        let nextIndex = 0
-        const keys = iteratorToArray(this.keys())
+        const keys = this.keys()
         return makeIterable({
             next() {
-                return nextIndex < keys.length
-                    ? { value: self.get(keys[nextIndex++])!, done: false }
-                    : { value: undefined as any, done: true }
+                const { done, value } = keys.next()
+                return {
+                    done,
+                    value: done ? (undefined as any) : self.get(value)
+                }
             }
         })
     }
 
     entries(): IterableIterator<IMapEntry<K, V>> {
         const self = this
-        let nextIndex = 0
-        const keys = iteratorToArray(this.keys())
+        const keys = this.keys()
         return makeIterable({
-            next: function() {
-                if (nextIndex < keys.length) {
-                    const key = keys[nextIndex++]
-                    return {
-                        value: [key, self.get(key)!] as [K, V],
-                        done: false
-                    }
+            next() {
+                const { done, value } = keys.next()
+                return {
+                    done,
+                    value: done ? (undefined as any) : ([value, self.get(value)!] as [K, V])
                 }
-                return { done: true }
             }
-        } as any)
+        })
     }
 
     forEach(callback: (value: V, key: K, object: Map<K, V>) => void, thisArg?) {

--- a/src/v5/types/observablemap.ts
+++ b/src/v5/types/observablemap.ts
@@ -267,33 +267,30 @@ export class ObservableMap<K = any, V = any>
 
     values(): IterableIterator<V> {
         const self = this
-        let nextIndex = 0
-        const keys = Array.from(this.keys())
-        return makeIterable<V>({
+        const keys = this.keys()
+        return makeIterable({
             next() {
-                return nextIndex < keys.length
-                    ? { value: self.get(keys[nextIndex++]), done: false }
-                    : { done: true }
+                const { done, value } = keys.next()
+                return {
+                    done,
+                    value: done ? (undefined as any) : self.get(value)
+                }
             }
-        } as any)
+        })
     }
 
     entries(): IterableIterator<IMapEntry<K, V>> {
         const self = this
-        let nextIndex = 0
-        const keys = Array.from(this.keys())
+        const keys = this.keys()
         return makeIterable({
-            next: function() {
-                if (nextIndex < keys.length) {
-                    const key = keys[nextIndex++]
-                    return {
-                        value: [key, self.get(key)!] as [K, V],
-                        done: false
-                    }
+            next() {
+                const { done, value } = keys.next()
+                return {
+                    done,
+                    value: done ? (undefined as any) : ([value, self.get(value)!] as [K, V])
                 }
-                return { done: true }
             }
-        } as any)
+        })
     }
 
     [Symbol.iterator]() {

--- a/test/v4/base/map.js
+++ b/test/v4/base/map.js
@@ -1120,3 +1120,23 @@ test(".replace() should reportChanged on key order change", () => {
     expect(Array.from(map)).toEqual(expectedMap)
     expect(autorunInvocationCount).toBe(2)
 })
+
+test("#2112 - iterators should be resilient to concurrent delete operation", () => {
+    function testIterator(method) {
+        const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+        const expectedMap = mobx.observable.map(map)
+        for (const entry of map[method]()) {
+            const key = Array.isArray(entry) ? entry[0] : entry
+            const deleted1 = map.delete(key)
+            const deleted2 = expectedMap.delete(key)
+            expect(deleted1).toBe(true)
+            expect(deleted2).toBe(true)
+            expect(map.size).toBe(expectedMap.size)
+            expect(Array.from(map)).toEqual(Array.from(expectedMap))
+        }
+    }
+
+    testIterator("keys")
+    testIterator("values")
+    testIterator("entries")
+})

--- a/test/v5/base/map.js
+++ b/test/v5/base/map.js
@@ -1120,3 +1120,23 @@ test(".replace() should reportChanged on key order change", () => {
     expect(Array.from(map)).toEqual(expectedMap)
     expect(autorunInvocationCount).toBe(2)
 })
+
+test("#2112 - iterators should be resilient to concurrent delete operation", () => {
+    function testIterator(method) {
+        const map = mobx.observable.map([[1, 1], [2, 2], [3, 3]])
+        const expectedMap = mobx.observable.map(map)
+        for (const entry of map[method]()) {
+            const key = Array.isArray(entry) ? entry[0] : entry
+            const deleted1 = map.delete(key)
+            const deleted2 = expectedMap.delete(key)
+            expect(deleted1).toBe(true)
+            expect(deleted2).toBe(true)
+            expect(map.size).toBe(expectedMap.size)
+            expect(Array.from(map)).toEqual(Array.from(expectedMap))
+        }
+    }
+
+    testIterator("keys")
+    testIterator("values")
+    testIterator("entries")
+})


### PR DESCRIPTION
Reuses existing iterator instead of converting it to array first.
Added test for #2112, which was already fixed, most likely by #2279 (for V4)
Types may need some adjustments, help welcome :)