### PR TITLE
Don't call Action while ComputedValue is computing

### DIFF
--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -60,6 +60,11 @@ export function executeAction(
     scope?: any,
     args?: IArguments
 ) {
+    if (__DEV__ && globalState.computingValue) {
+        console.warn(
+            `[MobX] Don't call Action ${actionName} while ComputedValue ${globalState.computingValue.name_} is computing`
+        )
+    }
     const runInfo = _startAction(actionName, canRunAsDeriviation, scope, args)
     try {
         return fn.apply(scope, args)

--- a/src/core/computedvalue.ts
+++ b/src/core/computedvalue.ts
@@ -217,6 +217,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
         this.isComputing_ = true
         // don't allow state changes during computation
         const prev = allowStateChangesStart(false)
+        const prevComputingValue = computingValueStart(this)
         let res: T | CaughtException
         if (track) {
             res = trackDerivedFunction(this, this.derivation_, this.scope_)
@@ -231,6 +232,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
                 }
             }
         }
+        computingValueEnd(prevComputingValue)
         allowStateChangesEnd(prev)
         this.isComputing_ = false
         return res
@@ -297,3 +299,13 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
 }
 
 export const isComputedValue = createInstanceofPredicate("ComputedValue", ComputedValue)
+
+export function computingValueStart(computingValue: ComputedValue<any> | null) {
+    const prev = globalState.computingValue
+    globalState.computingValue = computingValue
+    return prev
+}
+
+export function computingValueEnd(prev: ComputedValue<any> | null) {
+    globalState.computingValue = prev
+}

--- a/src/core/globalstate.ts
+++ b/src/core/globalstate.ts
@@ -1,4 +1,4 @@
-import { IDerivation, IObservable, Reaction, die, getGlobal } from "../internal"
+import { IDerivation, IObservable, ComputedValue, Reaction, die, getGlobal } from "../internal"
 
 /**
  * These values will persist if global state is reset
@@ -135,6 +135,11 @@ export class MobXGlobals {
      * print warnings about code that would fail if proxies weren't available
      */
     verifyProxies = false
+
+    /**
+     * Currently running ComputedValue
+     */
+    computingValue: ComputedValue<any> | null = null
 }
 
 let canMergeGlobalState = true

--- a/test/v5/base/__snapshots__/action.js.snap
+++ b/test/v5/base/__snapshots__/action.js.snap
@@ -2,13 +2,13 @@
 
 exports[`error logging, #1836 - 1 1`] = `
 Array [
-  "<STDOUT> [mobx] (error in reaction 'Autorun@68' suppressed, fix error of causing action below)",
+  "<STDOUT> [mobx] (error in reaction 'Autorun@63' suppressed, fix error of causing action below)",
   "<STDERR> Error: Action error",
 ]
 `;
 
 exports[`error logging, #1836 - 2 1`] = `
 Array [
-  "<STDERR> [mobx] Encountered an uncaught exception that was thrown by a reaction or observer component, in: 'Reaction[Autorun@71]'",
+  "<STDERR> [mobx] Encountered an uncaught exception that was thrown by a reaction or observer component, in: 'Reaction[Autorun@66]'",
 ]
 `;


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    🚨🚨🚨 IMPORTANT NOTICE 🚨🚨🚨

    Next major of MobX V6 is under development. Try to direct all changes toward `mobx6` branch instead of `master`.

    🚨🚨🚨 IMPORTANT NOTICE 🚨🚨🚨

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

Warn when call action while ComputedValue is computing. This PR is related to https://github.com/mobxjs/mobx/issues/2346

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated changelog
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
