### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -21,6 +21,10 @@ const users = [
 ]
 
 const siteConfig = {
+    algolia: {
+        apiKey: '500db32fbdbd53a814f42aafdfa26bd4',
+        indexName: 'mobxjs',
+    },
     title: "MobX", // Title for your website.
     tagline: "Simple, scalable state management",
 


### PR DESCRIPTION
👋 team,

This PR impacts only the documentation website. It follows the request made by @mweststrate 

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.

<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2393"><img src="https://gitpod.io/api/apps/github/pbs/github.com/s-pace/mobx.git/9025a46a77288e7e111d3427b542bff6ad645826.svg" /></a>

