### PR TITLE
GitHub issue/pr links in IDEA Git log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test/typescript/typescript-tests.js
 dist/
 **/.idea/*
 !/.idea/icon.png
+!/.idea/vcs.xml
 .wp-build*/
 *.iml
 *.ipr

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/mobxjs/mobx/issues/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
Clickable links in IDEA Git log

Before -`#2331`, `#2329`
After - #2331, #2329

<img width="658" alt="Screenshot 2020-04-18 at 14 55 22" src="https://user-images.githubusercontent.com/9942723/79637097-07d11d80-8185-11ea-823c-b9bfc58cbd34.png">


<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2335"><img src="https://gitpod.io/api/apps/github/pbs/github.com/turansky/mobx.git/3b74ae6a0808f5b618148d40b0be004cedc1ebcc.svg" /></a>

