### PR TITLE
Warn if too many reactions are triggered inside of a single microtask loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 5.15.4 / 4.15.4
 
 -   Fix process.env replacement in build [#2267](https://github.com/mobxjs/mobx/pull/2267) by [@fredyc](https://github.com/fredyc)
+-   Add warning when too many reactions are triggered within one microtask loop, as suggested in [#2311](https://github.com/mobxjs/mobx/pull/2311) by [@spion](https://github.com/spion) and submitted in [#2312](https://github.com/mobxjs/mobx/pull/2312) by [@sliftist](https://github.com/sliftist)
 
 # 5.15.3 / 4.15.3
 

--- a/src/v4/core/reaction.ts
+++ b/src/v4/core/reaction.ts
@@ -212,7 +212,7 @@ export function onReactionError(handler: (error: any, derivation: IDerivation) =
 const MAX_REACTION_ITERATIONS = 100
 
 const REACTIONS_IN_MICROTASK_LOOP_WARN_THRESHOLD = 20
-let curMicrotaskReactionCount = 0
+let currentMicrotaskReactionCount = 0
 
 let reactionScheduler: (fn: () => void) => void = f => f()
 
@@ -229,18 +229,20 @@ function runReactionsHelper() {
 
     // Calculate how many times the reaction helper is triggered
     //  inside a single microtask, and warn if it is too many.
-    if (allReactions.length > 0) {
-        if (curMicrotaskReactionCount === 0) {
+    if (process.env.NODE_ENV !== "production" && allReactions.length > 0) {
+        if (currentMicrotaskReactionCount === 0) {
             Promise.resolve().then(() => {
-                if (curMicrotaskReactionCount > REACTIONS_IN_MICROTASK_LOOP_WARN_THRESHOLD) {
+                if (currentMicrotaskReactionCount > REACTIONS_IN_MICROTASK_LOOP_WARN_THRESHOLD) {
                     console.warn(
-                        `MOBX WARNING, a single microtask loop had ${curMicrotaskReactionCount} reactions (which are caused by changes to observables). Batch these actions with @action or runInAction to gain up to a ${curMicrotaskReactionCount}X performance boost!`
+                        `MOBX WARNING, a single microtask loop had ${currentMicrotaskReactionCount} reactions` +
+                            ` (which are caused by changes to observables). Batch these actions with @action or ` +
+                            `runInAction to gain up to a ${currentMicrotaskReactionCount}X performance boost!`
                     )
                 }
-                curMicrotaskReactionCount = 0
+                currentMicrotaskReactionCount = 0
             })
         }
-        curMicrotaskReactionCount++
+        currentMicrotaskReactionCount += 1
     }
 
     // While running reactions, new reactions might be triggered.

--- a/src/v4/core/reaction.ts
+++ b/src/v4/core/reaction.ts
@@ -234,7 +234,7 @@ function runReactionsHelper() {
             Promise.resolve().then(() => {
                 if (curMicrotaskReactionCount > REACTIONS_IN_MICROTASK_LOOP_WARN_THRESHOLD) {
                     console.warn(
-                        `MOBX WARNING, a sigle microtask loop had ${curMicrotaskReactionCount} reactions (which are caused by changes to observables). Batch these actions with @action or runInAction to gain up to a ${curMicrotaskReactionCount}X performance boost!`
+                        `MOBX WARNING, a single microtask loop had ${curMicrotaskReactionCount} reactions (which are caused by changes to observables). Batch these actions with @action or runInAction to gain up to a ${curMicrotaskReactionCount}X performance boost!`
                     )
                 }
                 curMicrotaskReactionCount = 0

--- a/src/v5/core/reaction.ts
+++ b/src/v5/core/reaction.ts
@@ -243,7 +243,7 @@ function runReactionsHelper() {
             Promise.resolve().then(() => {
                 if (curMicrotaskReactionCount > REACTIONS_IN_MICROTASK_LOOP_WARN_THRESHOLD) {
                     console.warn(
-                        `MOBX WARNING, a sigle microtask loop had ${curMicrotaskReactionCount} reactions (which are caused by changes to observables). Batch these actions with @action or runInAction to gain up to a ${curMicrotaskReactionCount}X performance boost!`
+                        `MOBX WARNING, a single microtask loop had ${curMicrotaskReactionCount} reactions (which are caused by changes to observables). Batch these actions with @action or runInAction to gain up to a ${curMicrotaskReactionCount}X performance boost!`
                     )
                 }
                 curMicrotaskReactionCount = 0

--- a/src/v5/core/reaction.ts
+++ b/src/v5/core/reaction.ts
@@ -221,7 +221,7 @@ export function onReactionError(handler: (error: any, derivation: IDerivation) =
 const MAX_REACTION_ITERATIONS = 100
 
 const REACTIONS_IN_MICROTASK_LOOP_WARN_THRESHOLD = 20
-let curMicrotaskReactionCount = 0
+let currentMicrotaskReactionCount = 0
 
 let reactionScheduler: (fn: () => void) => void = f => f()
 
@@ -238,18 +238,20 @@ function runReactionsHelper() {
 
     // Calculate how many times the reaction helper is triggered
     //  inside a single microtask, and warn if it is too many.
-    if (allReactions.length > 0) {
-        if (curMicrotaskReactionCount === 0) {
+    if (process.env.NODE_ENV !== "production" && allReactions.length > 0) {
+        if (currentMicrotaskReactionCount === 0) {
             Promise.resolve().then(() => {
-                if (curMicrotaskReactionCount > REACTIONS_IN_MICROTASK_LOOP_WARN_THRESHOLD) {
+                if (currentMicrotaskReactionCount > REACTIONS_IN_MICROTASK_LOOP_WARN_THRESHOLD) {
                     console.warn(
-                        `MOBX WARNING, a single microtask loop had ${curMicrotaskReactionCount} reactions (which are caused by changes to observables). Batch these actions with @action or runInAction to gain up to a ${curMicrotaskReactionCount}X performance boost!`
+                        `MOBX WARNING, a single microtask loop had ${currentMicrotaskReactionCount} reactions` +
+                            ` (which are caused by changes to observables). Batch these actions with @action or ` +
+                            `runInAction to gain up to a ${currentMicrotaskReactionCount}X performance boost!`
                     )
                 }
-                curMicrotaskReactionCount = 0
+                currentMicrotaskReactionCount = 0
             })
         }
-        curMicrotaskReactionCount++
+        currentMicrotaskReactionCount += 1
     }
 
     // While running reactions, new reactions might be triggered.

--- a/src/v5/core/reaction.ts
+++ b/src/v5/core/reaction.ts
@@ -220,6 +220,9 @@ export function onReactionError(handler: (error: any, derivation: IDerivation) =
  */
 const MAX_REACTION_ITERATIONS = 100
 
+const REACTIONS_IN_MICROTASK_LOOP_WARN_THRESHOLD = 20
+let curMicrotaskReactionCount = 0
+
 let reactionScheduler: (fn: () => void) => void = f => f()
 
 export function runReactions() {
@@ -232,6 +235,22 @@ function runReactionsHelper() {
     globalState.isRunningReactions = true
     const allReactions = globalState.pendingReactions
     let iterations = 0
+
+    // Calculate how many times the reaction helper is triggered
+    //  inside a single microtask, and warn if it is too many.
+    if (allReactions.length > 0) {
+        if (curMicrotaskReactionCount === 0) {
+            Promise.resolve().then(() => {
+                if (curMicrotaskReactionCount > REACTIONS_IN_MICROTASK_LOOP_WARN_THRESHOLD) {
+                    console.warn(
+                        `MOBX WARNING, a sigle microtask loop had ${curMicrotaskReactionCount} reactions (which are caused by changes to observables). Batch these actions with @action or runInAction to gain up to a ${curMicrotaskReactionCount}X performance boost!`
+                    )
+                }
+                curMicrotaskReactionCount = 0
+            })
+        }
+        curMicrotaskReactionCount++
+    }
 
     // While running reactions, new reactions might be triggered.
     // Hence we work with two variables and check whether


### PR DESCRIPTION
As suggested by @spion in #2311 , warns if too many reactions occur in a single microtask loop.

Hopefully this helps the learning curve with mobx, as in https://github.com/mobxjs/mobx-react/issues/505 sometimes programmers may not see a reason to use actions, as mobx works without actions.

However as an application grows and the number of reactions grows, the application may run into performance issues from lack of batching, at which point this warning will fire.

<!--
    Thanks for taking the effort to create a PR!
-->

<!--
    If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

    Keep in mind we are maintaining MobX 4 & 5 in the repo. If applicable, change both.

    Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated changelog
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
