### PR TITLE
Docs grammar corrections II

### DIFF
--- a/docs/intro/concepts.md
+++ b/docs/intro/concepts.md
@@ -16,16 +16,18 @@ MobX distinguishes the following three concepts in your application:
 2. Actions
 3. Derivations
 
-Let's take a closer look at these concepts. Or, alternatively, in the [10 minute introduction to MobX and React](https://mobx.js.org/getting-started) you can interactively dive deeper into these concepts step by step and build a simple Todo list app using [React](https://facebook.github.io/react/) around it.
+Let's take a closer look at these concepts below, or alternatively, in the [10 minute introduction to MobX and React](https://mobx.js.org/getting-started) where you can interactively dive deeper into these concepts step by step and build a simple Todo list app using [React](https://facebook.github.io/react/) around it.
 
 ### 1. Define state and make it observable
 
 _State_ is the data that drives your application.
-Usually there is _domain specific state_ like a list of todo items and there is _view state_ such as the currently selected element.
-State is like spreadsheets cells that hold a value.
+Usually, there is _domain specific state_ like a list of todo items, and there is _view state_, such as the currently selected element.
+State is like spreadsheet cells that hold a value.
 
-Store state in any data structure you like; plain objects, array, classes, cyclic data structures, references, it doesn't matter for the workings of MobX.
-Just make sure that all properties that you want to change over time are marked `observable` so that MobX can track them. Here is a simple example:
+Store state in any data structure you like: plain objects, arrays, classes, cyclic data structures or references. It doesn't matter for the workings of MobX.
+Just make sure that all properties you want to change over time are marked `observable` so MobX can track them.
+
+Here is a simple example:
 
 ```javascript
 import { makeObservable, observable, action } from "mobx"
@@ -50,22 +52,22 @@ class Todo {
 }
 ```
 
-(Tip: this example could be shortened by using [`makeAutoObservable`](../refguide/observable.md) instead, but by being explicit we can show the different concepts in detail)
+**Hint**: this example can be shortened using [`makeAutoObservable`](../refguide/observable.md), but by being explicit we can showcase the different concepts in greater detail.
 
 Using `observable` is like turning a property of an object into a spreadsheet cell.
-But unlike spreadsheets, these values can be not only primitive values, but also references, objects and arrays.
+But unlike spreadsheets, these values can not only be primitive values, but also references, objects and arrays.
 
-But what about `toggle`, which we marked `action`?
+But what about `toggle`, which we marked as `action`?
 
 ### 2. Update state using actions
 
 An _action_ is any piece of code that changes the _state_. User events, backend data pushes, scheduled events, etc.
 An action is like a user that enters a new value into a spreadsheet cell.
 
-In the `Todo` model you can see that we have a method `toggle` that changes the value of `finished`. `finished` is marked as `observable`. MobX recommends that you mark any code that changes `observable`s as [`action`](../refguide/action.md), so that MobX can automatically apply transactions for optimal performance.
+In the `Todo` model above you can see that we have a `toggle` method that changes the value of `finished`. `finished` is marked as `observable`. It is recommended that you mark any piece of code that changes `observable`'s as an [`action`](../refguide/action.md). That way MobX can automatically apply transactions for effortless optimal performance.
 
-Using actions helps you to structure your code and prevents from inadvertently changing state when you don't want to.
-Methods that modify state are called _actions_ in MobX terminology. In contrast to _views_ which compute new information based on the current state.
+Using actions helps you structure your code and prevents you from inadvertently changing state when you don't want to.
+Methods that modify state are called _actions_ in MobX terminology. In contrast to _views_, which compute new information based on the current state.
 Every method should serve at most one of those two goals.
 
 ### 3. Create derivations that automatically respond to state changes
@@ -73,21 +75,21 @@ Every method should serve at most one of those two goals.
 _Anything_ that can be derived from the _state_ without any further interaction is a derivation.
 Derivations exist in many forms:
 
--   The _user interface_.
--   _Derived data_, such as the number of `todos` left.
--   _Backend integrations_ like sending changes to the server.
+-   The _user interface_
+-   _Derived data_, such as the number of remaining `todos`
+-   _Backend integrations_, e.g. sending changes to the server
 
-MobX distinguishes two kind of derivations:
+MobX distinguishes between two kinds of derivations:
 
--   _Computed values_. These are values that can always be derived from the current observable state using a pure function.
--   _Reactions_. Reactions are side effects that need to happen automatically if the state changes. These are needed as a bridge between imperative and reactive programming. Or to make it more clear, they are ultimately needed to achieve I/O.
+-   _Computed values_, which can always be derived from the current observable state using a pure function
+-   _Reactions_, side effects that need to happen automatically when the state changes (bridge between imperative and reactive programming)
 
-People starting with MobX tend to use reactions too often.
-The golden rule is: if you want to create a value based on the current state, use `computed`.
+When starting with MobX, people tend to overuse reactions.
+The golden rule is, always use `computed` if you want to create a value based on the current state.
 
 #### 3.1. Model derived values using computed
 
