### PR TITLE
Fix #2326  pass correct array to callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Fixed ObservableSet.prototype.forEach not being reactive in 4.x [#2341](https://github.com/mobxjs/mobx/pull/2341) by [@melnikov-s](https://github.com/melnikov-s)
 -   Add error when computed value declared for unspecified getter [#1867](https://github.com/mobxjs/mobx/issues/1867) by [@berrunder](https://github.com/berrunder)
+-   Fixed [#2326](https://github.com/mobxjs/mobx/issues/2326) correct array is passed to callbacks by [@urugator](https://github.com/urugator)
 
 # 5.15.4 / 4.15.4
 

--- a/src/v4/types/observablearray.ts
+++ b/src/v4/types/observablearray.ts
@@ -629,21 +629,7 @@ addHiddenProp(ObservableArray.prototype, toStringTagSymbol(), "Array")
 /**
  * Wrap function from prototype
  */
-;[
-    //"every",
-    //"filter",
-    //"forEach",
-    "indexOf",
-    "join",
-    "lastIndexOf",
-    //"map",
-    //"reduce",
-    //"reduceRight",
-    "slice",
-    //"some",
-    "toString",
-    "toLocaleString"
-].forEach(funcName => {
+;["indexOf", "join", "lastIndexOf", "slice", "toString", "toLocaleString"].forEach(funcName => {
     const baseFunc = Array.prototype[funcName]
     invariant(
         typeof baseFunc === "function",

--- a/src/v4/types/observablearray.ts
+++ b/src/v4/types/observablearray.ts
@@ -663,7 +663,6 @@ addHiddenProp(ObservableArray.prototype, toStringTagSymbol(), "Array")
         `Base function not defined on Array prototype: '${funcName}'`
     )
     addHiddenProp(ObservableArray.prototype, funcName, function(callback, thisArg) {
-        //return baseFunc.apply(this.peek(), arguments)
         const adm = this.$mobx
         adm.atom.reportObserved()
         return adm.values[funcName]((...args) => {

--- a/test/v4/base/array.js
+++ b/test/v4/base/array.js
@@ -472,7 +472,11 @@ test("replace can handle large arrays", () => {
 test("can iterate arrays", () => {
     const x = mobx.observable([])
     const y = []
-    const d = mobx.reaction(() => Array.from(x), items => y.push(items), { fireImmediately: true })
+    const d = mobx.reaction(
+        () => Array.from(x),
+        items => y.push(items),
+        { fireImmediately: true }
+    )
 
     x.push("a")
     x.push("b")
@@ -623,4 +627,25 @@ test("reproduce #2021", () => {
     } finally {
         delete Array.prototype.extension
     }
+})
+
+test("correct array should be passed to callbacks #2326", () => {
+    const array = observable([1, 2, 3])
+
+    function callback() {
+        const lastArg = arguments[arguments.length - 1]
+        expect(lastArg).toBe(array)
+    }
+    ;[
+        "every",
+        "filter",
+        "find",
+        "findIndex",
+        //"flatMap" // not supported
+        "forEach",
+        "map",
+        "reduce",
+        "reduceRight",
+        "some"
+    ].forEach(method => array[method](callback))
 })

--- a/test/v5/base/array.js
+++ b/test/v5/base/array.js
@@ -401,7 +401,11 @@ test("replace can handle large arrays", () => {
 test("can iterate arrays", () => {
     const x = mobx.observable([])
     const y = []
-    const d = mobx.reaction(() => Array.from(x), items => y.push(items), { fireImmediately: true })
+    const d = mobx.reaction(
+        () => Array.from(x),
+        items => y.push(items),
+        { fireImmediately: true }
+    )
 
     x.push("a")
     x.push("b")
@@ -439,7 +443,10 @@ test("slice works", () => {
 test("slice is reactive", () => {
     const a = mobx.observable([1, 2, 3])
     let ok = false
-    when(() => a.slice().length === 4, () => (ok = true))
+    when(
+        () => a.slice().length === 4,
+        () => (ok = true)
+    )
     expect(ok).toBe(false)
     a.push(1)
     expect(ok).toBe(true)
@@ -587,4 +594,25 @@ test("reproduce #2021", () => {
     } finally {
         delete Array.prototype.extension
     }
+})
+
+test("correct array should be passed to callbacks #2326", () => {
+    const array = observable([1, 2, 3])
+
+    function callback() {
+        const lastArg = arguments[arguments.length - 1]
+        expect(lastArg).toBe(array)
+    }
+    ;[
+        "every",
+        "filter",
+        "find",
+        "findIndex",
+        "flatMap",
+        "forEach",
+        "map",
+        "reduce",
+        "reduceRight",
+        "some"
+    ].forEach(method => array[method](callback))
 })


### PR DESCRIPTION
additionally:
Possibly fixed `find`, `findIndex`, `includes` not being reactive in V5
Added support for `flatMap`/`flat` in V5

<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2348"><img src="https://gitpod.io/api/apps/github/pbs/github.com/urugator/mobx.git/b5784daf1aba927c30e54abb67cc1f5c50fc7c61.svg" /></a>

