### PR TITLE
Replaces jQuery with vanilla JS in store example

### DIFF
--- a/docs/best/store.md
+++ b/docs/best/store.md
@@ -262,7 +262,6 @@ Example of a store (using ES6 syntax):
 
 ```javascript
 import { makeAutoObservable, observable, computed, asStructure } from "mobx"
-import jquery from "jquery"
 
 export class UiState {
     language = "en_US"
@@ -271,15 +270,15 @@ export class UiState {
     // .struct makes sure observer won't be signaled unless the
     // dimensions object changed in a deepEqual manner
     windowDimensions = {
-        width: jquery(window).width(),
-        height: jquery(window).height()
+        width: window.innerWidth,
+        height: window.innerHeight
     }
 
     constructor() {
         makeAutoObservable(this, { windowDimensions: observable.struct })
-        jquery.resize(() => {
+        window.onresize = () => {
             this.windowDimensions = getWindowDimensions()
-        })
+        }
     }
 
     get appIsInSync() {


### PR DESCRIPTION
Docs-only change.

<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2408"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jamonholmgren/mobx.git/c69ef3f732133a1226c900e1ede285b0e1b3ef1f.svg" /></a>