-You created a computed value by defining a property using a JS getter function (`get`) and then marking it with `computed` with `makeObservable`.
+To create a *computed* value define a property using a JS getter function `get` and then mark it as `computed` with `makeObservable`.
 
 ```javascript
 import { makeObservable, observable, computed } from "mobx"
@@ -108,13 +110,13 @@ class TodoList {
 
 MobX will ensure that `unfinishedTodoCount` is updated automatically when a todo is added or when one of the `finished` properties is modified.
 
-Computations like these resemble formulas in spreadsheet programs like MS Excel. They update automatically, but only when required. That is, if something is interested in their outcome.
+These computations resemble formulas in spreadsheet programs like MS Excel. They update automatically, but only when required. That is, if something is interested in their outcome.
 
 #### 3.2. Model side effects using reactions
 
-For you as a user to be able to see a change in state or computed values on the screen a _reaction_ is needed that repaints part of the GUI.
+For you as a user to be able to see a change in state or computed values on the screen a _reaction_ is needed that repaints a part of the GUI.
 
-Reactions are similar to computed values, but instead of producing information, reactions produces side effect like printing to the console, making network requests, incrementally updating the React component tree to patch the DOM, etc.
+Reactions are similar to computed values, but instead of producing information, reactions produce side effect like printing to the console, making network requests, incrementally updating the React component tree to patch the DOM, etc.
 In short, reactions bridge the worlds of [reactive](https://en.wikipedia.org/wiki/Reactive_programming) and [imperative](https://en.wikipedia.org/wiki/Imperative_programming) programming.
 
 By far the most used form of reactions are UI components.
@@ -124,7 +126,7 @@ as making a network request when submitting a form, should be triggered explicit
 
 #### 3.3. Reactive React components
 
-If you are using React, you can turn your components into reactive components by wrapping them with the [`observer`](http://mobxjs.github.io/mobx/react/react-integration.html) function from the `mobx-react-lite` package.
+If you are using React, you can make your components reactive by wrapping them with the [`observer`](http://mobxjs.github.io/mobx/react/react-integration.html) function from the bindings package you've [chosen during installation](installation.md#installation). In this example, we're going to use the more lightweight `mobx-react-lite` package.
 
 ```javascript
 import * as React from "react"
@@ -155,18 +157,18 @@ render(<TodoListView todoList={store} />, document.getElementById("root"))
 
 `observer` converts React components into derivations of the data they render.
 When using MobX there are no smart or dumb components.
-All components render smartly but are defined in a dumb manner. MobX will simply make sure the components are always re-rendered whenever needed, and never more than that.
+All components render smartly, but are defined in a dumb manner. MobX will simply make sure the components are always re-rendered whenever needed, and never more than that.
 
 So the `onClick` handler in the above example will force the proper `TodoView` to render as it uses the `toggle` action, but will only cause the `TodoListView` to render if the number of unfinished tasks has changed.
 And if you would remove the `Tasks left` line (or put that into a separate component), the `TodoListView` will no longer re-render when ticking a task.
 
-To learn more about how React works with MobX, read [React integration](../react/react-integration.md).
+To learn more about how React works with MobX, read about it in [React integration](../react/react-integration.md).
 
 #### 3.4. Custom reactions
 
