### PR TITLE
Proof of concept, microtasks to batch batches.

### DIFF
--- a/src/v5/api/configure.ts
+++ b/src/v5/api/configure.ts
@@ -7,7 +7,7 @@ import {
 } from "../internal"
 
 export function configure(options: {
-    enforceActions?: boolean | "strict" | "never" | "always" | "observed"
+    enforceActions?: boolean | "strict" | "never" | "always" | "observed" | "useMicrotasks"
     computedRequiresReaction?: boolean
     /**
      * (Experimental)
@@ -48,6 +48,7 @@ export function configure(options: {
                 ea = true
                 break
             case false:
+            case "useMicrotasks":
             case "never":
                 ea = false
                 break
@@ -57,11 +58,12 @@ export function configure(options: {
                 break
             default:
                 fail(
-                    `Invalid value for 'enforceActions': '${enforceActions}', expected 'never', 'always' or 'observed'`
+                    `Invalid value for 'enforceActions': '${enforceActions}', expected 'never', 'always', 'observed' or 'useMicrotasks'`
                 )
         }
         globalState.enforceActions = ea
         globalState.allowStateChanges = ea === true || ea === "strict" ? false : true
+        globalState.queueReportChangedEndBatchAsMicrotask = true
     }
     if (computedRequiresReaction !== undefined) {
         globalState.computedRequiresReaction = !!computedRequiresReaction

--- a/src/v5/api/configure.ts
+++ b/src/v5/api/configure.ts
@@ -49,6 +49,7 @@ export function configure(options: {
                 break
             case false:
             case "useMicrotasks":
+                globalState.queueReportChangedEndBatchAsMicrotask = true
             case "never":
                 ea = false
                 break
@@ -63,7 +64,6 @@ export function configure(options: {
         }
         globalState.enforceActions = ea
         globalState.allowStateChanges = ea === true || ea === "strict" ? false : true
-        globalState.queueReportChangedEndBatchAsMicrotask = true
     }
     if (computedRequiresReaction !== undefined) {
         globalState.computedRequiresReaction = !!computedRequiresReaction

--- a/src/v5/core/atom.ts
+++ b/src/v5/core/atom.ts
@@ -10,7 +10,8 @@ import {
     onBecomeUnobserved,
     propagateChanged,
     reportObserved,
-    startBatch
+    startBatch,
+    globalState
 } from "../internal"
 import { Lambda } from "../utils/utils"
 
@@ -64,7 +65,13 @@ export class Atom implements IAtom {
     public reportChanged() {
         startBatch()
         propagateChanged(this)
-        endBatch()
+        if (globalState.queueReportChangedEndBatchAsMicrotask) {
+            Promise.resolve().then(() => {
+                endBatch()
+            })
+        } else {
+            endBatch()
+        }
     }
 
     toString() {

--- a/src/v5/core/globalstate.ts
+++ b/src/v5/core/globalstate.ts
@@ -139,6 +139,12 @@ export class MobXGlobals {
      * they are not the cause, see: https://github.com/mobxjs/mobx/issues/1836
      */
     suppressReactionErrors = false
+
+    /*
+     * Queues the endBatch call in reportChanged in a microtask. This allows automatic batching of multiple
+     * observable changes that originate outside of an action.
+     */
+    queueReportChangedEndBatchAsMicrotask = false
 }
 
 declare const window: any

--- a/src/v5/core/observable.ts
+++ b/src/v5/core/observable.ts
@@ -244,7 +244,7 @@ function logTraceInfo(derivation: IDerivation, observable: IObservable) {
 
         // prettier-ignore
         new Function(
-            `debugger;
+`debugger;
 /*
 Tracing '${derivation.name}'
 

--- a/src/v5/core/observable.ts
+++ b/src/v5/core/observable.ts
@@ -244,7 +244,7 @@ function logTraceInfo(derivation: IDerivation, observable: IObservable) {
 
         // prettier-ignore
         new Function(
-`debugger;
+            `debugger;
 /*
 Tracing '${derivation.name}'
 


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR!
-->

(This isn't a serious pull request, just a proof of concept).

`mobx` uses actions to batch observable changes, but I was thinking it could have an option to use microtasks to batch changes, at least when changes are made outside of an action.

I tried it out, and it seems to work, I deployed a highly experimental build at [slift/mobx](https://github.com/sliftist/mobx#0548ddc4179aa87452fd46f621ebf114f854b7da) (`yarn add sliftist/mobx#0548ddc4179aa87452fd46f621ebf114f854b7da`), and am going to start using that branch in projects to get additional testing.

My implementation isn't meant to be a serious implementation, it basically just does this:
```diff
public reportChanged() {
    startBatch()
    propagateChanged(this)
    endBatch()
+   if (globalState.queueReportChangedEndBatchAsMicrotask) {
+       Promise.resolve().then(() => {
+           endBatch()
+       })
+   } else {
        endBatch()
+   }
}
```

If this is something `mobx` is interested in pursuing, I would need to make changes to ensure microtasks are only used outside of actions, instead of in all reportChanged calls.


Batching changes via a microtask can yield a large performance increase. For example:

```tsx
@observable lookup = {};
constructor() {
    this.runLoop();
    autorun(this.reactionHandler.bind(this));
}
async runLoop() {
    while(true) {
        await new Promise((resolve) => setTimeout(resolve, 1000));
        for(let key in this.lookup) {
            this.lookup[key]++;
        }
        this.lookup[Date.now()] = 0;
    }
}
reactionHandler() {
    let sum = 0;
    for(let key in this.lookup) {
        sum += this.lookup[key];
    }
    console.log("Keys", Object.keys(this.lookup).length, "Sum", sum);
}
```

This case scales `O(N^2)` without batching, due to every lookup change triggering the reactionHandler, but `O(N)` with batching.

I'm unsure on the full ramifications of this change; if there are parts of `mobx` that are incompatible with this approach, or if instead it would be a relatively stable change (behind a flag), so guidance would be greatly appreciated!

Related:
- [is @action really necessary?](https://github.com/mobxjs/mobx-react/issues/505)
- [Opt-in variant of batched updates](https://github.com/mobxjs/mobx-react/pull/787)