### PR TITLE
Improve computed "get" error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # UNPUBLISHED (keep this here and add unpublished changes)
 
+-   Improve computed "get" error message [#1940](https://github.com/mobxjs/mobx/issues/1940) by [@ivandotv](https://github.com/ivandotv)
 -   Fixed ObservableSet.prototype.forEach not being reactive in 4.x [#2341](https://github.com/mobxjs/mobx/pull/2341) by [@melnikov-s](https://github.com/melnikov-s)
 -   Add error when computed value declared for unspecified getter [#1867](https://github.com/mobxjs/mobx/issues/1867) by [@berrunder](https://github.com/berrunder)
 

--- a/src/v4/core/computedvalue.ts
+++ b/src/v4/core/computedvalue.ts
@@ -107,7 +107,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
      * This is useful for working with vectors, mouse coordinates etc.
      */
     constructor(options: IComputedValueOptions<T>) {
-        invariant(options.get, "missing option for computed: get " + options.name)
+        invariant(options.get, `missing option for computed ${options.name}: get`)
         this.derivation = options.get!
         this.name = options.name || "ComputedValue@" + getNextId()
         if (options.set) this.setter = createAction(this.name + "-setter", options.set) as any

--- a/src/v4/core/computedvalue.ts
+++ b/src/v4/core/computedvalue.ts
@@ -107,7 +107,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
      * This is useful for working with vectors, mouse coordinates etc.
      */
     constructor(options: IComputedValueOptions<T>) {
-        invariant(options.get, "missing option for computed: get")
+        invariant(options.get, "missing option for computed: get " + options.name)
         this.derivation = options.get!
         this.name = options.name || "ComputedValue@" + getNextId()
         if (options.set) this.setter = createAction(this.name + "-setter", options.set) as any

--- a/src/v4/core/computedvalue.ts
+++ b/src/v4/core/computedvalue.ts
@@ -107,9 +107,9 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
      * This is useful for working with vectors, mouse coordinates etc.
      */
     constructor(options: IComputedValueOptions<T>) {
-        invariant(options.get, `missing option for computed ${options.name}: get`)
-        this.derivation = options.get!
         this.name = options.name || "ComputedValue@" + getNextId()
+        invariant(options.get, `missing option for computed ${this.name}: get`)
+        this.derivation = options.get!
         if (options.set) this.setter = createAction(this.name + "-setter", options.set) as any
         this.equals =
             options.equals ||
@@ -162,9 +162,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
         if (this.setter) {
             invariant(
                 !this.isRunningSetter,
-                `The setter of computed value '${
-                    this.name
-                }' is trying to update itself. Did you intend to update an _observable_ value, instead of the computed property?`
+                `The setter of computed value '${this.name}' is trying to update itself. Did you intend to update an _observable_ value, instead of the computed property?`
             )
             this.isRunningSetter = true
             try {
@@ -176,9 +174,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
             invariant(
                 false,
                 process.env.NODE_ENV !== "production" &&
-                    `[ComputedValue '${
-                        this.name
-                    }'] It is not possible to assign a new value to a computed value.`
+                    `[ComputedValue '${this.name}'] It is not possible to assign a new value to a computed value.`
             )
     }
 
@@ -264,16 +260,12 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
         }
         if (this.isTracing !== TraceMode.NONE) {
             console.log(
-                `[mobx.trace] '${
-                    this.name
-                }' is being read outside a reactive context. Doing a full recompute`
+                `[mobx.trace] '${this.name}' is being read outside a reactive context. Doing a full recompute`
             )
         }
         if (globalState.computedRequiresReaction) {
             console.warn(
-                `[mobx] Computed value ${
-                    this.name
-                } is being read outside a reactive context. Doing a full recompute`
+                `[mobx] Computed value ${this.name} is being read outside a reactive context. Doing a full recompute`
             )
         }
     }

--- a/src/v5/core/computedvalue.ts
+++ b/src/v5/core/computedvalue.ts
@@ -105,7 +105,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
      * This is useful for working with vectors, mouse coordinates etc.
      */
     constructor(options: IComputedValueOptions<T>) {
-        invariant(options.get, "missing option for computed: get")
+        invariant(options.get, "missing option for computed: get " + options.name)
         this.derivation = options.get!
         this.name = options.name || "ComputedValue@" + getNextId()
         if (options.set) this.setter = createAction(this.name + "-setter", options.set) as any

--- a/src/v5/core/computedvalue.ts
+++ b/src/v5/core/computedvalue.ts
@@ -105,9 +105,9 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
      * This is useful for working with vectors, mouse coordinates etc.
      */
     constructor(options: IComputedValueOptions<T>) {
-        invariant(options.get, "missing option for computed: get " + options.name)
-        this.derivation = options.get!
         this.name = options.name || "ComputedValue@" + getNextId()
+        invariant(options.get, `missing option for computed ${this.name}: get`)
+        this.derivation = options.get!
         if (options.set) this.setter = createAction(this.name + "-setter", options.set) as any
         this.equals =
             options.equals ||
@@ -171,9 +171,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
         if (this.setter) {
             invariant(
                 !this.isRunningSetter,
-                `The setter of computed value '${
-                    this.name
-                }' is trying to update itself. Did you intend to update an _observable_ value, instead of the computed property?`
+                `The setter of computed value '${this.name}' is trying to update itself. Did you intend to update an _observable_ value, instead of the computed property?`
             )
             this.isRunningSetter = true
             try {
@@ -185,9 +183,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
             invariant(
                 false,
                 process.env.NODE_ENV !== "production" &&
-                    `[ComputedValue '${
-                        this.name
-                    }'] It is not possible to assign a new value to a computed value.`
+                    `[ComputedValue '${this.name}'] It is not possible to assign a new value to a computed value.`
             )
     }
 
@@ -273,16 +269,12 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
         }
         if (this.isTracing !== TraceMode.NONE) {
             console.log(
-                `[mobx.trace] '${
-                    this.name
-                }' is being read outside a reactive context. Doing a full recompute`
+                `[mobx.trace] '${this.name}' is being read outside a reactive context. Doing a full recompute`
             )
         }
         if (globalState.computedRequiresReaction) {
             console.warn(
-                `[mobx] Computed value ${
-                    this.name
-                } is being read outside a reactive context. Doing a full recompute`
+                `[mobx] Computed value ${this.name} is being read outside a reactive context. Doing a full recompute`
             )
         }
     }


### PR DESCRIPTION
Consider this error:
```
    [mobx] missing option for computed: get

      63 | 
    > 64 |   constructor() {
         |                 ^
      65 |     this._cid = uuid()
      66 |     this._isNew = true
      67 |   }

      at invariant (node_modules/mobx/lib/mobx.js:94:15)
      at new ComputedValue (node_modules/mobx/lib/mobx.js:1152:9)
      at ObservableObjectAdministration.addComputedProp (node_modules/mobx/lib/mobx.js:4041:35)
      at Object.propertyCreator (node_modules/mobx/lib/mobx.js:584:34)
      at initializeInstance (node_modules/mobx/lib/mobx.js:334:19)
      at TestModel.set (node_modules/mobx/lib/mobx.js:316:17)
      at new Model (src/model/Model.ts:64:17)
      at new TestModel (src/__fixtures__/testModel.ts:16:5)
      at Object.<anonymous> (src/model/__tests__/model.test.ts:13:21)
```
This pull request makes the error: `[mobx] missing option for computed: get` a little bit clearer by also showing the `name` of the computed property.

[Error: [mobx] missing option for computed: get . Not able to make out what the issue exactly is](
https://github.com/mobxjs/mobx/issues/1940)


<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2361"><img src="https://gitpod.io/api/apps/github/pbs/github.com/ivandotv/mobx.git/e23f040851db7b5a173aba9eccc1b63b63632d7d.svg" /></a>