-You will need them rarely, but custom reactions can simply be created using the [`autorun`](../refguide/autorun.md#autorun),
+You will need them rarely, but they can be created using the [`autorun`](../refguide/autorun.md#autorun),
 [`reaction`](../refguide/autorun.md#reaction) or [`when`](../refguide/autorun.md#when) functions to fit your specific situations.
-For example the following `autorun` prints a log message each time the amount of `unfinishedTodoCount` changes:
+For example, the following `autorun` prints a log message each time the amount of `unfinishedTodoCount` changes:
 
 ```javascript
 /* a function that automatically observes the state */
@@ -175,11 +177,11 @@ autorun(() => {
 })
 ```
 
-Why does a new message get printed each time the `unfinishedTodoCount` is changed? The answer is this rule of thumb:
+Why does a new message get printed every time the `unfinishedTodoCount` is changed? The answer is this rule of thumb:
 
 _MobX reacts to any existing observable property that is read during the execution of a tracked function._
 
-For an in-depth explanation about how MobX determines to which observables needs to be reacted, check [understanding what MobX reacts to](../best/what-does-mobx-react-to.md).
+For an in-depth explanation about how MobX determines which observables need to be reacted to, check out [understanding what MobX reacts to](../best/what-does-mobx-react-to.md).
 
 ## Principles
 
@@ -187,21 +189,21 @@ MobX supports a uni-directional data flow where _actions_ change the _state_, wh
 
 ![Action, State, View](../assets/action-state-view.png)
 
-All _Derivations_ are updated **automatically** and **atomically** when the _state_ changes. As a result it is never possible to observe intermediate values.
+All _derivations_ are updated **automatically** and **atomically** when the _state_ changes. As a result, it is never possible to observe intermediate values.
 
-All _Derivations_ are updated **synchronously** by default. This means that, for example, _actions_ can safely inspect a computed value directly after altering the _state_.
+All _derivations_ are updated **synchronously** by default. This means that, for example, _actions_ can safely inspect a computed value directly after altering the _state_.
 
 _Computed values_ are updated **lazily**. Any computed value that is not actively in use will not be updated until it is needed for a side effect (I/O).
 If a view is no longer in use it will be garbage collected automatically.
 
-All _Computed values_ should be **pure**. They are not supposed to change _state_.
+All _computed values_ should be **pure**. They are not supposed to change _state_.
 
 For some more background context, read [the fundamental principles behind MobX](https://hackernoon.com/the-fundamental-principles-behind-mobx-7a725f71f3e8).
 
 ## Try it out!
 
-You can play with the above yourself on [CodeSandbox](https://codesandbox.io/s/concepts-principles-il8lt?file=/src/index.js:1161-1252).
+You can play with the above examples yourself on [CodeSandbox](https://codesandbox.io/s/concepts-principles-il8lt?file=/src/index.js:1161-1252).
 
 ## Linting
 
-If you find it hard to adopt the mental model of MobX, MobX can be configured to be very strict and warn at run-time whenever you deviate from these patterns. See [linting MobX](../refguide/configure.md#linting-options).
+If you find it hard to adopt the mental model of MobX, configure it to be very strict and warn at run-time whenever you deviate from these patterns. See [linting MobX](../refguide/configure.md#linting-options).

--- a/docs/intro/concepts.md
+++ b/docs/intro/concepts.md
@@ -207,4 +207,4 @@ You can play with the above examples yourself on [CodeSandbox](https://codesandb
 
 ## Linting
 
-If you find it hard to adopt the mental model of MobX, configure it to be very strict and warn at run-time whenever you deviate from these patterns. Check out [linting MobX](../refguide/configure.md#linting-options).
+If you find it hard to adopt the mental model of MobX, configure it to be very strict and warn at runtime whenever you deviate from these patterns. Check out [linting MobX](../refguide/configure.md#linting-options).

--- a/docs/intro/concepts.md
+++ b/docs/intro/concepts.md
@@ -25,7 +25,7 @@ Usually, there is _domain specific state_ like a list of todo items, and there i
 State is like spreadsheet cells that hold a value.
 
 Store state in any data structure you like: plain objects, arrays, classes, cyclic data structures or references. It doesn't matter for the workings of MobX.
-Just make sure that all properties you want to change over time are marked `observable` so MobX can track them.
+Just make sure that all properties you want to change over time are marked as `observable` so MobX can track them.
 
 Here is a simple example:
 
@@ -116,7 +116,8 @@ These computations resemble formulas in spreadsheet programs like MS Excel. They
 
 For you as a user to be able to see a change in state or computed values on the screen a _reaction_ is needed that repaints a part of the GUI.
 
-Reactions are similar to computed values, but instead of producing information, reactions produce side effect like printing to the console, making network requests, incrementally updating the React component tree to patch the DOM, etc.
+Reactions are similar to computed values, but instead of producing information, reactions produce side effects like printing to the console, making network requests, incrementally updating React component tree to patch the DOM, etc.
+
 In short, reactions bridge the worlds of [reactive](https://en.wikipedia.org/wiki/Reactive_programming) and [imperative](https://en.wikipedia.org/wiki/Imperative_programming) programming.
 
 By far the most used form of reactions are UI components.
@@ -159,16 +160,16 @@ render(<TodoListView todoList={store} />, document.getElementById("root"))
 When using MobX there are no smart or dumb components.
 All components render smartly, but are defined in a dumb manner. MobX will simply make sure the components are always re-rendered whenever needed, and never more than that.
 
-So the `onClick` handler in the above example will force the proper `TodoView` to render as it uses the `toggle` action, but will only cause the `TodoListView` to render if the number of unfinished tasks has changed.
-And if you would remove the `Tasks left` line (or put that into a separate component), the `TodoListView` will no longer re-render when ticking a task.
+So the `onClick` handler in the above example will force the proper `TodoView` component to render as it uses the `toggle` action, but will only cause the `TodoListView` component to render if the number of unfinished tasks has changed.
+And if you would remove the `Tasks left` line (or put that into a separate component), the `TodoListView` component will no longer re-render when ticking a task.
 
-To learn more about how React works with MobX, read about it in [React integration](../react/react-integration.md).
+To learn more about how React works with MobX, check out [React integration](../react/react-integration.md).
 
 #### 3.4. Custom reactions
 
 You will need them rarely, but they can be created using the [`autorun`](../refguide/autorun.md#autorun),
 [`reaction`](../refguide/autorun.md#reaction) or [`when`](../refguide/autorun.md#when) functions to fit your specific situations.
-For example, the following `autorun` prints a log message each time the amount of `unfinishedTodoCount` changes:
+For example, the following `autorun` prints a log message every time the amount of `unfinishedTodoCount` changes:
 
 ```javascript
 /* a function that automatically observes the state */
@@ -181,7 +182,7 @@ Why does a new message get printed every time the `unfinishedTodoCount` is chang
 
 _MobX reacts to any existing observable property that is read during the execution of a tracked function._
 
-For an in-depth explanation about how MobX determines which observables need to be reacted to, check out [understanding what MobX reacts to](../best/what-does-mobx-react-to.md).
+To learn more about how MobX determines which observables need to be reacted to, check out [understanding what MobX reacts to](../best/what-does-mobx-react-to.md).
 
 ## Principles
 

--- a/docs/intro/concepts.md
+++ b/docs/intro/concepts.md
@@ -199,7 +199,7 @@ If a view is no longer in use it will be garbage collected automatically.
 
 All _computed values_ should be **pure**. They are not supposed to change _state_.
 
-For some more background context, read [the fundamental principles behind MobX](https://hackernoon.com/the-fundamental-principles-behind-mobx-7a725f71f3e8).
+To learn more about the background context, check out [the fundamental principles behind MobX](https://hackernoon.com/the-fundamental-principles-behind-mobx-7a725f71f3e8).
 
 ## Try it out!
 
@@ -207,4 +207,4 @@ You can play with the above examples yourself on [CodeSandbox](https://codesandb
 
 ## Linting
 
-If you find it hard to adopt the mental model of MobX, configure it to be very strict and warn at run-time whenever you deviate from these patterns. See [linting MobX](../refguide/configure.md#linting-options).
+If you find it hard to adopt the mental model of MobX, configure it to be very strict and warn at run-time whenever you deviate from these patterns. Check out [linting MobX](../refguide/configure.md#linting-options).

--- a/docs/react/react-integration.md
+++ b/docs/react/react-integration.md
@@ -16,9 +16,9 @@ import {observer} from 'mobx-react-lite
 const MyComponent = observer(props => ReactElement)
 ```
 
-While MobX works independently from React they are most commonly used together. In [the gist of Mobx](../intro/concepts.md) you have already seen the most important part of this integration: the `observer` [HoC](https://reactjs.org/docs/higher-order-components.html) that you can wrap around a React component.
-`observer` is provided by the separate [`mobx-react-lite` package](https://github.com/mobxjs/mobx-react-lite).
-Using `observer` is pretty straight forward [[try it]](https://codesandbox.io/s/minimal-observer-p9ti4?file=/src/index.tsx):
+While MobX works independently from React, they are most commonly used together. In [the gist of Mobx](../intro/concepts.md) you have already seen the most important part of this integration: the `observer` [HoC](https://reactjs.org/docs/higher-order-components.html) that you can wrap around a React component.
+
+`observer` is provided by a separate React bindings package you choose [during installation](../intro/installation.md#installation). In this example, we're going to use the more lightweight [`mobx-react-lite` package](https://github.com/mobxjs/mobx-react-lite).
 
 ```javascript
 import React from "react"
@@ -40,8 +40,8 @@ class Timer {
 
 const myTimer = new Timer()
 
-// A function component wrapped with `observer` will reacts to any
-// future change in an observable it used before
+// A function component wrapped with `observer` will react
+// to any future change in an observable it used before.
 const TimerView = observer(({ timer }) => <span>Seconds passed: {timer.secondsPassed}</span>)
 
 ReactDOM.render(<TimerView timer={myTimer} />, document.body)
@@ -50,22 +50,23 @@ setInterval(() => {
     myTimer.increaseTimer()
 }, 1000)
 ```
+**Hint:** you can play with the above example yourself on [CodeSandbox](https://codesandbox.io/s/minimal-observer-p9ti4?file=/src/index.tsx).
 
-The `observer` HoC subscribes React components automatically to _any observables_ that are used _during render_.
+The `observer` HoC subscribes React components automatically to _any observables_ that are used _during rendering_.
 As a result, components will automatically re-render when relevant observables change.
 It also makes sure that components don't re-render when there are _no relevant_ changes.
-So, observables that are accessible by the component, but not actually read, won't cause a re-render ever.
-As a result MobX applications are in practice very well optimized out of the box and typically don't need any additional code to prevent excessive rendering.
+So, observables that are accessible by the component, but not actually read, won't ever cause a re-render.
 
-For `observer` to work it doesn't matter _how_ the observables arrive in the component; only that they are read.
+In practice this makes MobX applications very well optimized out of the box and typically don't need any additional code to prevent excessive rendering.
+
+For `observer` to work, it doesn't matter _how_ the observables arrive in the component, only that they are read.
 Reading observables deeply is fine, complex expression like `todos[0].author.displayName` work out of the box.
-This makes the subscription mechanism much more precise and efficient compared to other framework in which data dependencies have to be declared explicitly or be pre-computed (with for example selectors).
+This makes the subscription mechanism much more precise and efficient compared to other frameworks in which data dependencies have to be declared explicitly or be pre-computed (e.g. selectors).
 
 ## Local and external state
 
-Since it doesn't matter (technically that is) which observables we read, or where observables originated from,
-there is great flexibility in how state is organized.
-The examples below demonstrate different patterns on how external and local observable state can be used in `observer` components.
+There is great flexibility in how state is organized, since it doesn't matter (technically that is) which observables we read or where observables originated from.
+The examples below demonstrate different patterns on how external and local observable state can be used in components wrapped with `observer`.
 
 ### Using external state in `observer` components
 
@@ -88,7 +89,7 @@ ReactDOM.render(<TimerView timer={myTimer} />, document.body)
 <!--using global variables-->
 
 Since it doesn't matter _how_ we got the reference to an observable, we can consume
-observables from outer scopes directly. (Including from imports etc).
+observables from outer scopes directly (including from imports, etc.).
 
 ```javascript
 const myTimer = new Timer() // see Timer definition above
@@ -99,7 +100,7 @@ const TimerView = observer(() => <span>Seconds passed: {myTimer.secondsPassed}</
 ReactDOM.render(<TimerView />, document.body)
 ```
 
-Using observables directly works very well, but since this typically introduces module state, this pattern might complicate unit testing, and we recommend using React Context instead.
+Using observables directly works very well, but since this typically introduces module state, this pattern might complicate unit testing. Instead, we recommend using React Context instead.
 
 <!--using React context-->
 
@@ -134,7 +135,7 @@ Note that we don't recommend ever replacing the `value` of a `Provider` with a d
 ### Using local observable state in `observer` components
 
 Since observables used by `observer` can come from anywhere, they can be local state as well.
-Again, different options are available for us:
+Again, different options are available for us.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--`useState` with observable class-->
@@ -219,24 +220,26 @@ ReactDOM.render(<TimerView />, document.body)
 
 ### You might not need locally observable state
 
-In general we recommend to not resort to MobX observables for local component state too quickly; as this can theoretically lock you out of some features of React's Suspense mechanism.
-As a rule of thumb use MobX observables when the state captures domain data that is shared among components (including children), such as todo items, users, bookings, etc.
-State that is only captures UI state, such as loading state, selections, etc, might be better served by the [`useState` hook](https://reactjs.org/docs/hooks-state.html), since this allows you to leverage React suspense features in the future.
+In general we recommend to not resort to MobX observables for local component state too quickly, as this can theoretically lock you out of some features of React's Suspense mechanism.
+As a rule of thumb, use MobX observables when the state captures domain data that is shared among components (including children). Such as todo items, users, bookings, etc.
+
+State that only captures UI state, like loading state, selections, etc, might be better served by the [`useState` hook](https://reactjs.org/docs/hooks-state.html), since this will allow you to leverage React suspense features in the future.
 
 Using observables inside React components adds value as soon as they are either 1) deep, 2) have computed values or 3) are shared with other `observer` components.
 
-## Always read observables inside `observer` components.
+## Always read observables inside `observer` components
 
-You might be wondering, when to apply `observer`? The simple rule of thumb is: _apply `observer` to all components that read observable data_.
-`observer` only enhances the component you are decorating, not the components called by it. So usually all your components should be wrapped by `observer`. Don't worry, this is not inefficient, in contrast, more `observer` components make rendering more efficient as updates become more fine-grained.
+You might be wondering, when do I apply `observer`? The simple rule of thumb is: _apply `observer` to all components that read observable data_.
+
+`observer` only enhances the component you are decorating, not the components called by it. So usually all your components should be wrapped by `observer`. Don't worry, this is not inefficient. On the contrary, more `observer` components make rendering more efficient as updates become more fine-grained.
 
 ### Tip: Grab values from objects as late as possible
 
-`observer` works the best if you pass object references around as long as possible, and only read their properties inside the `observer` based components that are going to render them into the DOM / low-level components.
+`observer` works best if you pass object references around as long as possible, and only read their properties inside the `observer` based components that are going to render them into the DOM / low-level components.
 In other words, `observer` reacts to the fact that you 'dereference' a value from an object.
 
 In the above example, the `TimerView` component would **not** react to future changes if it was defined
-as follows, because the `.secondsPassed` is not read inside the `observer` component, but outside, and hence _not_ tracked:
+as follows, because the `.secondsPassed` is not read inside the `observer` component, but outside, and is hence _not_ tracked:
 
 ```javascript
 const TimerView = observer(({ secondsPassed }) => <span>Seconds passed: {secondsPassed}</span>)
@@ -244,15 +247,15 @@ const TimerView = observer(({ secondsPassed }) => <span>Seconds passed: {seconds
 React.render(<TimerViewer secondPassed={myTimer.secondsPassed} />, document.body)
 ```
 
-Note that this is a different mindset from other libraries like React-redux, where it is a good practice to dereference early and pass primitives down, to better leverage memoization.
-If the problem is not entirely clear, make sure to study [what does MobX react to?](../best/what-does-mobx-react-to.md).
+Note that this is a different mindset from other libraries like `react-redux`, where it is a good practice to dereference early and pass primitives down, to better leverage memoization.
+If the problem is not entirely clear, make sure to check out [what does MobX react to?](../best/what-does-mobx-react-to.md).
 
 ### Don't pass observables into components that aren't `observer`
 
-Components wrapped with `observer` _only_ subscribe to observables used during the _own_ render of the component. So if observable objects/ arrays / maps are passed to child components, those have to be marked as `observer` as well.
+Components wrapped with `observer` _only_ subscribe to observables used during their _own_ rendering of the component. So if observable objects / arrays / maps are passed to child components, those have to be wrapped with `observer` as well.
 This is also true for any callback based components.
 
-If you want to pass observables to a component that isn't `observer`, either because it is a third-party component, or because you want to keep that component MobX agnostic, you will have to [convert the observables to plain JavaScript values or structures](../refguide/observable.md#converting-observables-back-to-vanilla-javascript-collections) before passing them on.
+If you want to pass observables to a component that isn't an `observer`, either because it is a third-party component, or because you want to keep that component MobX agnostic, you will have to [convert the observables to plain JavaScript values or structures](../refguide/observable.md#converting-observables-back-to-vanilla-javascript-collections) before passing them on.
 
 To elaborate on the above,
 take the following example observable `todo` object, a `TodoView` component (observer) and an imaginary `GridRow` component that takes a column / value mapping, but which isn't an `observer`:
@@ -268,17 +271,18 @@ class Todo {
 }
 
 const TodoView = observer(({ todo }: { todo: Todo }) =>
-   // WRONG: GridRow won't pick up changes in todo.title / todo.done
-   // since it isn't an observer
+   // WRONG: GridRow won't pick up changes in todo.title / todo.done since it
+   //        isn't an observer
    return <GridRow data={todo} />
 
-   // CORRECT: let `TodoView` detect relevant changes in `todo`, and pass plain data down
+   // CORRECT: let `TodoView` detect relevant changes in `todo`, and pass plain
+   //          data down
    return <GridRow data={{
        title: todo.title,
        done: todo.done
    }} />
 
-   // CORRECT: Using `toJS` works as well. But being explicit is typically better
+   // CORRECT: using `toJS` works as well, but being explicit is typically better
    return <GridRow data={toJS(todo)} />
 )
 ```
@@ -306,15 +310,15 @@ const TodoView = observer(({ todo }: { todo: Todo }) =>
 
 <details id="react-vs-lite"><summary>mobx-react vs. mobx-react-lite<a href="#react-vs-lite" class="tip-anchor"></a></summary>
 In this documentation we used `mobx-react-lite` as default.
-[`mobx-react`](https://github.com/mobxjs/mobx-react/) is it's big brother, which uses `mobx-react-lite` under the hood.
+[mobx-react](https://github.com/mobxjs/mobx-react/) is it's big brother, which uses `mobx-react-lite` under the hood.
 It offers a few more features which are typically not needed anymore in greenfield projects. The additional things offered by mobx-react:
 
-1. Support for React class components
-1. `Provider` and `inject`. MobX own React.createContext predecessor which is not needed anymore
-1. observable specific `propTypes`
+1. Support for React class components.
+1. `Provider` and `inject`. MobX's own React.createContext predecessor which is not needed anymore.
+1. Observable specific `propTypes`.
 
-Note that `mobx-react` fully repackages and re-exports `mobx-react-lite`, including function component support.
-If you use `mobx-react`, there is no need to add `mobx-react-lite` as dependency or import from it anywhere.
+Note that `mobx-react` fully repackages and re-exports `mobx-react-lite`, including functional component support.
+If you use `mobx-react`, there is no need to add `mobx-react-lite` as a dependency or import from it anywhere.
 
 </details>
 
@@ -343,7 +347,7 @@ const TimerView = observer(
 )
 ```
 
-See the [mobx-react docs](https://github.com/mobxjs/mobx-react#api-documentation) for more information.
+Check out [mobx-react docs](https://github.com/mobxjs/mobx-react#api-documentation) for more information.
 
 </details>
 
@@ -364,7 +368,7 @@ then no display name will be visible in the DevTools.
 
 The following approaches can be used to fix this:
 
--   use `function` with a name instead of an arrow function. `mobx-react` infers component name from function name:
+-   use `function` with a name instead of an arrow function. `mobx-react` infers component name from the function name:
 
     ```javascript
     export const MyComponent = observer(function MyComponent(props) {
@@ -372,14 +376,14 @@ The following approaches can be used to fix this:
     })
     ```
 
--   The transpiler (like Babel or TypeScript) infers component name from variable name:
+-   Transpilers (like Babel or TypeScript) infer component name from the variable name:
 
     ```javascript
     const _MyComponent = props => <div>hi</div>
     export const MyComponent = observer(_MyComponent)
     ```
 
--   Infer from variable name again, using default export:
+-   Infer from the variable name again, using default export:
 
     ```javascript
     const MyComponent = props => <div>hi</div>
@@ -411,10 +415,9 @@ otherwise it might do nothing at all.
 </details>
 
 <details id="computed-props"><summary>🚀 Tip: Deriving computeds from props<a href="#computed-props" class="tip-anchor"></a></summary>
-In some the computed values of your local observable might depend on some of the
-props your component receives.
+In some cases the computed values of your local observables might depend on some of the props your component receives.
 However, the set of props that a React component receives is in itself not observable, so changes to the props won't be reflected in any computed values.
-To make props observable, the [`useAsObservableSource`](https://github.com/mobxjs/mobx-react#useasobservablesource-hook) hook can be used, that will sync the props of a component into an local observable object.
+To make props observable, the [useAsObservableSource](https://github.com/mobxjs/mobx-react#useasobservablesource-hook) hook can be used, that will sync the props of a component into an local observable object.
 _Note that it is important to not deconstruct the result of this hook._
 
 ```javascript
@@ -449,7 +452,7 @@ is a much simpler, albeit slightly less efficient solution.
 `useEffect` can be used to set up side effects that need to happen, and which are bound to the life-cycle of the React component.
 Using `useEffect` requires specifying dependencies.
 With MobX that isn't really needed, since MobX has already a way to automatically determine the dependencies of an effect, `autorun`.
-Combining `autorun` and coupling it to the life-cycle of the component using `useEffect` is luckily straight forward:
+Combining `autorun` and coupling it to the life-cycle of the component using `useEffect` is luckily straightforward:
 
 ```javascript
 import { observer, useLocalObservable, useAsObservableSource } from "mobx-react-lite"
@@ -500,16 +503,16 @@ If you'd rather explicitly define which observables should trigger the effect, u
 
 ### How can I further optimize my React components?
 
-See the relevant [React performance section](react-performance.md).
+Check out the relevant [React performance section](react-performance.md).
 
 ## Troubleshooting
 
 Help! My component isn't re-rendering...
 
-1. Make sure you didn't forget `observer` (yes, this is the most common mistake)
+1. Make sure you didn't forget `observer` (yes, this is the most common mistake).
 1. Verify that the thing you intend to react to is indeed observable. Use utilities like [`isObservable`](../refguide/api.md#isobservable), [`isObservableProp`](../refguide/api.md#isobservableprop) if needed to verify this at runtime.
 1. Check the console logs in the browsers for any warnings or errors.
-1. Make sure you grok how tracking works in general: [what does MobX react to](../best/what-does-mobx-react-to.md)
+1. Make sure you grok how tracking works in general. Check out [What does MobX react to?](../best/what-does-mobx-react-to.md).
 1. Read the common pitfalls as described above.
-1. [Configure](configure) MobX to warn you of unsound usage of MobX mechanisms and check the console logs.
+1. [Configure](configure) MobX to warn you of unsound usage of mechanisms and check the console logs.
 1. Use [trace](../best/debugging-mobx.md) to verify that you are subscribing to the right things or check what MobX is doing in general using [spy](../best/debugging-mobx#spy) / the [mobx-logger](https://github.com/winterbe/mobx-logger) package.

--- a/docs/react/react-integration.md
+++ b/docs/react/react-integration.md
@@ -16,7 +16,7 @@ import {observer} from 'mobx-react-lite
 const MyComponent = observer(props => ReactElement)
 ```
 
-While MobX works independently from React, they are most commonly used together. In [the gist of Mobx](../intro/concepts.md) you have already seen the most important part of this integration: the `observer` [HoC](https://reactjs.org/docs/higher-order-components.html) that you can wrap around a React component.
+While MobX works independently from React, they are most commonly used together. In [the gist of MobX](../intro/concepts.md) you have already seen the most important part of this integration: the `observer` [HoC](https://reactjs.org/docs/higher-order-components.html) that you can wrap around a React component.
 
 `observer` is provided by a separate React bindings package you choose [during installation](../intro/installation.md#installation). In this example, we're going to use the more lightweight [`mobx-react-lite` package](https://github.com/mobxjs/mobx-react-lite).
 
@@ -52,12 +52,12 @@ setInterval(() => {
 ```
 **Hint:** you can play with the above example yourself on [CodeSandbox](https://codesandbox.io/s/minimal-observer-p9ti4?file=/src/index.tsx).
 
-The `observer` HoC subscribes React components automatically to _any observables_ that are used _during rendering_.
+The `observer` HoC automatically subscribes React components to _any observables_ that are used _during rendering_.
 As a result, components will automatically re-render when relevant observables change.
 It also makes sure that components don't re-render when there are _no relevant_ changes.
 So, observables that are accessible by the component, but not actually read, won't ever cause a re-render.
 
-In practice this makes MobX applications very well optimized out of the box and typically don't need any additional code to prevent excessive rendering.
+In practice this makes MobX applications very well optimized out of the box and they typically don't need any additional code to prevent excessive rendering.
 
 For `observer` to work, it doesn't matter _how_ the observables arrive in the component, only that they are read.
 Reading observables deeply is fine, complex expression like `todos[0].author.displayName` work out of the box.
@@ -73,7 +73,7 @@ The examples below demonstrate different patterns on how external and local obse
 <!--DOCUSAURUS_CODE_TABS-->
 <!--using props-->
 
-Observables can be passed as properties into components as props, as was done in the example above:
+Observables can be passed into components as props, as was done in the example above:
 
 ```javascript
 import { observer } from "mobx-react-lite"
@@ -128,7 +128,7 @@ ReactDOM.render(
 )
 ```
 
-Note that we don't recommend ever replacing the `value` of a `Provider` with a different value. Using MobX, there should be no need for that, since the observable that is shared can be updated itself.
+Note that we don't recommend ever replacing the `value` of a `Provider` with a different one. Using MobX, there should be no need for that, since the observable that is shared can be updated itself.
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -197,7 +197,7 @@ ReactDOM.render(<TimerView />, document.body)
 <!--`useLocalObservable` hook-->
 
 The combination `const [store] = useState(() => observable({ /* something */}))` is
-quite common. To make this pattern simpler the [`useLocalObservable`](https://github.com/mobxjs/mobx-react#uselocalobservable-hook) hook is exposed from `mobx-react-lite`, making it possible to simplify the earlier example to:
+quite common. To make this pattern simpler the [`useLocalObservable`](https://github.com/mobxjs/mobx-react#uselocalobservable-hook) hook is exposed from `mobx-react-lite` package, making it possible to simplify the earlier example to:
 
 ```javascript
 import { observer, useLocalObservable } from "mobx-react-lite"
@@ -220,7 +220,7 @@ ReactDOM.render(<TimerView />, document.body)
 
 ### You might not need locally observable state
 
-In general we recommend to not resort to MobX observables for local component state too quickly, as this can theoretically lock you out of some features of React's Suspense mechanism.
+In general, we recommend to not resort to MobX observables for local component state too quickly, as this can theoretically lock you out of some features of React's Suspense mechanism.
 As a rule of thumb, use MobX observables when the state captures domain data that is shared among components (including children). Such as todo items, users, bookings, etc.
 
 State that only captures UI state, like loading state, selections, etc, might be better served by the [`useState` hook](https://reactjs.org/docs/hooks-state.html), since this will allow you to leverage React suspense features in the future.
@@ -229,7 +229,7 @@ Using observables inside React components adds value as soon as they are either 
 
 ## Always read observables inside `observer` components
 
-You might be wondering, when do I apply `observer`? The simple rule of thumb is: _apply `observer` to all components that read observable data_.
+You might be wondering, when do I apply `observer`? The rule of thumb is: _apply `observer` to all components that read observable data_.
 
 `observer` only enhances the component you are decorating, not the components called by it. So usually all your components should be wrapped by `observer`. Don't worry, this is not inefficient. On the contrary, more `observer` components make rendering more efficient as updates become more fine-grained.
 
@@ -248,7 +248,7 @@ React.render(<TimerViewer secondPassed={myTimer.secondsPassed} />, document.body
 ```
 
 Note that this is a different mindset from other libraries like `react-redux`, where it is a good practice to dereference early and pass primitives down, to better leverage memoization.
-If the problem is not entirely clear, make sure to check out [what does MobX react to?](../best/what-does-mobx-react-to.md).
+If the problem is not entirely clear, make sure to check out [What does MobX react to?](../best/what-does-mobx-react-to.md).
 
 ### Don't pass observables into components that aren't `observer`
 

--- a/docs/react/react-performance.md
+++ b/docs/react/react-performance.md
@@ -8,9 +8,11 @@ hide_title: true
 
 # Optimizing rendering of React components
 
-MobX is very fast, [often even faster than Redux](https://twitter.com/mweststrate/status/718444275239882753). But here are some tips to get most out of React and MobX. Most apply to React in general and are not specific to MobX.
+MobX is very fast, [often even faster than Redux](https://twitter.com/mweststrate/status/718444275239882753), but here are some tips to get most out of React and MobX. Most apply to React in general and are not specific to MobX.
 Note that while it's good to be aware of these patterns, usually your application
-will be fast enough even if you don't worry about them at all. Prioritize performance only when it's an actual issue!
+will be fast enough even if you don't worry about them at all.
+
+Prioritize performance only when it's an actual issue!
 
 ## Use many small components
 
@@ -21,7 +23,7 @@ So the smaller your components are, the smaller the change they have to re-rende
 
 The above is especially true when rendering big collections.
 React is notoriously bad at rendering large collections as the reconciler has to evaluate the components produced by a collection on each collection change.
-It is therefore recommended to have components that just map over a collection and render it, and render nothing else:
+It is therefore recommended to have components that just map over a collection and render it, and render nothing else.
 
 Bad:
 

--- a/docs/react/react-performance.md
+++ b/docs/react/react-performance.md
@@ -9,7 +9,6 @@ hide_title: true
 # Optimizing rendering of React components
 
 MobX is very fast, [often even faster than Redux](https://twitter.com/mweststrate/status/718444275239882753). But here are some tips to get most out of React and MobX. Most apply to React in general and are not specific to MobX.
-
 Note that while it's good to be aware of these patterns, usually your application
 will be fast enough even if you don't worry about them at all. Prioritize performance only when it's an actual issue!
 
@@ -71,16 +70,16 @@ When using `mobx-react` it is recommended to dereference values as late as possi
 This is because MobX will re-render components that dereference observable values automatically.
 If this happens deeper in your component tree, less components have to re-render.
 
-Faster:
-
-```javascript
-<DisplayName person={person} />
-```
-
 Slower:
 
 ```javascript
 <DisplayName name={person.name} />
+```
+
+Faster:
+
+```javascript
+<DisplayName person={person} />
 ```
 
 There is nothing wrong with the latter, but a change in the `name` property will, in the first case, trigger only the `DisplayName` to re-render, while in the latter, the owner of the component has to re-render. If rendering the owning component is fast enough (usually it will be!), that approach will work well.

--- a/docs/react/react-performance.md
+++ b/docs/react/react-performance.md
@@ -6,24 +6,21 @@ hide_title: true
 
 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CEBD4KQ7&placement=mobxjsorg" id="_carbonads_js"></script>
 
-# Optimizing rendering React components
+# Optimizing rendering of React components
 
-MobX is very fast, [often even faster than Redux](https://twitter.com/mweststrate/status/718444275239882753).
-
-But here are some tips to get most out of React and MobX. Most tips apply to React in general and are not specific for MobX.
+MobX is very fast, [often even faster than Redux](https://twitter.com/mweststrate/status/718444275239882753). But here are some tips to get most out of React and MobX. Most apply to React in general and are not specific to MobX.
 
 Note that while it's good to be aware of these patterns, usually your application
-will be fast enough if you don't worry about them at all. Prioritize performance only
-when it's an actual issue!
+will be fast enough even if you don't worry about them at all. Prioritize performance only when it's an actual issue!
 
 ## Use many small components
 
 `observer` components will track all values they use and re-render if any of them changes.
-So the smaller your components are, the smaller the change they have to re-render; it means that more parts of your user interface have the possibility to render independently of each other.
+So the smaller your components are, the smaller the change they have to re-render. It means that more parts of your user interface have the possibility to render independently of each other.
 
 ## Render lists in dedicated components
 
-This is especially true when rendering big collections.
+The above is especially true when rendering big collections.
 React is notoriously bad at rendering large collections as the reconciler has to evaluate the components produced by a collection on each collection change.
 It is therefore recommended to have components that just map over a collection and render it, and render nothing else:
 
@@ -66,7 +63,7 @@ const TodosView = observer(({ todos }) => (
 ## Don't use array indexes as keys
 
 Don't use array indexes or any value that might change in the future as key. Generate ids for your objects if needed.
-See also this [blog](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318).
+Check out this [blog](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318).
 
 ## Dereference values late
 
@@ -74,7 +71,7 @@ When using `mobx-react` it is recommended to dereference values as late as possi
 This is because MobX will re-render components that dereference observable values automatically.
 If this happens deeper in your component tree, less components have to re-render.
 
-Fast:
+Faster:
 
 ```javascript
 <DisplayName person={person} />
@@ -90,7 +87,7 @@ There is nothing wrong with the latter, but a change in the `name` property will
 
 ### Function props
 
-[🚀] You may notice that to deference values late you have to create lots of small observer components where each is customized to render some different part of data, for example:
+[🚀] You may notice that to dereference values late you have to create lots of small observer components where each is customized to render some different part of data, for example:
 
 ```javascript
 const PersonNameDisplayer = observer(({ person }) => <DisplayName name={person.name} />)


### PR DESCRIPTION
Hey,

I've updated the docs below. Feel free to merge at any point and I'll create a new PR for the remaining files.

-   [x] docs/intro/concepts.md
-   [x] docs/react/react-integration.md
-   [x] docs/react/react-performance.md

Only the great `docs/refguide` remains.

![screenshot-20200918233909562623482](https://user-images.githubusercontent.com/37121652/93647259-44d95e80-fa08-11ea-8155-c35b6577f876.png)


<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2452"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zangornjak/mobx.git/0c641ee2daf5f84aa3245b1b2058b233380c9c0c.svg" /></a>

