### PR TITLE
replace word debounce with throttle in the documentation

### DIFF
--- a/docs/refguide/api.md
+++ b/docs/refguide/api.md
@@ -368,7 +368,7 @@ Returns a disposer function to cancel the side effect.
 **options**
 
 -   **`name?: string`**: A name for easier identification and debugging
--   **`delay?: number`**: the sideEffect will be delayed and debounced with the given `delay`. Defaults to `0`.
+-   **`delay?: number`**: the sideEffect will be delayed and throttled with the given `delay`. Defaults to `0`.
 -   **`onError?: (error) => void`**: error handler that will be triggered if the autorun function throws an exception
 -   **`scheduler?: (callback) => void`**: Set a custom scheduler to determine how re-running the autorun function should be scheduled
 -   **`requiresObservable?: boolean`** Enables [`reactionRequiresObservable`](#reactionrequiresobservable-boolean) locally for the autorun
@@ -400,14 +400,14 @@ Usage: `reaction(() => data, data => { sideEffect }, options)`.
 A variation on `autorun` that gives more fine-grained control on which observables that will be tracked.
 It takes two function, the first one is tracked and returns data that is used as input for the second one, the side effect.
 Unlike `autorun` the side effect won't be run initially, and any observables that are accessed while executing the side effect will not be tracked.
-The side effect can be debounced, just like `autorunAsync`.
+The side effect can be throttled, just like `autorunAsync`.
 
 [&laquo;details&raquo;](reaction.md)
 
 **options**
 
 -   **`fireImmediately?: boolean`**: Wait for a change before firing the _effect function_. Defaults to `false`.
--   **`delay?: number`**: the sideEffect will be delayed and debounced with the given `delay`. Defaults to `0`.
+-   **`delay?: number`**: the sideEffect will be delayed and throttled with the given `delay`. Defaults to `0`.
 -   **`equals`**: Custom equality function to determine whether the expr function differed from it's previous result, and hence should fire effect. Accepts the same options as the equals option of `computed`.
 -   Also accepts all of the options from [`autorun`](#autorun)
 -   **`requiresObservable?: boolean`** Enables [`reactionRequiresObservable`](#reactionrequiresobservable-boolean) locally for the reaction

--- a/docs/refguide/autorun.md
+++ b/docs/refguide/autorun.md
@@ -62,7 +62,7 @@ numbers.push(5)
 
 Autorun accepts as the second argument an options object with the following optional options:
 
--   `delay`: Number in milliseconds that can be used to debounce the effect function. If zero (the default), no debouncing will happen.
+-   `delay`: Number in milliseconds that can be used to throttle the effect function. If zero (the default), no throttling will happen.
 -   `name`: String that is used as name for this reaction in for example [`spy`](spy.md) events.
 -   `onError`: function that will handle the errors of this reaction, rather then propagating them.
 -   `scheduler`: Set a custom scheduler to determine how re-running the autorun function should be scheduled. It takes a function that should be invoked at some point in the future, for example: `{ scheduler: run => { setTimeout(run, 1000) }}`

--- a/docs/refguide/reaction.md
+++ b/docs/refguide/reaction.md
@@ -30,7 +30,7 @@ In other words: reaction requires you to produce the things you need in your sid
 Reaction accepts a third argument as an options object with the following optional options:
 
 -   `fireImmediately`: Boolean that indicates that the effect function should immediately be triggered after the first run of the data function. `false` by default.
--   `delay`: Number in milliseconds that can be used to debounce the effect function. If zero (the default), no debouncing will happen.
+-   `delay`: Number in milliseconds that can be used to throttle the effect function. If zero (the default), no throttling will happen.
 -   `equals`: `comparer.default` by default. If specified, this comparer function will be used to compare the previous and next values produced by the _data_ function. The _effect_ function will only be invoked if this function returns false. If specified, this will override `compareStructural`.
 -   `name`: String that is used as name for this reaction in for example [`spy`](spy.md) events.
 -   `onError`: function that will handle the errors of this reaction, rather then propagating them.


### PR DESCRIPTION
### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated changelog
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

Default scheduler for `reaction` and `autorun` is actually **throttling** the execution even though in the documentation it says it's **debouncing**. There is a big difference between the two, and I think the documentation should reflect that.
There is an issue opened because of this confusion: https://github.com/mobxjs/mobx/issues/1956
[throttle vs debounce example reminder](http://demo.nimius.net/debounce_throttle/)

<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2337"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ivandotv/mobx.git/b04ce422201e843abb33fb7cc178469183e1f578.svg" /></a>

Fixes #2337