### PR TITLE
Report better error for missing decorated getter #1867

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # UNPUBLISHED (keep this here and add unpublished changes)
 
+-   Add error when computed value declared for unspecified getter [#1867](https://github.com/mobxjs/mobx/issues/1867) by [@berrunder](https://github.com/berrunder)
+
 # 5.15.4 / 4.15.4
 
 -   Fix process.env replacement in build [#2267](https://github.com/mobxjs/mobx/pull/2267) by [@fredyc](https://github.com/fredyc)
--   Add error when computed value declared for unspecified getter [#1867](https://github.com/mobxjs/mobx/issues/1867) by [@berrunder](https://github.com/berrunder)  
 
 # 5.15.3 / 4.15.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 5.15.4 / 4.15.4
 
 -   Fix process.env replacement in build [#2267](https://github.com/mobxjs/mobx/pull/2267) by [@fredyc](https://github.com/fredyc)
+-   Add error when computed value declared for unspecified getter [#1867](https://github.com/mobxjs/mobx/issues/1867) by [@berrunder](https://github.com/berrunder)  
 
 # 5.15.3 / 4.15.3
 

--- a/src/v4/api/computed.ts
+++ b/src/v4/api/computed.ts
@@ -25,6 +25,12 @@ export const computedDecorator = createPropDecorator(
         decoratorTarget: any,
         decoratorArgs: any[]
     ) => {
+        if (process.env.NODE_ENV !== "production") {
+            invariant(
+                descriptor && descriptor.get,
+                `Trying to declare a computed value for unspecified getter '${propertyName}'`
+            )
+        }
         const { get, set } = descriptor // initialValue is the descriptor for get / set props
         // Optimization: faster on decorator target or instance? Assuming target
         // Optimization: find out if declaring on instance isn't just faster. (also makes the property descriptor simpler). But, more memory usage..

--- a/src/v5/api/computed.ts
+++ b/src/v5/api/computed.ts
@@ -5,7 +5,8 @@ import {
     asObservableObject,
     comparer,
     createPropDecorator,
-    invariant
+    invariant,
+    stringifyKey
 } from "../internal"
 
 export interface IComputed {
@@ -25,6 +26,14 @@ export const computedDecorator = createPropDecorator(
         decoratorTarget: any,
         decoratorArgs: any[]
     ) => {
+        if (process.env.NODE_ENV !== "production") {
+            invariant(
+                descriptor && descriptor.get,
+                `Trying to declare a computed value for unspecified getter '${stringifyKey(
+                    propertyName
+                )}'`
+            )
+        }
         const { get, set } = descriptor // initialValue is the descriptor for get / set props
         // Optimization: faster on decorator target or instance? Assuming target
         // Optimization: find out if declaring on instance isn't just faster. (also makes the property descriptor simpler). But, more memory usage..

--- a/test/v4/base/decorate.js
+++ b/test/v4/base/decorate.js
@@ -444,3 +444,20 @@ test("decorate a property with two decorators", function() {
 
     d()
 })
+
+test("expect warning for missing decorated getter", () => {
+    const obj = {
+        x: 0,
+        get y() {
+            return 1
+        }
+    }
+
+    decorate(obj, {
+        x: observable,
+        y: computed,
+        z: computed
+    })
+
+    expect(() => obj.z).toThrow(/Trying to declare a computed value for unspecified getter 'z'/)
+})

--- a/test/v5/base/decorate.js
+++ b/test/v5/base/decorate.js
@@ -444,3 +444,20 @@ test("decorate a property with two decorators", function() {
 
     d()
 })
+
+test("expect warning for missing decorated getter", () => {
+    const obj = {
+        x: 0,
+        get y() {
+            return 1
+        }
+    }
+
+    decorate(obj, {
+        x: observable,
+        y: computed,
+        z: computed
+    })
+
+    expect(() => obj.z).toThrow(/Trying to declare a computed value for unspecified getter 'z'/)
+})


### PR DESCRIPTION
Hello. As suggested by @jefffriesen in #1867, this pr adds better error text in case of missing getter when using decorator syntax.

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated changelog
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)
