### PR TITLE
Add memoization and getter access documentation

### DIFF
--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -97,7 +97,20 @@ const orderLine = observable.object({
 ```
 
 ## Computed values are not getters
-The previous computed examples use the `get` keyword however, they generally should not be accessed directly as a getter. This can be a source of confusion to users new to Mobx from other derived cascading data layers like Reselect. As long as a computed value is not used by a reaction, it is not memoized and so it executes everytime it is accessed just like a normal eager evaluating function. This can cause performance degredation if a computed value is read high in a frequency loop like `requestAnimationFrame`.  MobX can be configured to report an error when computeds are being access directly by using the `computedRequiresReaction` value
+The previous computed examples use the `get` keyword however, they generally should not be accessed directly as a getter. This can be a source of confusion to users new to Mobx from other derived cascading data layers like Reselect. The following code demonsrates issue.
+
+```
+const Ol = new OrderLine(2.00)
+
+// don't do this.
+// avoid accessing Ol.total directly
+// it will recompute everytime.
+setInterval(() => {
+  console.log(Ol.total);
+}, 60);
+```
+
+As long as a computed value is not used by a reaction, it is not memoized and so it executes everytime it is accessed just like a normal eager evaluating function. This can cause performance degredation if a computed value is read high in a frequency loop like `requestAnimationFrame`.  MobX can be configured to report an error when computeds are being access directly by using the `computedRequiresReaction` value
 
 ```javascript
 configure({
@@ -126,6 +139,15 @@ class OrderLine {
         return this.price * this.amount
     }
 }
+
+const Ol = new OrderLine(2.00)
+
+// this is now ok
+// because total will be cached from computeTotal
+// when its dependencies are updated
+setInterval(() => {
+  console.log(Ol.total);
+}, 60);
 ```
 
 

--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -97,7 +97,7 @@ const orderLine = observable.object({
 ```
 
 ## Computed values are not getters
-The previous computed examples use the `get` keyword however, they generally should not be accessed directly as a getter. This can be a source of confusion to users new to Mobx from other derived cascading data layers like Reselect. As long as a computed value is not used by a reaction, it is not memoized and so it executes everytime it is accessed just like a normal eager evaluating function. This can cause preformance degredation if a computed value is read high frequency loop like `requestAnimationFrame`.  MobX can be configured to report an error when computeds are being access directly by using the `computedRequiresReaction` value
+The previous computed examples use the `get` keyword however, they generally should not be accessed directly as a getter. This can be a source of confusion to users new to Mobx from other derived cascading data layers like Reselect. As long as a computed value is not used by a reaction, it is not memoized and so it executes everytime it is accessed just like a normal eager evaluating function. This can cause performance degredation if a computed value is read high in a frequency loop like `requestAnimationFrame`.  MobX can be configured to report an error when computeds are being access directly by using the `computedRequiresReaction` value
 
 ```javascript
 configure({
@@ -106,7 +106,7 @@ configure({
 ```
 
 ### Computed memoization
-A computed value should always be read by a reaction. Reading a computed value directly will cause it to recompute which can be expensive depending on the how complex the derived result is. The following code uses the previous `OrderLine` class example and memoizes the `total` value so that it can be read directly.
+A computed value should always be read by a reaction. Reading a computed value directly will cause it to recompute which can be expensive, depending on the how complex the derived result is. The following code uses the previous `OrderLine` class example and memoizes the `total` value so that it can be read directly.
 
 ```javascript
 class OrderLine {

--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -172,7 +172,7 @@ class OrderLine {
 }
 ```
 
-### Autorun computeds vs keepalives
+### Autorun vs keepAlive
 The only case where autorun would be more beneficial than a `keepAlive` computed, is during a manual managment case in which you call the returned disposer to nicely clean up the computed value if it is no longer used typically you would do that in a destructor of a class for example.
 
 ## Setters for computed values

--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -96,6 +96,39 @@ const orderLine = observable.object({
 })
 ```
 
+## Computed values are not getters
+The previous computed examples use the `get` keyword however, they generally should not be accessed directly as a getter. This can be a source of confusion to users new to Mobx from other derived cascading data layers like Reselect. As long as a computed value is not used by a reaction, it is not memoized and so it executes everytime it is accessed just like a normal eager evaluating function. This can cause preformance degredation if a computed value is read high frequency loop like `requestAnimationFrame`.  MobX can be configured to report an error when computeds are being access directly by using the `computedRequiresReaction` value
+
+```javascript
+configure({
+  computedRequiresReaction: true
+});
+```
+
+### Computed memoization
+A computed value should always be read by a reaction. Reading a computed value directly will cause it to recompute which can be expensive depending on the how complex the derived result is. The following code uses the previous `OrderLine` class example and memoizes the `total` value so that it can be read directly.
+
+```javascript
+class OrderLine {
+    @observable price = 0
+    @observable amount = 1
+
+    constructor(price) {
+        this.price = price
+        // When computed total changes
+        // cache value to this.total
+        autorun(() => {
+            this.total = this.computedTotal
+        })
+    }
+
+    @computed get computeTotal() {
+        return this.price * this.amount
+    }
+}
+```
+
+
 ## Setters for computed values
 
 It is possible to define a setter for computed values as well. Note that these setters cannot be used to alter the value of the computed property directly,

--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -97,7 +97,7 @@ const orderLine = observable.object({
 ```
 
 ## Computed values are not getters
-The previous computed examples use the `get` keyword however, they generally should not be accessed directly as a getter. This can be a source of confusion to users new to Mobx from other derived cascading data layers like Reselect. The following code demonsrates issue.
+The previous computed examples in the `OrderLine` class use the `get` keyword however, they generally should not be accessed directly as a getter. This can be a source of confusion to users new to Mobx from other derived cascading data layers like Reselect. The following code demonsrates the issue.
 
 ```
 const Ol = new OrderLine(2.00)
@@ -110,7 +110,7 @@ setInterval(() => {
 }, 60);
 ```
 
-As long as a computed value is not used by a reaction, it is not memoized and so it executes everytime it is accessed just like a normal eager evaluating function. This can cause performance degredation if a computed value is read high in a frequency loop like `requestAnimationFrame`.  MobX can be configured to report an error when computeds are being access directly by using the `computedRequiresReaction` value
+As long as a computed value is not used by a reaction, it is not memoized and so it executes everytime it is accessed just like a normal eager evaluating function. This can cause performance degredation if a computed value is read high in a frequency loop like `requestAnimationFrame`.  MobX can be configured to report an error when computeds are being access directly by using the `computedRequiresReaction` option
 
 ```javascript
 configure({
@@ -118,7 +118,9 @@ configure({
 });
 ```
 
-### Computed memoization
+Though this restriction is confusing and contradictory Computeds can be altered to work in a direct access manner with some of the following methods...
+
+### Computed memoization with reactions
 A computed value should always be read by a reaction. Reading a computed value directly will cause it to recompute which can be expensive, depending on the how complex the derived result is. The following code uses the previous `OrderLine` class example and memoizes the `total` value so that it can be read directly.
 
 ```javascript
@@ -150,9 +152,9 @@ setInterval(() => {
 }, 60);
 ```
 
-#### KeepAlive Computeds
+### Computed KeepAlive
 
-A computed may be passed the `keepAlive` flag. keepAlive will cause the computed to act as though it is observed by a reaction. This is a convience method and is synoymous with the `autorun` pattern demonstrated above.
+A computed may be initalized with the `keepAlive` flag. `keepAlive` will cause the computed to act as though it is observed by a reaction. This is a convience method and `keepAlive` does the same as the autorun in example above, but it does it a lot more efficient (it can for example keep the computed alive, but defer computation until somebody actually reads the value, something the autorun can't do).
 
 ``` javascript
 class OrderLine {
@@ -169,6 +171,9 @@ class OrderLine {
     }
 }
 ```
+
+### Autorun computeds vs keepalives
+The only case where autorun would be more beneficial than a `keepAlive` computed, is during a manual managment case in which you call the returned disposer to nicely clean up the computed value if it is no longer used typically you would do that in a destructor of a class for example.
 
 ## Setters for computed values
 

--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -137,7 +137,7 @@ class OrderLine {
         })
     }
 
-    @computed get computeTotal() {
+    @computed get computedTotal() {
         return this.price * this.amount
     }
 }

--- a/docs/refguide/computed-decorator.md
+++ b/docs/refguide/computed-decorator.md
@@ -150,6 +150,25 @@ setInterval(() => {
 }, 60);
 ```
 
+#### KeepAlive Computeds
+
+A computed may be passed the `keepAlive` flag. keepAlive will cause the computed to act as though it is observed by a reaction. This is a convience method and is synoymous with the `autorun` pattern demonstrated above.
+
+``` javascript
+class OrderLine {
+    @observable price = 0
+    @observable amount = 1
+
+    constructor(price) {
+        this.price = price
+    }
+
+    @computed({keepAlive: true})
+    get total() {
+        return this.price * this.amount
+    }
+}
+```
 
 ## Setters for computed values
 


### PR DESCRIPTION
This PR adds some paragraphs around computed caching and memoization that seem to be a stumbling block for new users of Mobx. I have been using Mobx for a few years coming from other derived data layers and this was never explicitly clear to me.  The use of the `get` keyword in example code with intention of not using the method as a getter is unintuitive.

I had to ask for clarification about this on stackoverflow: https://stackoverflow.com/questions/61129530/mobx-how-to-cache-computed-values

and then pieced together tidbits from https://github.com/mobxjs/mobx/issues/356

<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2329"><img src="https://gitpod.io/api/apps/github/pbs/github.com/kevzettler/mobx.git/002450e75a7a0b4d8bccd5b3435cb0f70df4011b.svg" /></a>

