### PR TITLE
cache getKeys() of ObservableObjectAdministration

### DIFF
--- a/src/types/observableobject.ts
+++ b/src/types/observableobject.ts
@@ -291,10 +291,12 @@ export class ObservableObjectAdministration
             return this.keysValue_
         }
         // return Reflect.ownKeys(this.values) as any
-        const res: PropertyKey[] = []
-        for (const [key, value] of this.values_) if (value instanceof ObservableValue) res.push(key)
+        this.keysValue_ = []
+        for (const [key, value] of this.values_)
+            if (value instanceof ObservableValue) this.keysValue_.push(key)
+        if (__DEV__) Object.freeze(this.keysValue_)
         this.isStaledKeysValue_ = false
-        return (this.keysValue_ = res)
+        return this.keysValue_
     }
 
     private reportKeysChanged() {


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    🚨🚨🚨 IMPORTANT NOTICE 🚨🚨🚨

    Next major of MobX V6 is under development. Try to direct all changes toward `mobx6` branch instead of `master`.

    🚨🚨🚨 IMPORTANT NOTICE 🚨🚨🚨

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated changelog
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
I made the PR to cache getKeys() of ObservableObjectAdministration. 
When I run `yarn test`, the program hit the cache 91 times.




<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2410"><img src="https://gitpod.io/api/apps/github/pbs/github.com/MoonBall/mobx.git/3b93bd0fdd70ebd8b21ea8cae02c1da39f0e7101.svg" /></a>

