### PR TITLE
Fix for ObservableSet.prototype.forEach being non-reactive in 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # UNPUBLISHED (keep this here and add unpublished changes)
 
+-   Fixed ObservableSet.prototype.forEach not being reactive in 4.x [#2341](https://github.com/mobxjs/mobx/pull/2341) by [@melnikov-s](https://github.com/melnikov-s)
 -   Add error when computed value declared for unspecified getter [#1867](https://github.com/mobxjs/mobx/issues/1867) by [@berrunder](https://github.com/berrunder)
 
 # 5.15.4 / 4.15.4

--- a/src/v4/types/observableset.ts
+++ b/src/v4/types/observableset.ts
@@ -107,6 +107,7 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
     }
 
     forEach(callbackFn: (value: T, value2: T, set: Set<T>) => void, thisArg?: any) {
+        this._atom.reportObserved()
         this._data.forEach(value => {
             callbackFn.call(thisArg, value, value, this)
         })

--- a/test/v4/base/set.js
+++ b/test/v4/base/set.js
@@ -267,3 +267,17 @@ test("toJS", () => {
     expect(z.x).not.toBe(x)
     expect(mobx.isObservable(z.x)).toBeFalsy()
 })
+
+test("set.forEach is reactive", () => {
+    let c = 0
+    const s = set()
+
+    autorun(() => {
+        s.forEach(() => {})
+        c++
+    })
+
+    s.add(1)
+    s.add(2)
+    expect(c).toBe(3)
+})

--- a/test/v5/base/set.js
+++ b/test/v5/base/set.js
@@ -267,3 +267,17 @@ test("toJS", () => {
     expect(z.x).not.toBe(x)
     expect(mobx.isObservable(z.x)).toBeFalsy()
 })
+
+test("set.forEach is reactive", () => {
+    let c = 0
+    const s = set()
+
+    autorun(() => {
+        s.forEach(() => {})
+        c++
+    })
+
+    s.add(1)
+    s.add(2)
+    expect(c).toBe(3)
+})


### PR DESCRIPTION
It appears that there's a missing `reportObserved` on the `forEach` method within `ObservableSet` in mobx 4.x. This makes it non-reactive. Verified that 5.x is working as intended.  

Issue can be reproduced here: https://codesandbox.io/s/mobx-set-foreach-broken-t8bjg

```javascript
import { observable, autorun } from "mobx";

const set = observable(new Set());

autorun(() => {
  set.forEach(v => console.log(v));
});

set.add("bar"); // won't run
set.add("foo"); // won't run

```

<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2341"><img src="https://gitpod.io/api/apps/github/pbs/github.com/melnikov-s/mobx.git/f8667c7ee4fbb9ffdf5130ae9c1c631055c803be.svg" /></a>



<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2341"><img src="https://gitpod.io/api/apps/github/pbs/github.com/melnikov-s/mobx.git/3bf987d09a39983cc99ef5473ef19f6e337dea3a.svg" /></a>

