### PR TITLE
docs: Fix simple typo, occured -> occurred

### DIFF
--- a/docs/assets/getting-started-assets/javascripts/react-with-addons.js
+++ b/docs/assets/getting-started-assets/javascripts/react-with-addons.js
@@ -15708,7 +15708,7 @@
 
                         /**
                          * @param {boolean} previouslyEnabled Enabled status of
-                         *   `ReactBrowserEventEmitter` before the reconciliation occured. `close`
+                         *   `ReactBrowserEventEmitter` before the reconciliation occurred. `close`
                          *   restores the previous value.
                          */
                         close: function(previouslyEnabled) {
@@ -16660,7 +16660,7 @@
                         },
 
                         /**
-                         * Simulates a top level event being dispatched from a raw event that occured
+                         * Simulates a top level event being dispatched from a raw event that occurred
                          * on an `Element` node.
                          * @param topLevelType {Object} A type from `EventConstants.topLevelTypes`
                          * @param {!Element} node The dom to simulate an event occurring on.
@@ -16675,7 +16675,7 @@
                         },
 
                         /**
-                         * Simulates a top level event being dispatched from a raw event that occured
+                         * Simulates a top level event being dispatched from a raw event that occurred
                          * on the `ReactDOMComponent` `comp`.
                          * @param topLevelType {Object} A type from `EventConstants.topLevelTypes`.
                          * @param comp {!ReactDOMComponent}
@@ -19805,7 +19805,7 @@
                         Mixin: Mixin,
 
                         /**
-                         * Token to look for to determine if an error occured.
+                         * Token to look for to determine if an error occurred.
                          */
                         OBSERVED_ERROR: {}
                     }


### PR DESCRIPTION
There is a small typo in docs/assets/getting-started-assets/javascripts/react-with-addons.js.

Should read `occurred` rather than `occured`.



<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2338"><img src="https://gitpod.io/api/apps/github/pbs/github.com/timgates42/mobx.git/ddf2c3f319ad2c49e7dd22e41e01dc8e7aa57a7e.svg" /></a>

