### PR TITLE
fix: observable canot be created when enforceActions is `always` #2424

### DIFF
--- a/src/v4/types/observableset.ts
+++ b/src/v4/types/observableset.ts
@@ -27,7 +27,9 @@ import {
     toStringTagSymbol,
     declareIterator,
     addHiddenFinalProp,
-    iteratorToArray
+    iteratorToArray,
+    allowStateChangesStart,
+    allowStateChangesEnd
 } from "../internal"
 
 const ObservableSetMarker = {}
@@ -239,14 +241,19 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
         }
 
         transaction(() => {
-            if (Array.isArray(other)) {
-                this.clear()
-                other.forEach(value => this.add(value))
-            } else if (isES6Set(other)) {
-                this.clear()
-                other.forEach(value => this.add(value))
-            } else if (other !== null && other !== undefined) {
-                fail("Cannot initialize set from " + other)
+            const prev = allowStateChangesStart(true)
+            try {
+                if (Array.isArray(other)) {
+                    this.clear()
+                    other.forEach(value => this.add(value))
+                } else if (isES6Set(other)) {
+                    this.clear()
+                    other.forEach(value => this.add(value))
+                } else if (other !== null && other !== undefined) {
+                    fail("Cannot initialize set from " + other)
+                }
+            } finally {
+                allowStateChangesEnd(prev) 
             }
         })
 

--- a/src/v5/types/observablemap.ts
+++ b/src/v5/types/observablemap.ts
@@ -32,7 +32,9 @@ import {
     untracked,
     onBecomeUnobserved,
     globalState,
-    convertToMap
+    convertToMap,
+    allowStateChangesStart,
+    allowStateChangesEnd
 } from "../internal"
 
 export interface IKeyValueMap<V = any> {
@@ -307,15 +309,22 @@ export class ObservableMap<K = any, V = any>
             other = other.toJS()
         }
         transaction(() => {
-            if (isPlainObject(other))
-                getPlainObjectKeys(other).forEach(key => this.set((key as any) as K, other[key]))
-            else if (Array.isArray(other)) other.forEach(([key, value]) => this.set(key, value))
-            else if (isES6Map(other)) {
-                if (other.constructor !== Map)
-                    fail("Cannot initialize from classes that inherit from Map: " + other.constructor.name) // prettier-ignore
-                other.forEach((value, key) => this.set(key, value))
-            } else if (other !== null && other !== undefined)
-                fail("Cannot initialize map from " + other)
+            const prev = allowStateChangesStart(true)
+            try {
+                if (isPlainObject(other))
+                    getPlainObjectKeys(other).forEach((key) =>
+                        this.set((key as any) as K, other[key])
+                    )
+                else if (Array.isArray(other)) other.forEach(([key, value]) => this.set(key, value))
+                else if (isES6Map(other)) {
+                    if (other.constructor !== Map)
+                        fail("Cannot initialize from classes that inherit from Map: " + other.constructor.name) // prettier-ignore
+                    other.forEach((value, key) => this.set(key, value))
+                } else if (other !== null && other !== undefined)
+                    fail("Cannot initialize map from " + other)
+            } finally {
+                allowStateChangesEnd(prev)
+            }
         })
         return this
     }

--- a/src/v5/types/observableset.ts
+++ b/src/v5/types/observableset.ts
@@ -24,7 +24,9 @@ import {
     untracked,
     makeIterable,
     transaction,
-    isES6Set
+    isES6Set,
+    allowStateChangesStart,
+    allowStateChangesEnd
 } from "../internal"
 
 const ObservableSetMarker = {}
@@ -221,14 +223,19 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
         }
 
         transaction(() => {
-            if (Array.isArray(other)) {
-                this.clear()
-                other.forEach(value => this.add(value))
-            } else if (isES6Set(other)) {
-                this.clear()
-                other.forEach(value => this.add(value))
-            } else if (other !== null && other !== undefined) {
-                fail("Cannot initialize set from " + other)
+            const prev = allowStateChangesStart(true)
+            try {
+                if (Array.isArray(other)) {
+                    this.clear()
+                    other.forEach(value => this.add(value))
+                } else if (isES6Set(other)) {
+                    this.clear()
+                    other.forEach(value => this.add(value))
+                } else if (other !== null && other !== undefined) {
+                    fail("Cannot initialize set from " + other)
+                } 
+            } finally {
+                allowStateChangesEnd(prev)
             }
         })
 

--- a/test/v4/base/observables.js
+++ b/test/v4/base/observables.js
@@ -2137,3 +2137,14 @@ test("observable supports non-enumerable getters #2386", () => {
     expect(o.double).toBe(1)
     expect(mobx.isObservableProp(o, "double")).toBe(true)
 })
+
+test("observable can be created when enforceActions is `always` #2424", () => {
+    mobx.configure({ enforceActions: "always" });
+    observable.array([["item", "text"]]);
+    observable.set(["item"]);
+    observable.map([
+        ["item", "text"]
+    ]);
+    observable.object({ item: "text" });
+    mobx.configure({ enforceActions: "never" });
+})

--- a/test/v5/base/observables.js
+++ b/test/v5/base/observables.js
@@ -2137,3 +2137,14 @@ test("observable supports non-enumerable getters #2386", () => {
     expect(o.double).toBe(1)
     expect(mobx.isObservableProp(o, "double")).toBe(true)
 })
+
+test("observable can be created when enforceActions is `always` #2424", () => {
+    mobx.configure({ enforceActions: "always" });
+    observable.array([["item", "text"]]);
+    observable.set(["item"]);
+    observable.map([
+        ["item", "text"]
+    ]);
+    observable.object({ item: "text" });
+    mobx.configure({ enforceActions: "never" });
+})


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    🚨🚨🚨 IMPORTANT NOTICE 🚨🚨🚨

    Next major of MobX V6 is under development. Try to direct all changes toward `mobx6` branch instead of `master`.

    🚨🚨🚨 IMPORTANT NOTICE 🚨🚨🚨

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->
fix: observable canot be created when enforceActions is `always` https://github.com/mobxjs/mobx/issues/2424

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated changelog
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->


<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2425"><img src="https://gitpod.io/api/apps/github/pbs/github.com/mobxjs/mobx.git/a91da70da8509201c94cfdabcb5bc65f23c576ff.svg" /></a>

