### PR TITLE
Docs grammar corrections III

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,7 @@ import ReactDOM from "react-dom"
 import { makeAutoObservable } from "mobx"
 import { observer } from "mobx-react"
 
-// Model the application state
+// Model the application state.
 class Timer {
     secondsPassed = 0
 
@@ -114,14 +114,14 @@ class Timer {
 
 const myTimer = new Timer()
 
-// Build a user interface for this app, that merely uses the state...
+// Build a user interface for this app that merely uses the state.
 const TimerView = observer(({ timer }) => (
     <button onClick={() => timer.resetTimer()}>Seconds passed: {timer.secondsPassed}</button>
 ))
 
 ReactDOM.render(<TimerView timer={myTimer} />, document.body)
 
-// For demo's sake, let's force some updates...
+// Update the 'Seconds passed: X' text every second.
 setInterval(() => {
     myTimer.increaseTimer()
 }, 1000)

--- a/docs/best/debugging-mobx.md
+++ b/docs/best/debugging-mobx.md
@@ -90,7 +90,7 @@ Returns a tree structure with all reactions / computations that are observing th
 
 ### `getAtom`
 
-[🚀] Usage:
+Usage:
 
 -   `getAtom(thing, property?)`.
 
@@ -118,7 +118,7 @@ spy(event => {
 
 Spy listeners always receive one object, which usually has at least a `type` field. The following events are emitted by default by spy.
 
-| type                            | observableKind | other fields                                          | nested |
+| Type                            | observableKind | Other fields                                          | Nested |
 | ------------------------------- | -------------- | ----------------------------------------------------- | ------ |
 | action                          |                | name, object (scope), arguments[]                     | yes    |
 | scheduled-reaction              |                | name                                                  | no     |

--- a/docs/best/debugging-mobx.md
+++ b/docs/best/debugging-mobx.md
@@ -39,7 +39,7 @@ import { observer } from "mobx-react"
 import { trace } from "mobx"
 
 const MyComponent = observer(() => {
-    trace(true) // enter the debugger whenever an observable value causes this component to re-run
+    trace(true) // Enter the debugger whenever an observable value causes this component to re-run.
     return <div>{this.props.user.name}</name>
 })
 ```

--- a/docs/best/decorators.md
+++ b/docs/best/decorators.md
@@ -5,7 +5,7 @@ hide_title: true
 
 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CEBD4KQ7&placement=mobxjsorg" id="_carbonads_js"></script>
 
-# Decorators in MobX [🚀]
+# Enabling decorators [🚀]
 
 MobX before version 6 encouraged the use of ES.next decorators to mark things as `observable`, `computed` and `action`. However, decorators are currently not an ES standard, and the process of standardization is taking a long time. It also looks like the standard will be different from the way decorators were implemented previously. In the interest of compatibility we have chosen to move away from them in MobX 6, and recommend the use of [`makeObservable` / `makeAutoObservable`](../refguide/observable) instead.
 

--- a/docs/best/stateless-HMR.md
+++ b/docs/best/stateless-HMR.md
@@ -12,7 +12,9 @@ One thing that can be a challenge when getting started with MobX (and React in g
 
 ```
 [HMR] The following modules couldn't be hot updated: (Full reload needed)
-This is usually because the modules which have changed (and their parents) do not know how to hot reload themselves. See http://webpack.github.io/docs/hot-module-replacement-with-webpack.html for more details.
+This is usually because the modules which have changed (and their parents)
+do not know how to hot reload themselves.
+See http://webpack.github.io/docs/hot-module-replacement-with-webpack.html for more details.
 [HMR]  - ./src/ToDoItem.jsx
 ```
 

--- a/docs/best/store.md
+++ b/docs/best/store.md
@@ -92,7 +92,7 @@ export class TodoStore {
         this.loadTodos()
     }
 
-    // Fetches all todos from the server.
+    // Fetches all Todos from the server.
     loadTodos() {
         this.isLoading = true
         this.transportLayer.fetchTodos().then(fetchedTodos => {
@@ -103,9 +103,9 @@ export class TodoStore {
         })
     }
 
-    // Update a todo with information from the server. Guarantees a todo only
-    // exists once. Might either construct a new todo, update an existing one,
-    // or remove a todo if it has been deleted on the server.
+    // Update a Todo with information from the server. Guarantees a Todo only
+    // exists once. Might either construct a new Todo, update an existing one,
+    // or remove a Todo if it has been deleted on the server.
     updateTodoFromServer(json) {
         const todo = this.todos.find(todo => todo.id === json.id)
         if (!todo) {
@@ -119,14 +119,14 @@ export class TodoStore {
         }
     }
 
-    // Creates a fresh todo on the client and the server.
+    // Creates a fresh Todo on the client and the server.
     createTodo() {
         const todo = new Todo(this)
         this.todos.push(todo)
         return todo
     }
 
-    // A todo was somehow deleted, clean it from the client memory.
+    // A Todo was somehow deleted, clean it from the client memory.
     removeTodo(todo) {
         this.todos.splice(this.todos.indexOf(todo), 1)
         todo.dispose()

--- a/docs/best/store.md
+++ b/docs/best/store.md
@@ -119,7 +119,7 @@ export class TodoStore {
         }
     }
 
-    // Creates a fresh todo on the client and server.
+    // Creates a fresh todo on the client and the server.
     createTodo() {
         const todo = new Todo(this)
         this.todos.push(todo)
@@ -182,8 +182,7 @@ export class Todo {
 
     // Update this Todo with information from the server.
     updateFromJson(json) {
-        // Make sure our changes aren't sent back to the server.
-        this.autoSave = false
+        this.autoSave = false // Prevent sending of our changes back to the server.
         this.completed = json.completed
         this.task = json.task
         this.author = this.store.authorStore.resolveAuthor(json.authorId)

--- a/docs/best/store.md
+++ b/docs/best/store.md
@@ -84,17 +84,15 @@ export class TodoStore {
 
     constructor(transportLayer, authorStore) {
         makeAutoObservable(this)
-        this.authorStore = authorStore // Store that can resolve authors for us
-        this.transportLayer = transportLayer // Thing that can make server requests for us
+        this.authorStore = authorStore // Store that can resolve authors.
+        this.transportLayer = transportLayer // Thing that can make server requests.
         this.transportLayer.onReceiveTodoUpdate(updatedTodo =>
             this.updateTodoFromServer(updatedTodo)
         )
         this.loadTodos()
     }
 
-    /**
-     * Fetches all todos from the server
-     */
+    // Fetches all todos from the server.
     loadTodos() {
         this.isLoading = true
         this.transportLayer.fetchTodos().then(fetchedTodos => {
@@ -105,11 +103,9 @@ export class TodoStore {
         })
     }
 
-    /**
-     * Update a todo with information from the server. Guarantees a todo
-     * only exists once. Might either construct a new todo, update an existing one,
-     * or remove a todo if it has been deleted on the server.
-     */
+    // Update a todo with information from the server. Guarantees a todo only
+    // exists once. Might either construct a new todo, update an existing one,
+    // or remove a todo if it has been deleted on the server.
     updateTodoFromServer(json) {
         const todo = this.todos.find(todo => todo.id === json.id)
         if (!todo) {
@@ -123,52 +119,29 @@ export class TodoStore {
         }
     }
 
-    /**
-     * Creates a fresh todo on the client and server
-     */
+    // Creates a fresh todo on the client and server.
     createTodo() {
         const todo = new Todo(this)
         this.todos.push(todo)
         return todo
     }
 
-    /**
-     * A todo was somehow deleted, clean it from the client memory
-     */
+    // A todo was somehow deleted, clean it from the client memory.
     removeTodo(todo) {
         this.todos.splice(this.todos.indexOf(todo), 1)
         todo.dispose()
     }
 }
 
-// domain object Todo
+// Domain object Todo.
 export class Todo {
-    /**
-     * unique id of this todo, immutable.
-     */
-    id = null
-
+    id = null // Unique id of this Todo, immutable.
     completed = false
     task = ""
-
-    /**
-     * reference to an Author object (from the authorStore)
-     */
-    author = null
-
+    author = null // Reference to an Author object (from the authorStore).
     store = null
-
-    /**
-     * Indicates whether changes in this object
-     * should be submitted to the server
-     */
-    autoSave = true
-
-    /**
-     * Disposer for the side effect that automatically
-     * stores this Todo, see dispose.
-     */
-    saveHandler = null
+    autoSave = true // Indicator for submitting changes in this Todo to the server.
+    saveHandler = null // Disposer of the side effect auto-saving this Todo (dispose).
 
     constructor(store, id = uuid.v4()) {
         makeAutoObservable(this, {
@@ -182,10 +155,9 @@ export class Todo {
         this.id = id
 
         this.saveHandler = reaction(
-            // observe everything that is used in the JSON:
-            () => this.asJson,
-            // if autoSave is on, send json to server
+            () => this.asJson, // Observe everything that is used in the JSON.
             json => {
+                // If autoSave is true, send JSON to the server.
                 if (this.autoSave) {
                     this.store.transportLayer.saveTodo(json)
                 }
@@ -193,9 +165,7 @@ export class Todo {
         )
     }
 
-    /**
-     * Remove this todo from the client and server
-     */
+    // Remove this Todo from the client and the server.
     delete() {
         this.store.transportLayer.deleteTodo(this.id)
         this.store.removeTodo(this)
@@ -210,11 +180,9 @@ export class Todo {
         }
     }
 
-    /**
-     * Update this todo with information from the server
-     */
+    // Update this Todo with information from the server.
     updateFromJson(json) {
-        // make sure our changes aren't sent back to the server
+        // Make sure our changes aren't sent back to the server.
         this.autoSave = false
         this.completed = json.completed
         this.task = json.task
@@ -222,8 +190,8 @@ export class Todo {
         this.autoSave = true
     }
 
+    // Clean up the observer.
     dispose() {
-        // clean up the observer
         this.saveHandler()
     }
 }
@@ -267,7 +235,7 @@ export class UiState {
     pendingRequestCount = 0
 
     // .struct makes sure observer won't be signaled unless the
-    // dimensions object changed in a deepEqual manner
+    // dimensions object changed in a deepEqual manner.
     windowDimensions = {
         width: window.innerWidth,
         height: window.innerHeight
@@ -312,7 +280,7 @@ class UserStore {
     }
 
     getTodos(user) {
-        // access todoStore through the root store
+        // Access todoStore through the root store.
         return this.rootStore.todoStore.todos.filter(todo => todo.author === user)
     }
 }

--- a/docs/best/what-does-mobx-react-to.md
+++ b/docs/best/what-does-mobx-react-to.md
@@ -90,7 +90,7 @@ It is also possible to get the internal dependency (or observer) tree by using `
 ```javascript
 import { getDependencyTree } from "mobx"
 
-// prints the dependency tree of the reaction coupled to the disposer
+// Prints the dependency tree of the reaction coupled to the disposer.
 console.log(getDependencyTree(disposer))
 // Outputs:
 // { name: 'Autorun@2', dependencies: [ { name: 'Message@1.title' } ] }
@@ -165,7 +165,7 @@ autorun(() => {
     console.log(message)
 })
 
-// Won't trigger a re-run
+// Won't trigger a re-run.
 message.updateTitle("Hello world")
 ```
 
@@ -179,19 +179,19 @@ The way to make this work is to make sure to always pass immutable data or defen
 
 ```javascript
 autorun(() => {
-    console.log(message.title) // clearly, the `.title` observable is used
+    console.log(message.title) // Clearly, the `.title` observable is used.
 })
 
 autorun(() => {
-    console.log(mobx.toJS(message)) // toJS creates a deep clone, and thus will read the message
+    console.log(mobx.toJS(message)) // toJS creates a deep clone, and thus will read the message.
 })
 
 autorun(() => {
-    console.log({ ...message }) // creates a shallow clone, also using `.title` in the process
+    console.log({ ...message }) // Creates a shallow clone, also using `.title` in the process.
 })
 
 autorun(() => {
-    console.log(JSON.stringify(message)) // also reads the entire structure
+    console.log(JSON.stringify(message)) // Also reads the entire structure.
 })
 ```
 
@@ -371,7 +371,7 @@ const twitterUrls = observable.object({
 })
 
 autorun(() => {
-    console.log(get(twitterUrls, "Sara")) // get can track not yet existing properties
+    console.log(get(twitterUrls, "Sara")) // `get` can track not yet existing properties.
 })
 
 runInAction(() => {

--- a/docs/faq/migrate-to-6.md
+++ b/docs/faq/migrate-to-6.md
@@ -11,7 +11,7 @@ MobX 6 is quite different from MobX 5. This pages covers a migration guide from 
 
 [CHANGELOG](https://github.com/mobxjs/mobx/blob/mobx6/CHANGELOG.md#600)
 
-_⚠️ Warning: Depending on factors like the size and complexity of your code base, your MobX usage patterns, and the quality of your automated tests, this migration guide might take you anywhere between an hour and a couple of days. Please refrain from upgrading if you don't trust your Continuous Integration or QA / test procedures enough to pick up any unexpected breakages. Unexpected behavioral changes might be caused by changes in MobX itself or the changes needed to your Babel / TypeScript build configuration. ⚠️_
+_⚠️ **Warning**: Depending on factors like the size and complexity of your code base, your MobX usage patterns, and the quality of your automated tests, this migration guide might take you anywhere between an hour and a couple of days. Please refrain from upgrading if you don't trust your Continuous Integration or QA / test procedures enough to pick up any unexpected breakages. Unexpected behavioral changes might be caused by changes in MobX itself or the changes needed to your Babel / TypeScript build configuration. ⚠️_
 
 ## Getting started
 

--- a/docs/faq/migrate-to-6.md
+++ b/docs/faq/migrate-to-6.md
@@ -11,7 +11,7 @@ MobX 6 is quite different from MobX 5. This pages covers a migration guide from 
 
 [CHANGELOG](https://github.com/mobxjs/mobx/blob/mobx6/CHANGELOG.md#600)
 
-_⚠️ Disclaimer: Depending on factors like the size and complexity of your code base, your MobX usage patterns, and the quality of your automated tests, this migration guide might take you anywhere between an hour and a couple of days. Please refrain from upgrading if you don't trust your Continuous Integration or QA / test procedures enough to pick up any unexpected breakages. Unexpected behavioral changes might be caused by changes in MobX itself or the changes needed to your Babel / TypeScript build configuration. ⚠️_
+_⚠️ Warning: Depending on factors like the size and complexity of your code base, your MobX usage patterns, and the quality of your automated tests, this migration guide might take you anywhere between an hour and a couple of days. Please refrain from upgrading if you don't trust your Continuous Integration or QA / test procedures enough to pick up any unexpected breakages. Unexpected behavioral changes might be caused by changes in MobX itself or the changes needed to your Babel / TypeScript build configuration. ⚠️_
 
 ## Getting started
 

--- a/docs/faq/migrate-to-6.md
+++ b/docs/faq/migrate-to-6.md
@@ -7,7 +7,7 @@ hide_title: true
 
 MobX 6 is quite different from MobX 5. This pages covers a migration guide from MobX 4 and 5 to 6, and an extensive list of all the changes.
 
-# Migrating to MobX 6
+# Migrating from MobX 4/5 [🚀]
 
 [CHANGELOG](https://github.com/mobxjs/mobx/blob/mobx6/CHANGELOG.md#600)
 

--- a/docs/intro/concepts.md
+++ b/docs/intro/concepts.md
@@ -172,7 +172,7 @@ You will need them rarely, but they can be created using the [`autorun`](../refg
 For example, the following `autorun` prints a log message every time the amount of `unfinishedTodoCount` changes:
 
 ```javascript
-/* a function that automatically observes the state */
+// A function that automatically observes the state.
 autorun(() => {
     console.log("Tasks left: " + todos.unfinishedTodoCount)
 })

--- a/docs/intro/installation.md
+++ b/docs/intro/installation.md
@@ -31,7 +31,7 @@ You will have to explicitly enable the fallback implementation by configuring [`
 ```javascript
 import { configure } from "mobx"
 
-configure({ useProxies: "never" }) // or "ifavailable"
+configure({ useProxies: "never" }) // Or "ifavailable".
 ```
 
 ## MobX and Decorators

--- a/docs/intro/installation.md
+++ b/docs/intro/installation.md
@@ -12,9 +12,9 @@ MobX works in any ES5 environment, which includes browsers and NodeJS.
 
 There are two types of React bindings. `mobx-react` also supports class based components, whereas `mobx-react-lite` supports only functional components. Append the appropriate bindings for your use case to the below *Yarn* or *NPM* command.
 
-**Yarn:** `yarn add mobx`.
+**Yarn:** `yarn add mobx`
 
-**NPM:** `npm install --save mobx`.
+**NPM:** `npm install --save mobx`
 
 **CDN:** https://cdnjs.com/libraries/mobx / https://unpkg.com/mobx/lib/mobx.umd.js
 

--- a/docs/intro/installation.md
+++ b/docs/intro/installation.md
@@ -16,11 +16,9 @@ There are two types of React bindings. `mobx-react` also supports class based co
 
 **NPM:** `npm install --save mobx`.
 
-**CDN:**
--   cdnjs: https://cdnjs.com/libraries/mobx
--   unpkg: https://unpkg.com/mobx/lib/mobx.umd.js
+**CDN:** https://cdnjs.com/libraries/mobx / https://unpkg.com/mobx/lib/mobx.umd.js
 
-⚠️ When using a CDN, it is best to check the url in your browser and see what version it resolves to, so that your users aren't accidentally served a newer version in the future when updates are released. Use an url like: https://unpkg.com/mobx@5.15.4/lib/mobx.umd.production.min.js instead. For a development build, substitute `production.min` with `development` in the URL. ⚠️
+⚠️ **Warning:** When using a CDN, it is best to check the url in your browser and see what version it resolves to, so that your users aren't accidentally served a newer version in the future when updates are released. Use an url like: https://unpkg.com/mobx@5.15.4/lib/mobx.umd.production.min.js instead. For a development build, substitute `production.min` with `development` in the URL. ⚠️
 
 ## MobX on older JavaScript environments
 

--- a/docs/react/react-integration.md
+++ b/docs/react/react-integration.md
@@ -405,9 +405,7 @@ Now you can see component names:
 
 </details>
 
-<details id="wrap-order"><summary>
-[🚀] Tip: When combining `observer` with other higher-order-components, apply `observer` first<a href="#wrap-order" class="tip-anchor"></a>
-</summary>
+<details id="wrap-order"><summary>[🚀] Tip: When combining `observer` with other higher-order-components, apply `observer` first<a href="#wrap-order" class="tip-anchor"></a></summary>
 
 When `observer` needs to be combined with other decorators or higher-order-components, make sure that `observer` is the innermost (first applied) decorator;
 otherwise it might do nothing at all.

--- a/docs/react/react-integration.md
+++ b/docs/react/react-integration.md
@@ -92,7 +92,7 @@ Since it doesn't matter _how_ we got the reference to an observable, we can cons
 observables from outer scopes directly (including from imports, etc.).
 
 ```javascript
-const myTimer = new Timer() // see Timer definition above
+const myTimer = new Timer() // See the Timer definition above.
 
 // No props, `myTimer` is directly consumed from the closure.
 const TimerView = observer(() => <span>Seconds passed: {myTimer.secondsPassed}</span>)

--- a/docs/react/react-integration.md
+++ b/docs/react/react-integration.md
@@ -78,11 +78,11 @@ Observables can be passed into components as props, as was done in the example a
 ```javascript
 import { observer } from "mobx-react-lite"
 
-const myTimer = new Timer() // see Timer definition above
+const myTimer = new Timer() // See the Timer definition above.
 
 const TimerView = observer(({ timer }) => <span>Seconds passed: {timer.secondsPassed}</span>)
 
-// pass myTimer as props
+// Pass myTimer as a prop.
 ReactDOM.render(<TimerView timer={myTimer} />, document.body)
 ```
 
@@ -94,7 +94,7 @@ observables from outer scopes directly (including from imports, etc.).
 ```javascript
 const myTimer = new Timer() // see Timer definition above
 
-// No props, the `myTimer` is directly consumed from the closure
+// No props, `myTimer` is directly consumed from the closure.
 const TimerView = observer(() => <span>Seconds passed: {myTimer.secondsPassed}</span>)
 
 ReactDOM.render(<TimerView />, document.body)
@@ -113,8 +113,8 @@ import {createContext, useContext} from "react"
 const TimerContext = createContext<Timer>()
 
 const TimerView = observer(() => {
-    // grab the timer from context
-    const timer = useContext(TimerContext) // see Timer definition above
+    // Grab the timer from context.
+    const timer = useContext(TimerContext) // See the Timer definition above.
     return (
         <span>Seconds passed: {timer.secondsPassed}</span>
     )
@@ -148,7 +148,7 @@ import { observer } from "mobx-react-lite"
 import { useState } from "react"
 
 const TimerView = observer(() => {
-    const [timer] = useState(() => new Timer()) // see Timer definition above
+    const [timer] = useState(() => new Timer()) // See the Timer definition above.
     return <span>Seconds passed: {timer.secondsPassed}</span>
 })
 
@@ -272,17 +272,17 @@ class Todo {
 
 const TodoView = observer(({ todo }: { todo: Todo }) =>
    // WRONG: GridRow won't pick up changes in todo.title / todo.done since it
-   //        isn't an observer
+   //        isn't an observer.
    return <GridRow data={todo} />
 
    // CORRECT: let `TodoView` detect relevant changes in `todo`, and pass plain
-   //          data down
+   //          data down.
    return <GridRow data={{
        title: todo.title,
        done: todo.done
    }} />
 
-   // CORRECT: using `toJS` works as well, but being explicit is typically better
+   // CORRECT: using `toJS` works as well, but being explicit is typically better.
    return <GridRow data={toJS(todo)} />
 )
 ```
@@ -296,10 +296,10 @@ Or, we can create an in-line anonymous observer using [`<Observer />`](https://g
 ```javascript
 const TodoView = observer(({ todo }: { todo: Todo }) =>
    // WRONG: GridRow.onRender won't pick up changes in todo.title / todo.done
-   // since it isn't an observer
+   //        since it isn't an observer.
    return <GridRow onRender={() => <td>{todo.title}</td>} />
 
-   // CORRECT: wrap the callback rendering in Observer to be able to detect changes
+   // CORRECT: wrap the callback rendering in Observer to be able to detect changes.
    return <GridRow onRender={() => <Observer>{() =>
      <td>{todo.title}</td>
    }} />
@@ -432,7 +432,7 @@ const TimerView = observer(({ offset }) => {
             this.secondsPassed++
         },
         get offsetTime() {
-            return this.secondsPassed - observableProps.offset // not 'offset'!
+            return this.secondsPassed - observableProps.offset // Not 'offset'!
         }
     }))
     return <span>Seconds passed: {timer.offsetTime}</span>
@@ -466,7 +466,7 @@ const TimerView = observer(({ offset }) => {
         }
     }))
 
-    // effect that triggers upon observable changes
+    // Effect that triggers upon observable changes.
     useEffect(
         () =>
             autorun(() => {
@@ -475,8 +475,7 @@ const TimerView = observer(({ offset }) => {
         []
     )
 
-    // effect to set up a timer
-    // (this one is just here for demo purposes)
+    // Effect to set up a timer, only for demo purposes.
     useEffect(() => {
         const handle = setInterval(() => timer.increaseTimer, 1000)
         return () => {

--- a/docs/react/react-integration.md
+++ b/docs/react/react-integration.md
@@ -113,7 +113,7 @@ import {createContext, useContext} from "react"
 const TimerContext = createContext<Timer>()
 
 const TimerView = observer(() => {
-    // Grab the timer from context.
+    // Grab the timer from the context.
     const timer = useContext(TimerContext) // See the Timer definition above.
     return (
         <span>Seconds passed: {timer.secondsPassed}</span>
@@ -271,12 +271,12 @@ class Todo {
 }
 
 const TodoView = observer(({ todo }: { todo: Todo }) =>
-   // WRONG: GridRow won't pick up changes in todo.title / todo.done since it
-   //        isn't an observer.
+   // WRONG: GridRow won't pick up changes in todo.title / todo.done
+   //        since it isn't an observer.
    return <GridRow data={todo} />
 
-   // CORRECT: let `TodoView` detect relevant changes in `todo`, and pass plain
-   //          data down.
+   // CORRECT: let `TodoView` detect relevant changes in `todo`,
+   //          and pass plain data down.
    return <GridRow data={{
        title: todo.title,
        done: todo.done

--- a/docs/react/react-integration.md
+++ b/docs/react/react-integration.md
@@ -406,7 +406,7 @@ Now you can see component names:
 </details>
 
 <details id="wrap-order"><summary>
-🚀 When combining `observer` with other higher-order-components, apply `observer` first<a href="#wrap-order" class="tip-anchor"></a>
+[🚀] Tip: When combining `observer` with other higher-order-components, apply `observer` first<a href="#wrap-order" class="tip-anchor"></a>
 </summary>
 
 When `observer` needs to be combined with other decorators or higher-order-components, make sure that `observer` is the innermost (first applied) decorator;
@@ -414,7 +414,7 @@ otherwise it might do nothing at all.
 
 </details>
 
-<details id="computed-props"><summary>🚀 Tip: Deriving computeds from props<a href="#computed-props" class="tip-anchor"></a></summary>
+<details id="computed-props"><summary>[🚀] Tip: Deriving computeds from props<a href="#computed-props" class="tip-anchor"></a></summary>
 In some cases the computed values of your local observables might depend on some of the props your component receives.
 However, the set of props that a React component receives is in itself not observable, so changes to the props won't be reflected in any computed values.
 To make props observable, the [useAsObservableSource](https://github.com/mobxjs/mobx-react#useasobservablesource-hook) hook can be used, that will sync the props of a component into an local observable object.
@@ -447,7 +447,7 @@ is a much simpler, albeit slightly less efficient solution.
 
 </details>
 
-<details id="useeffect"><summary>🚀 Tip: useEffect and observables<a href="#useeffect" class="tip-anchor"></a></summary>
+<details id="useeffect"><summary>[🚀] Tip: useEffect and observables<a href="#useeffect" class="tip-anchor"></a></summary>
 
 `useEffect` can be used to set up side effects that need to happen, and which are bound to the life-cycle of the React component.
 Using `useEffect` requires specifying dependencies.

--- a/docs/react/react-performance.md
+++ b/docs/react/react-performance.md
@@ -84,9 +84,7 @@ Faster:
 <DisplayName person={person} />
 ```
 
-In the faster example, a change in the `name` property triggers only `DisplayName` to re-render, while in the slower one the owner of the component has to re-render as well.
-
-There is nothing wrong with that, and if rendering of the owning component is fast enough (usually it is!), then this approach works well.
+In the faster example, a change in the `name` property triggers only `DisplayName` to re-render, while in the slower one the owner of the component has to re-render as well. There is nothing wrong with that, and if rendering of the owning component is fast enough (usually it is!), then this approach works well.
 
 ### Function props
 

--- a/docs/react/react-performance.md
+++ b/docs/react/react-performance.md
@@ -84,11 +84,11 @@ Faster:
 <DisplayName person={person} />
 ```
 
-There is nothing wrong with the latter, but a change in the `name` property will, in the first case, trigger only the `DisplayName` to re-render, while in the latter, the owner of the component has to re-render. If rendering the owning component is fast enough (usually it will be!), that approach will work well.
+There is nothing wrong with the slower example, but a change in the `name` property will in the faster example trigger only the `DisplayName` to re-render, while in the slower example, the owner of the component has to re-render as well. If rendering the owning component is fast enough (usually it is!), then this approach will work well.
 
 ### Function props
 
-[🚀] You may notice that to dereference values late you have to create lots of small observer components where each is customized to render some different part of data, for example:
+[🚀] You may notice that to dereference values late, you have to create lots of small observer components where each is customized to render a different part of data, for example:
 
 ```javascript
 const PersonNameDisplayer = observer(({ person }) => <DisplayName name={person.name} />)

--- a/docs/react/react-performance.md
+++ b/docs/react/react-performance.md
@@ -84,7 +84,9 @@ Faster:
 <DisplayName person={person} />
 ```
 
-There is nothing wrong with the slower example, but a change in the `name` property will in the faster example trigger only the `DisplayName` to re-render, while in the slower example, the owner of the component has to re-render as well. If rendering the owning component is fast enough (usually it is!), then this approach will work well.
+In the faster example, a change in the `name` property triggers only `DisplayName` to re-render, while in the slower one the owner of the component has to re-render as well.
+
+There is nothing wrong with that, and if rendering of the owning component is fast enough (usually it is!), then this approach works well.
 
 ### Function props
 

--- a/docs/react/react-performance.md
+++ b/docs/react/react-performance.md
@@ -86,9 +86,9 @@ Faster:
 
 In the faster example, a change in the `name` property triggers only `DisplayName` to re-render, while in the slower one the owner of the component has to re-render as well. There is nothing wrong with that, and if rendering of the owning component is fast enough (usually it is!), then this approach works well.
 
-### Function props
+### Function props [🚀]
 
-[🚀] You may notice that to dereference values late, you have to create lots of small observer components where each is customized to render a different part of data, for example:
+You may notice that to dereference values late, you have to create lots of small observer components where each is customized to render a different part of data, for example:
 
 ```javascript
 const PersonNameDisplayer = observer(({ person }) => <DisplayName name={person.name} />)

--- a/docs/refguide/configure.md
+++ b/docs/refguide/configure.md
@@ -8,7 +8,7 @@ hide_title: true
 
 # Configuring MobX [🚀]
 
-MobX has several configurations depending on how you prefer to use MobX, which JavaScript engines you want to target, and whether you want MobX to hint at best practices.
+MobX has several configurations depending on how you prefer to use it, which JavaScript engines you want to target, and whether you want MobX to hint at best practices.
 Most configuration options can be set by using the `configure` method.
 
 ## Proxy support
@@ -29,22 +29,21 @@ configure({
 
 Accepted values for the `useProxies` configuration are:
 
--   `"always"` (default): MobX is expected to only run in environments with [`Proxy` support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy). MobX will error if these are not available.
--   `"never"`: Proxies are never used. MobX falls back on non-proxy alternatives. This is compatible with all ES5 environments, but causes various [limitations](#limitations-without-proxies).
+-   `"always"` (default): MobX expects to run only in environments with [`Proxy` support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) and it will error if such an environment is not available.
+-   `"never"`: Proxies are not used and MobX falls back on non-proxy alternatives. This is compatible with all ES5 environments, but causes various [limitations](#limitations-without-proxies).
 -   `"ifavailable"` (experimental): Proxies are used if they are available, and otherwise MobX falls back to non-proxy alternatives. The benefit of this mode is that MobX will try to warn if APIs or language features that wouldn't work in ES5 environments are used, triggering errors when hitting an ES5 limitation running on a modern environment.
 
-**Note:** before MobX 6 one had to pick either MobX 4 for older engines, or MobX 5 for new engines. However, MobX 6 supports both, although polyfills for certain APIs like Map will be required when targetting older JavaScript engines.
-
-**Note:** proxies cannot be polyfilled. Even though polyfills do exist, they don't support the full spec and are unsuitable for MobX. Don't use them.
+**Note:** before MobX 6, one had to pick either MobX 4 for older engines, or MobX 5 for new engines. However, MobX 6 supports both, although polyfills for certain APIs like Map will be required when targetting older JavaScript engines.
+Proxies cannot be polyfilled. Even though polyfills do exist, they don't support the full spec and are unsuitable for MobX. Don't use them.
 
 ### Limitations without Proxy support
 
-1.  Observable arrays are not real arrays, so they won't pass the `Array.isArray()` check. The practical consequence is that you often need to `.slice()` the array first (to get a shallow copy of the real array) before passing it to third party libraries. For example, concatenating observable arrays doesn't work as expected, so '.slice()' them first.
+1.  Observable arrays are not real arrays, so they won't pass the `Array.isArray()` check. The practical consequence is that you often need to `.slice()` the array first (to get a shallow copy of the real array) before passing it to third party libraries. For example, concatenating observable arrays doesn't work as expected, so `.slice()` them first.
 2.  Adding or deleting properties of existing observable plain objects after creation is not automatically picked up. If you intend to use objects as index based lookup maps, in other words, as dynamic collections of things, use observable Maps instead.
 
-Note that it is possible to dynamically add properties to objects, and detect their additions, even when Proxies aren't enabled.
+It is possible to dynamically add properties to objects, and detect their additions, even when Proxies aren't enabled.
 This can be achieved by using the [collection utilities](object-api.md). Make sure that (new) properties are set using the `set` utility, and that the objects are iterated using one of the `values` / `keys` or `entries` utilities, rather than the built-in JavaScript mechanisms.
-But, since this is really easy to forget, we do recommend to use observable Maps instead if possible.
+But, since this is really easy to forget, we instead recommend using observable Maps if possible.
 
 ## Decorator support
 
@@ -52,7 +51,7 @@ For enabling experimental decorator support check out the [Decorators](../best/d
 
 ## Linting options
 
-To help you adopt the patterns advocated by MobX, to adopt a strict separation between actions, state and derivations, MobX can _"lint"_ your coding patterns at runtime by hinting at smells. To make sure MobX is as strict as possible, adopt the following settings and read on for their explanations:
+To help you adopt the patterns advocated by MobX, a strict separation between actions, state and derivations, MobX can _"lint"_ your coding patterns at runtime by hinting at smells. To make sure MobX is as strict as possible, adopt the following settings and read on for their explanations:
 
 ```typescript
 import { configure } from "mobx"
@@ -92,7 +91,7 @@ In the rare case where you create observables lazily, for example in a computed 
 #### `computedRequiresReaction: boolean`
 
 Forbids the direct access of any unobserved computed value from outside an action or reaction.
-This makes sure you aren't using computed values in a way where MobX won't cache them. In the following example, MobX won't cache the computed value in the first code block, but will cache the result in the second and third block:
+This guarantees you aren't using computed values in a way where MobX won't cache them. In the following example, MobX won't cache the computed value in the first code block, but will cache the result in the second and third block:
 
 ```javascript
 class Clock {
@@ -156,7 +155,6 @@ configure({ reactionRequiresObservable: true })
 By default, MobX will catch and re-throw exceptions happening in your code to make sure that a reaction in one exception does not prevent the scheduled execution of other, possibly unrelated, reactions. This means exceptions are not propagated back to the original causing code and therefore you won't be able to catch them using try/catch.
 
 By disabling error boundaries, exceptions can escape derivations. This might ease debugging, but might leave MobX and by extension your application in an unrecoverable broken state.
-
 This option is great for unit tests, but remember to call `_resetGlobalState` after each test, for example by using `afterEach` in jest, for example:
 
 ```js
@@ -185,7 +183,7 @@ afterEach(() => {
 
 Isolates the global state of MobX when there are multiple instances of MobX active in the same environment. This is useful when you have an encapsulated library that is using MobX, living in the same page as the app that is using MobX. The reactivity inside the library will remain self-contained when you call `configure({ isolateGlobalState: true })` from it.
 
-Without this option, if multiple MobX instances are active, the internal state will be shared. The benefit is that observables from both instances work together, the downside is that the MobX versions have to match.
+Without this option, if multiple MobX instances are active, their internal state will be shared. The benefit is that observables from both instances work together, the downside is that the MobX versions have to match.
 
 ```javascript
 configure({ isolateGlobalState: true })

--- a/docs/refguide/configure.md
+++ b/docs/refguide/configure.md
@@ -6,14 +6,14 @@ hide_title: true
 
 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CEBD4KQ7&placement=mobxjsorg" id="_carbonads_js"></script>
 
-# Configuring MobX
+# Configuring MobX [🚀]
 
-MobX has several configuration depending on how you prefer to use MobX, which JavaScript engines you want to target, and whether you want MobX to hint at best practices.
+MobX has several configurations depending on how you prefer to use MobX, which JavaScript engines you want to target, and whether you want MobX to hint at best practices.
 Most configuration options can be set by using the `configure` method.
 
 ## Proxy support
 
-By default MobX uses proxies to make arrays and plain objects observable. Proxies provide the best performance and most consistent behavior across environments.
+By default, MobX uses proxies to make arrays and plain objects observable. Proxies provide the best performance and most consistent behavior across environments.
 However, if you are targetting an environment that doesn't support proxies, proxy support has to be disabled.
 Most notably this is the case when targetting Internet Explorer or React Native without using the Hermes engine.
 
@@ -31,28 +31,28 @@ Accepted values for the `useProxies` configuration are:
 
 -   `"always"` (default): MobX is expected to only run in environments with [`Proxy` support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy). MobX will error if these are not available.
 -   `"never"`: Proxies are never used. MobX falls back on non-proxy alternatives. This is compatible with all ES5 environments, but causes various [limitations](#limitations-without-proxies).
--   `"ifavailable"`: (Experimental option) Proxies are used if they are available, and otherwise MobX falls back to non-proxy alternatives. The benefit of this mode is that MobX will try to warn if APIs or language features that wouldn't work in ES5 environments are used, triggering errors when hitting an ES5 limitation when running on a modern environment.
+-   `"ifavailable"` (experimental): Proxies are used if they are available, and otherwise MobX falls back to non-proxy alternatives. The benefit of this mode is that MobX will try to warn if APIs or language features that wouldn't work in ES5 environments are used, triggering errors when hitting an ES5 limitation running on a modern environment.
 
-Note: before MobX 6 one had to pick either MobX 4 for older engines, or MobX 5 for new engines. However, MobX 6 supports both, although polyfills for certain apis like Map will be required when targetting older JavaScript engines.
+**Note:** before MobX 6 one had to pick either MobX 4 for older engines, or MobX 5 for new engines. However, MobX 6 supports both, although polyfills for certain APIs like Map will be required when targetting older JavaScript engines.
 
-Note: Proxies cannot be polyfilled. Even though polyfills do exist, they don't support the full spec and are unsuitable for MobX. Don't use them.
+**Note:** proxies cannot be polyfilled. Even though polyfills do exist, they don't support the full spec and are unsuitable for MobX. Don't use them.
 
 ### Limitations without Proxy support
 
-1.  Observable arrays are not real arrays, so they won't pass the `Array.isArray()` check. The practical consequence is that you often need to `.slice()` the array first (to get a real array shallow copy) before passing to third party libraries. For example using observable arrays in concat arrays doesn't work as expected. So '.slice()' them first.
-2.  Adding or deleting properties to existing observable plain objects after creation is not automatically picked up. If you intend to use objects as index based lookup maps, in other words, as dymamic collection of things, use observable maps instead.
+1.  Observable arrays are not real arrays, so they won't pass the `Array.isArray()` check. The practical consequence is that you often need to `.slice()` the array first (to get a shallow copy of the real array) before passing it to third party libraries. For example, concatenating observable arrays doesn't work as expected, so '.slice()' them first.
+2.  Adding or deleting properties of existing observable plain objects after creation is not automatically picked up. If you intend to use objects as index based lookup maps, in other words, as dynamic collections of things, use observable Maps instead.
 
-Note that it is possible to add properties dynamically to objects, and detect their addition, even when Proxies aren't enabled.
-This can be achieved by using the [collection utilities](object-api.md); make sure that (new) properties are set using the `set` utility, and that the objects are iterated using one of the `values` / `keys` or `entries` utilities, rather than the build-in JavaScript mechanisms.
-But, since this is really easy to forget, we do recommend to use observable maps instead if possible.
+Note that it is possible to dynamically add properties to objects, and detect their additions, even when Proxies aren't enabled.
+This can be achieved by using the [collection utilities](object-api.md). Make sure that (new) properties are set using the `set` utility, and that the objects are iterated using one of the `values` / `keys` or `entries` utilities, rather than the built-in JavaScript mechanisms.
+But, since this is really easy to forget, we do recommend to use observable Maps instead if possible.
 
 ## Decorator support
 
-For enabling experimental decorator support see [Decorators](../best/decorators).
+For enabling experimental decorator support check out the [Decorators](../best/decorators) section.
 
 ## Linting options
 
-To help you to adopt the patterns advocated by MobX, to adopt a strict separation between actions, state and derivations, MobX can "lint" your coding patterns at runtime by hinting at smells. To make sure MobX is as strict as possible, adopt the following settings (read on for the explanation of those settings):
+To help you adopt the patterns advocated by MobX, to adopt a strict separation between actions, state and derivations, MobX can _"lint"_ your coding patterns at runtime by hinting at smells. To make sure MobX is as strict as possible, adopt the following settings and read on for their explanations:
 
 ```typescript
 import { configure } from "mobx"
@@ -67,7 +67,7 @@ configure({
 ```
 
 At some point you will discover that this level of strictness can be pretty annoying.
-It is fine to disable these rules to gain productivity once you are sure you (and your collegues) grokked the mental model of MobX.
+It is fine to disable these rules to gain productivity once you are sure you (and your colleagues) grokked the mental model of MobX.
 
 Also, occassionally you will have a case where you have to supress the warnings triggered by these rules (for example by wrapping in `runInAction`).
 That is fine, there are good exceptions to these recommendations.
@@ -80,20 +80,19 @@ The goal of _enforceActions_ is that you don't forget to wrap event handlers in 
 Possible options:
 
 -   `"observed"` (default): All state that is observed _somewhere_ needs to be changed through actions. This is the default, and the recommended strictness mode in non-trivial applications.
--   `"never"`: State can be modified from anywhere
--   `"always"`: State always needs be updated (which in practice also includes creation) in actions.
+-   `"never"`: State can be changed from anywhere.
+-   `"always"`: State always needs to be changed through actions, which in practice also includes creation.
 
-The benefit of `"observed"` is that it allows you to create observables outside actions and modify them freely, as long as they aren't used anywhere yet.
+The benefit of `"observed"` is that it allows you to create observables outside of actions and modify them freely, as long as they aren't used anywhere yet.
 
-Since state should in principle always be created from some event handlers, and event handlers should be wrapped, `"always"` captures this the best. But probably you don't want to use this mode in unit tests.
+Since state should in principle always be created from some event handlers, and event handlers should be wrapped, `"always"` captures this the best. But you probably don't want to use this mode in unit tests.
 
 In the rare case where you create observables lazily, for example in a computed property, you can wrap the creation ad-hoc in an action using `runInAction`.
 
 #### `computedRequiresReaction: boolean`
 
 Forbids the direct access of any unobserved computed value from outside an action or reaction.
-This makes sure you aren't using computed values in a way where MobX won't cache them.
-For example, in the following example, MobX won't cache the computed value in the first code block, but will cache the result in the second and third block:
+This makes sure you aren't using computed values in a way where MobX won't cache them. In the following example, MobX won't cache the computed value in the first code block, but will cache the result in the second and third block:
 
 ```javascript
 class Clock {
@@ -111,20 +110,20 @@ class Clock {
 
 const clock = new Clock()
 {
-    // This would compute twice, but is warned against by this flag
+    // This would compute twice, but is warned against by this flag.
     console.log(clock.milliseconds)
     console.log(clock.milliseconds)
 }
 {
     runInAction(() => {
-        // will compute only once
+        // Will compute only once.
         console.log(clock.milliseconds)
         console.log(clock.milliseconds)
     })
 }
 {
     autorun(() => {
-        // will compute only once
+        // Will compute only once.
         console.log(clock.milliseconds)
         console.log(clock.milliseconds)
     })
@@ -135,18 +134,18 @@ const clock = new Clock()
 
 Warns about any unobserved observable access.
 Use this if you want to check whether you are using observables without a "MobX context".
-This is a great way to find any missing `observer` wrappers for example in React components, but it will find missing actions as well.
-
-Note that using propTypes on components that are observer might trigger false positives for this rule.
+This is a great way to find any missing `observer` wrappers, for example in React components. But it will find missing actions as well.
 
 ```javascript
 configure({ observableRequiresReaction: true })
 ```
 
+**Note:** using propTypes on components that are wrapped with `observer` might trigger false positives for this rule.
+
 #### `reactionRequiresObservable: boolean`
 
-Warns when a reaction (eg `autorun`) is created without accessing any observables.
-Use this to check whether you are unneededly wrapping react components with `observer`, accidentally wrapping functions with `action` will they should be tracked by the autorun, or find cases where you simply forget to make some data structures or properties observable.
+Warns when a reaction (e.g. `autorun`) is created without accessing any observables.
+Use this to check whether you are unnecessarily wrapping React components with `observer`, wrapping functions with `action`, or find cases where you simply forgot to make some data structures or properties observable.
 
 ```javascript
 configure({ reactionRequiresObservable: true })
@@ -154,11 +153,11 @@ configure({ reactionRequiresObservable: true })
 
 #### `disableErrorBoundaries: boolean`
 
-By default, MobX will catch and rethrow exceptions happening in your code to make sure that a reaction in one exception does not prevent the scheduled execution of other, possibly unrelated, reactions. This means exceptions are not propagated back to the original causing code and therefore you won't be able to catch them using try/catch.
+By default, MobX will catch and re-throw exceptions happening in your code to make sure that a reaction in one exception does not prevent the scheduled execution of other, possibly unrelated, reactions. This means exceptions are not propagated back to the original causing code and therefore you won't be able to catch them using try/catch.
 
 By disabling error boundaries, exceptions can escape derivations. This might ease debugging, but might leave MobX and by extension your application in an unrecoverable broken state.
 
-This option is great for unit tests, but to call `_resetGlobalState` after each test, for example by using `afterEach` in jest. Example:
+This option is great for unit tests, but remember to call `_resetGlobalState` after each test, for example by using `afterEach` in jest, for example:
 
 ```js
 import { _resetGlobalState, observable, autorun, configure } from "mobx"
@@ -184,11 +183,7 @@ afterEach(() => {
 
 #### `isolateGlobalState: boolean`
 
-Isolates the global state of MobX when there are multiple instances of MobX in the same environment.
-
-This is useful when you have an encapsulated library that is using MobX, living in the same page as the app that is using MobX.
-
-The reactivity inside the library will remain self-contained when you call `configure({isolateGlobalState: true})` inside the library.
+Isolates the global state of MobX when there are multiple instances of MobX active in the same environment. This is useful when you have an encapsulated library that is using MobX, living in the same page as the app that is using MobX. The reactivity inside the library will remain self-contained when you call `configure({ isolateGlobalState: true })` from it.
 
 Without this option, if multiple MobX instances are active, the internal state will be shared. The benefit is that observables from both instances work together, the downside is that the MobX versions have to match.
 

--- a/docs/refguide/extending.md
+++ b/docs/refguide/extending.md
@@ -10,14 +10,13 @@ hide_title: true
 ## Atoms
 
 At some point you might want to have more data structures or other things (like streams) that can be used in reactive computations.
-Achieving that is pretty simple by using the concept of atoms.
+Achieving this is pretty simple by using the concept of atoms.
 Atoms can be used to signal MobX that some observable data source has been observed or changed, and MobX will signal the atom whenever it is used or no longer in use.
 
-_**Tip**: in many cases you can avoid the need to create your own atoms, by just creating a normal observable, and use
+_**Tip**: in many cases you can avoid the need to create your own atoms just by creating a normal observable, and using
 the [`onBecomeObserved`](on-become-observed.md) utility to be notified when MobX starts tracking an observable._
 
-The following example demonstrates how you can create an observable `Clock`, which can be used in reactive functions,
-and returns the current date-time.
+The following example demonstrates how you can create an observable `Clock` that returns the current date-time, which can be used in reactive functions.
 This clock will only actually tick if it is observed by someone.
 
 The complete API of the `Atom` class is demonstrated by this example.
@@ -87,7 +86,7 @@ const clock = new Clock()
 
 const disposer = autorun(() => console.log(clock.getTime()))
 
-// ... prints the time each second.
+// ... prints the time every second.
 
 disposer()
 

--- a/docs/refguide/extending.md
+++ b/docs/refguide/extending.md
@@ -11,11 +11,10 @@ hide_title: true
 
 At some point you might want to have more data structures or other things (like streams) that can be used in reactive computations.
 Achieving that is pretty simple by using the concept of atoms.
-Atoms can be used to signal MobX that some observable data source has been observed or changed.
-And MobX will signal the atom whenever it is used or no longer in use.
+Atoms can be used to signal MobX that some observable data source has been observed or changed, and MobX will signal the atom whenever it is used or no longer in use.
 
-_Tip: in many cases you can avoid the need to create your own atoms, by just creating a normal observable, and use
-the [`onBecomeObserved`](on-become-observed.md) utility to be notified when MobX starts tracking an observable_
+_**Tip**: in many cases you can avoid the need to create your own atoms, by just creating a normal observable, and use
+the [`onBecomeObserved`](on-become-observed.md) utility to be notified when MobX starts tracking an observable._
 
 The following example demonstrates how you can create an observable `Clock`, which can be used in reactive functions,
 and returns the current date-time.
@@ -32,43 +31,52 @@ class Clock {
     currentDateTime
 
     constructor() {
-        // creates an atom to interact with the MobX core algorithm
+        // Creates an atom to interact with the MobX core algorithm.
         this.atom = createAtom(
-            // first param: a name for this atom, for debugging purposes
+            // 1st parameter:
+            // - Atom's name, for debugging purposes.
             "Clock",
-            // second (optional) parameter: callback for when this atom transitions from unobserved to observed.
+            // 2nd (optional) parameter:
+            // - Callback for when this atom transitions
+            //   from unobserved to observed.
             () => this.startTicking(),
-            // third (optional) parameter: callback for when this atom transitions from observed to unobserved
-            // note that the same atom transitions multiple times between these two states
+            // 3rd (optional) parameter:
+            // - Callback for when this atom transitions
+            //   from observed to unobserved.
             () => this.stopTicking()
+            // The same atom transitions between these two states multiple times.
         )
     }
 
     getTime() {
-        // let MobX know this observable data source has been used
-        // reportObserved will return true if the atom is currently being observed
-        // by some reaction.
-        // reportObserved will also trigger the onBecomeObserved event handler (startTicking) if needed
+        // Let MobX know this observable data source has been used. reportObserved
+        // will return true if the atom is currently being observed by some
+        // reaction.
+        //
+        // If needed, it will also trigger the startTicking onBecomeObserved
+        // event handler.
         if (this.atom.reportObserved()) {
             return this.currentDateTime
         } else {
-            // apparently getTime was called but not while a reaction is running.
-            // So, nobody depends on this value, hence the onBecomeObserved handler (startTicking) won't be fired
-            // Depending on the nature of your atom
-            // it might behave differently in such circumstances
-            // (like throwing an error, returning a default value etc)
+            // getTime was called but not while a reaction was running, hence
+            // nobody depends on this value, and the startTicking onBecomeObserved
+            // handler won't be fired.
+            //
+            // Depending on the nature of your atom it might behave differently
+            // in such circumstances, like throwing an error, returning a default
+            // value, etc.
             return new Date()
         }
     }
 
     tick() {
         this.currentDateTime = new Date()
-        // let MobX know that this data source has changed
+        // Let MobX know that this data source has changed.
         this.atom.reportChanged()
     }
 
     startTicking() {
-        this.tick() // initial tick
+        this.tick() // Initial tick.
         this.intervalHandler = setInterval(() => this.tick(), 1000)
     }
 
@@ -82,9 +90,9 @@ const clock = new Clock()
 
 const disposer = autorun(() => console.log(clock.getTime()))
 
-// ... prints the time each second
+// ... prints the time each second.
 
 disposer()
 
-// printing stops. If nobody else uses the same `clock` the clock will stop ticking as well.
+// Printing stops. If nobody else uses the same `clock`, it will stop ticking as well.
 ```

--- a/docs/refguide/extending.md
+++ b/docs/refguide/extending.md
@@ -16,7 +16,7 @@ Atoms can be used to signal MobX that some observable data source has been obser
 _**Tip**: in many cases you can avoid the need to create your own atoms just by creating a normal observable, and using
 the [`onBecomeObserved`](on-become-observed.md) utility to be notified when MobX starts tracking an observable._
 
-The following example demonstrates how you can create an observable `Clock` that returns the current date-time, which can be used in reactive functions.
+The following example demonstrates how you can create an observable `Clock` that returns the current date-time, which can then be used in reactive functions.
 This clock will only actually tick if it is being observed by someone.
 
 The complete API of the `Atom` class is demonstrated by this example.
@@ -82,7 +82,6 @@ class Clock {
 }
 
 const clock = new Clock()
-
 const disposer = autorun(() => console.log(clock.getTime()))
 
 // ... prints the time every second.

--- a/docs/refguide/extending.md
+++ b/docs/refguide/extending.md
@@ -17,7 +17,7 @@ _**Tip**: in many cases you can avoid the need to create your own atoms just by 
 the [`onBecomeObserved`](on-become-observed.md) utility to be notified when MobX starts tracking an observable._
 
 The following example demonstrates how you can create an observable `Clock` that returns the current date-time, which can be used in reactive functions.
-This clock will only actually tick if it is observed by someone.
+This clock will only actually tick if it is being observed by someone.
 
 The complete API of the `Atom` class is demonstrated by this example.
 
@@ -54,7 +54,7 @@ class Clock {
         if (this.atom.reportObserved()) {
             return this.currentDateTime
         } else {
-            // getTime was called but not while a reaction was running, hence
+            // getTime was called, but not while a reaction was running, hence
             // nobody depends on this value, and the startTicking onBecomeObserved
             // handler won't be fired.
             //

--- a/docs/refguide/extending.md
+++ b/docs/refguide/extending.md
@@ -14,7 +14,7 @@ Achieving this is pretty simple by using the concept of atoms.
 Atoms can be used to signal MobX that some observable data source has been observed or changed, and MobX will signal the atom whenever it is used or no longer in use.
 
 _**Tip**: in many cases you can avoid the need to create your own atoms just by creating a normal observable, and using
-the [`onBecomeObserved`](on-become-observed.md) utility to be notified when MobX starts tracking an observable._
+the [`onBecomeObserved`](on-become-observed.md) utility to be notified when MobX starts tracking it._
 
 The following example demonstrates how you can create an observable `Clock` that returns the current date-time, which can then be used in reactive functions.
 This clock will only actually tick if it is being observed by someone.

--- a/docs/refguide/extending.md
+++ b/docs/refguide/extending.md
@@ -82,6 +82,7 @@ class Clock {
 }
 
 const clock = new Clock()
+
 const disposer = autorun(() => console.log(clock.getTime()))
 // Prints the time every second.
 

--- a/docs/refguide/extending.md
+++ b/docs/refguide/extending.md
@@ -37,24 +37,21 @@ class Clock {
             // - Atom's name, for debugging purposes.
             "Clock",
             // 2nd (optional) parameter:
-            // - Callback for when this atom transitions
-            //   from unobserved to observed.
+            // - Callback for when this atom transitions from unobserved to observed.
             () => this.startTicking(),
             // 3rd (optional) parameter:
-            // - Callback for when this atom transitions
-            //   from observed to unobserved.
+            // - Callback for when this atom transitions from observed to unobserved.
             () => this.stopTicking()
             // The same atom transitions between these two states multiple times.
         )
     }
 
     getTime() {
-        // Let MobX know this observable data source has been used. reportObserved
-        // will return true if the atom is currently being observed by some
-        // reaction.
+        // Let MobX know this observable data source has been used.
         //
-        // If needed, it will also trigger the startTicking onBecomeObserved
-        // event handler.
+        // reportObserved will return true if the atom is currently being observed
+        // by some reaction. If needed, it will also trigger the startTicking
+        // onBecomeObserved event handler.
         if (this.atom.reportObserved()) {
             return this.currentDateTime
         } else {

--- a/docs/refguide/extending.md
+++ b/docs/refguide/extending.md
@@ -83,10 +83,8 @@ class Clock {
 
 const clock = new Clock()
 const disposer = autorun(() => console.log(clock.getTime()))
+// Prints the time every second.
 
-// ... prints the time every second.
-
+// Stop printing. If nobody else uses the same `clock`, it will stop ticking as well.
 disposer()
-
-// Printing stops. If nobody else uses the same `clock`, it will stop ticking as well.
 ```

--- a/docs/refguide/extending.md
+++ b/docs/refguide/extending.md
@@ -67,8 +67,7 @@ class Clock {
 
     tick() {
         this.currentDateTime = new Date()
-        // Let MobX know that this data source has changed.
-        this.atom.reportChanged()
+        this.atom.reportChanged() // Let MobX know that this data source has changed.
     }
 
     startTicking() {

--- a/docs/refguide/mobx-utils.md
+++ b/docs/refguide/mobx-utils.md
@@ -1,6 +1,6 @@
 ---
-title: mobx-utils
-sidebar_label: mobx-utils 🚀
+title: MobX-utils
+sidebar_label: MobX-utils 🚀
 hide_title: true
 ---
 

--- a/docs/refguide/mobx-utils.md
+++ b/docs/refguide/mobx-utils.md
@@ -6,6 +6,6 @@ hide_title: true
 
 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CEBD4KQ7&placement=mobxjsorg" id="_carbonads_js"></script>
 
-# mobx-utils [🚀]
+# MobX-utils [🚀]
 
 [MobX-utils](https://github.com/mobxjs/mobx-utils) provides an extensive series of additional utility functions, observables and common patterns for MobX.

--- a/docs/refguide/modifiers.md
+++ b/docs/refguide/modifiers.md
@@ -13,16 +13,16 @@ You can use annotations to specify how observable properties behave when you use
 ### Deep observability
 
 When MobX creates an observable object, it introduces observable properties which by default use the `deep` modifier. The deep modifier basically recursively calls `observable(newValue)` for any newly assigned value, so
-all nested values become observable.
+all nested values become observable as well.
 
-This is a very convenient default. Without any additional effort all values assigned to an observable will themselves be made observable too (unless they already are), so no additional effort is required to make objects deeply observable.
+This is a very convenient default. All values assigned to an observable will themselves be made observable too (unless they already are), making objects deeply observable without any additional effort.
 
 ### Reference observability
 
 In some cases however, objects don't need to be converted into observables.
-Typical cases are immutable objects, or objects that are not managed by you but by an external library. The examples are JSX elements, DOM elements, native objects like History, window or etc. You just want to store a reference to those kinds of objects without turning them into an observable.
+Typical cases are immutable objects, or objects that are not managed by you but by an external library. Such examples are JSX and DOM elements, native objects like History, window, etc. You just want to store a reference to this kind of objects without turning them into an observable themselves.
 
-For these situations there is the `ref` modifier. It makes sure that an observable property is created which tracks only the reference but doesn't try to convert its value.
+For these situations there is the `ref` modifier. It makes sure that an observable property is created which tracks only the reference, but doesn't try to convert its value.
 
 For example:
 
@@ -59,7 +59,7 @@ class AuthorStore {
 
 In the example above, an assignment of a plain array with authors to the `authors` observable array, will update it with the original, non-observable authors.
 
-**Note:** `{ deep: false }` can be passed as option to `observable`, `observable.object`, `observable.array`, `observable.map` and `extendObservable` to create shallow collections.
+**Note:** `{ deep: false }` can be passed as an option to `observable`, `observable.object`, `observable.array`, `observable.map` and `extendObservable` to create shallow collections.
 
 ## Examples
 

--- a/docs/refguide/modifiers.md
+++ b/docs/refguide/modifiers.md
@@ -8,31 +8,29 @@ hide_title: true
 
 # Observable modifiers [🚀]
 
-When you use `makeObservable`, `makeAutoObservable`, `extendObservable` and `observable.object` you can use annotations to specify how observable properties behave:
-
-TODO: move to refguide
+You can use annotations to specify how observable properties behave when you use `makeObservable`, `makeAutoObservable`, `extendObservable` and `observable.object`.
 
 ### Deep observability
 
 When MobX creates an observable object, it introduces observable properties which by default use the `deep` modifier. The deep modifier basically recursively calls `observable(newValue)` for any newly assigned value, so
 all nested values become observable.
 
-This is a very convenient default. Without any additional effort all values assigned to an observable will themselves be made observable too (unless they already are), so no additional effort is required to make objects deep observable.
+This is a very convenient default. Without any additional effort all values assigned to an observable will themselves be made observable too (unless they already are), so no additional effort is required to make objects deeply observable.
 
 ### Reference observability
 
 In some cases however, objects don't need to be converted into observables.
 Typical cases are immutable objects, or objects that are not managed by you but by an external library. The examples are JSX elements, DOM elements, native objects like History, window or etc. You just want to store a reference to those kinds of objects without turning them into an observable.
 
-For these situations there is the `ref` modifier. It makes sure that an observable property is created which only tracks the reference but doesn't try to convert its value.
+For these situations there is the `ref` modifier. It makes sure that an observable property is created which tracks only the reference but doesn't try to convert its value.
 
 For example:
 
 ```javascript
 class Message {
     message = "Hello world"
-    // fictional example, if author is immutable, we just need to store a
-    // reference and shouldn't turn it into a mutable, observable object
+    // Fictional example: if author is immutable, we just need to store a
+    // reference and shouldn't turn it into a mutable, observable object.
     author = null
 
     constructor() {
@@ -41,11 +39,11 @@ class Message {
 }
 ```
 
-Note that an observable, boxed reference can be created by using `const box = observable.shallowBox(value)` ([more](api.md#observablebox)).
+**Note:** an observable, boxed reference can be created using `const box = observable.shallowBox(value)` ([more](api.md#observablebox)).
 
 ### Shallow observability
 
-The `observable.shallow` modifier applies observability 'one-level-deep'. You need those if you want to create a _collection_ of observable references.
+The `observable.shallow` modifier applies observability 'one-level-deep'. This is useful if you want to create a _collection_ of observable references.
 If a new collection is assigned to a property with this modifier, it is made observable, but its values will be left as is, so unlike `deep`, it won't recurse.
 
 Example:
@@ -59,9 +57,9 @@ class AuthorStore {
 }
 ```
 
-In the above example an assignment of a plain array with authors to the `authors` will update the authors with an observable array, containing the original, non-observable authors.
+In the example above, an assignment of a plain array with authors to the `authors` observable array, will update it with the original, non-observable authors.
 
-Note that `{ deep: false }` can be passed as option to `observable`, `observable.object`, `observable.array`, `observable.map` and `extendObservable` to create shallow collections.
+**Note:** `{ deep: false }` can be passed as option to `observable`, `observable.object`, `observable.array`, `observable.map` and `extendObservable` to create shallow collections.
 
 ## Examples
 
@@ -78,14 +76,14 @@ var person = observable(
             return this.showAge ? `${this.name} (age: ${this.age})` : this.name
         },
 
-        // action:
+        // Action
         setAge(age) {
             this.age = age
         }
     },
     {
         setAge: action
-        // the other properties will default to observables  / computed
+        // Other properties will default to observables or computeds.
     }
 )
 ```

--- a/docs/refguide/object-api.md
+++ b/docs/refguide/object-api.md
@@ -9,8 +9,8 @@ hide_title: true
 
 The Object API is a utility API that enables manipulating observable maps, objects and arrays with the same generic API.
 
-These APIs are fully reactive, which means that even [without `Proxy` support](configure.md#limitations-without-proxy-support) new property declarations can be detected by MobX if `set` is used to add them, and `values` or `keys` are used to iterate them.
-Another benefit of `values`, `keys` and `entries` is that they return arrays rather than iterators, which makes it possible to, for example, immediately call `.map(fn)` on the result.
+These APIs are fully reactive, which means that even [without `Proxy` support](configure.md#limitations-without-proxy-support) new property declarations can be detected by MobX if `set` is used to add them, and `values` or `keys` are used to iterate over them.
+Another benefit of `values`, `keys` and `entries` is that they return arrays rather than iterators, which makes it possible to, for example, immediately call `.map(fn)` on the results.
 
 All that being said, a typical project has little reason to use these APIs.
 

--- a/docs/refguide/object-api.md
+++ b/docs/refguide/object-api.md
@@ -5,7 +5,7 @@ hide_title: true
 
 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CEBD4KQ7&placement=mobxjsorg" id="_carbonads_js"></script>
 
-## Object API [🚀]
+## Collection utilities [🚀]
 
 The Object API is a utility API that enables manipulating observable maps, objects and arrays with the same generic API.
 

--- a/docs/refguide/object-api.md
+++ b/docs/refguide/object-api.md
@@ -18,7 +18,7 @@ Access:
 
 -   `values(collection)` returns an array of all the values in the collection.
 -   `keys(collection)` returns an array of all the keys in the collection.
--   `entries(collection)` returns an array of all the `[key, value]` pairs of entries in the collection.
+-   `entries(collection)` returns an array of all the entries `[key, value]` pairs in the collection.
 
 Mutation:
 

--- a/docs/refguide/object-api.md
+++ b/docs/refguide/object-api.md
@@ -16,13 +16,13 @@ All that being said, a typical project has little reason to use these APIs.
 
 Access:
 
--   `values(collection)` returns all values in the collection as array.
--   `keys(collection)` returns all keys in the collection as array.
--   `entries(collection)` returns a `[key, value]` pair for all entries in the collection as array.
+-   `values(collection)` returns an array of all the values in the collection.
+-   `keys(collection)` returns an array of all the keys in the collection.
+-   `entries(collection)` returns an array of all the `[key, value]` pairs of entries in the collection.
 
 Mutation:
 
--   `set(collection, key, value)` or `set(collection, { key: value })` updates the given collection with the provided key / value pair(s).
+-   `set(collection, key, value)` or `set(collection, { key: value })` update the given collection with the provided key / value pair(s).
 -   `remove(collection, key)` removes the specified child from the collection. Splicing is used for arrays.
 -   `has(collection, key)` returns _true_ if the collection has the specified _observable_ property.
 -   `get(collection, key)` returns the child under the specified key.

--- a/docs/refguide/object-api.md
+++ b/docs/refguide/object-api.md
@@ -27,7 +27,7 @@ Mutation:
 -   `has(collection, key)` returns _true_ if the collection has the specified _observable_ property.
 -   `get(collection, key)` returns the child under the specified key.
 
-If you use the access API in an environment without `Proxy` support, then you should also use the mutation APIs so that they can detect changes.
+If you use the access APIs in an environment without `Proxy` support, then also use the mutation APIs so they can detect the changes.
 
 ```javascript
 import { get, set, observable, values } from "mobx"

--- a/docs/refguide/object-api.md
+++ b/docs/refguide/object-api.md
@@ -9,28 +9,25 @@ hide_title: true
 
 The Object API is a utility API that enables manipulating observable maps, objects and arrays with the same generic API.
 
-These APIs are fully reactive, which means that even [without `Proxy` support](configure.md#limitations-without-proxy-support) new property declarations can be detected by mobx if `set` is used to add them, and `values` or `keys` to iterate them.
+These APIs are fully reactive, which means that even [without `Proxy` support](configure.md#limitations-without-proxy-support) new property declarations can be detected by MobX if `set` is used to add them, and `values` or `keys` to iterate them.
+Another benefit of `values`, `keys` and `entries` is that they return arrays rather than iterators, which makes it possible to, for example, immediately call `.map(fn)` on the result.
 
-Another benefit of `values`, `keys` and `entries` is that they return array rather than iterators, which makes it possible to, for example, immediately call `.map(fn)` on the result.
-
-That all being said, a typical project has little reason to use these APIs.
+All that being said, a typical project has little reason to use these APIs.
 
 Access:
 
--   `values(thing)` returns all values in the collection as array
--   `keys(thing)` returns all keys in the collection as array
--   `entries(thing)` returns a [key, value] pair for all entries in the collection as array
+-   `values(collection)` returns all values in the collection as array.
+-   `keys(collection)` returns all keys in the collection as array.
+-   `entries(collection)` returns a `[key, value]` pair for all entries in the collection as array.
 
 Mutation:
 
--   `set(thing, key, value)` or `set(thing, { key: value })` Updates the given collection with the provided key / value pair(s).
--   `remove(thing, key)` removes the specified child from the collection. For arrays splicing is used.
--   `has(thing, key)` returns true if the collection has the specified _observable_ property.
--   `get(thing, key)` returns the child under the specified key.
+-   `set(collection, key, value)` or `set(collection, { key: value })` updates the given collection with the provided key / value pair(s).
+-   `remove(collection, key)` removes the specified child from the collection. Splicing is used for arrays.
+-   `has(collection, key)` returns _true_ if the collection has the specified _observable_ property.
+-   `get(collection, key)` returns the child under the specified key.
 
-If you use the access API in an environment in an environment
-without `Proxy` support you should also use the mutation APIs
-so that they can detect changes.
+If you use the access API in an environment without `Proxy` support, then you should also use the mutation APIs so that they can detect changes.
 
 ```javascript
 import { get, set, observable, values } from "mobx"
@@ -40,7 +37,8 @@ const twitterUrls = observable.object({
 })
 
 autorun(() => {
-    console.log(get(twitterUrls, "Sara")) // get can track not yet existing properties
+    // Get can track not yet existing properties.
+    console.log(get(twitterUrls, "Sara"))
 })
 
 autorun(() => {

--- a/docs/refguide/object-api.md
+++ b/docs/refguide/object-api.md
@@ -9,7 +9,7 @@ hide_title: true
 
 The Object API is a utility API that enables manipulating observable maps, objects and arrays with the same generic API.
 
-These APIs are fully reactive, which means that even [without `Proxy` support](configure.md#limitations-without-proxy-support) new property declarations can be detected by MobX if `set` is used to add them, and `values` or `keys` to iterate them.
+These APIs are fully reactive, which means that even [without `Proxy` support](configure.md#limitations-without-proxy-support) new property declarations can be detected by MobX if `set` is used to add them, and `values` or `keys` are used to iterate them.
 Another benefit of `values`, `keys` and `entries` is that they return arrays rather than iterators, which makes it possible to, for example, immediately call `.map(fn)` on the result.
 
 All that being said, a typical project has little reason to use these APIs.

--- a/docs/refguide/object.md
+++ b/docs/refguide/object.md
@@ -12,7 +12,7 @@ Usage:
 
 -   `observable.object(props, annotations?, options?)`
 
-If a plain JavaScript object is passed to `observable`, all properties inside will be copied into a clone and made observable.
+If a plain JavaScript object is passed to `observable` all properties inside will be copied into a clone and made observable.
 A plain object is an object that wasn't created using a constructor function, but has `Object` as its prototype or no prototype at all.
 By default, `observable` is applied recursively. If one of the encountered values is an object or array, that value will be passed through `observable` as well.
 
@@ -57,10 +57,10 @@ Some things to keep in mind when making objects observable:
 
 -   Only plain objects will be made observable. For non-plain objects it is considered the responsibility of the constructor to initialize the observable properties using [`makeObservable` or `makeAutoObservable`](observable.md).
 -   Property getters will be automatically turned into derived properties, just like declaring it [`computed`](computed) would do.
--   `observable` is applied recursively to a whole object graph automatically. Both on instantiation and to any new values that will be assigned to observable properties in the future. Observable will not recurse into non-plain objects.
--   These defaults are fine in 95% of the cases, but for more fine-grained on how and which properties should be made observable, check out the [modifiers](modifiers.md) section.
--   Pass `{ deep: false }` as 3rd argument to disable the auto conversion of property values.
--   Pass `{ name: "my object" }` to assign a friendly debug name to an object.
+-   `observable` is automatically recursively applied to a whole object graph, both on instantiation and to any new values that will be assigned to observable properties in the future. Observable will not recurse into non-plain objects.
+-   These defaults are fine in 95% of the cases, but for more fine-grained control on how and which properties should be made observable, check out the [modifiers](modifiers.md) section.
+-   Pass `{ deep: false }` as 3rd argument to disable the automatic conversion of property values.
+-   Pass `{ name: "my object" }` to assign a friendly debug name to the object.
 
 ## `isObservableObject`
 
@@ -72,6 +72,6 @@ Returns `true` if `value` is an observable object.
 
 ## Limitations in environments without Proxy support
 
-When passing objects through `observable`, only the properties that exist at the time of making the object observable will be observable. Properties that are added to the object at a later time won't become observable, unless [`set`](object-api.md) or [`extendObservable`](api.md#extendobservable) is used.
+When passing objects through `observable` only the properties that exist at the time of making the object observable will be observable. Properties that are added to the object at a later time won't become observable, unless [`set`](object-api.md) or [`extendObservable`](api.md#extendobservable) is used.
 
 Check out [limitations without proxies](configure.md#limitations-without-proxy-support).

--- a/docs/refguide/object.md
+++ b/docs/refguide/object.md
@@ -16,7 +16,7 @@ If a plain JavaScript object is passed to `observable` all properties inside wil
 A plain object is an object that wasn't created using a constructor function, but has `Object` as its prototype or no prototype at all.
 By default, `observable` is applied recursively. If one of the encountered values is an object or array, that value will be passed through `observable` as well.
 
-The `annotations` param can be used to override the declaration that is used for a specific property, like [`makeObservable` and `makeAutoObservable`](observable.md). Also check out the [modifiers](modifiers.md) section.
+The `annotations` param can be used to override the declaration that is used for a specific property, like [`makeObservable` and `makeAutoObservable`](observable.md). Check out the [modifiers](modifiers.md) section as well.
 
 ```javascript
 import { observable, autorun, action } from "mobx"

--- a/docs/refguide/object.md
+++ b/docs/refguide/object.md
@@ -47,10 +47,10 @@ var person = observable(
 autorun(() => console.log(person.labelText))
 
 person.name = "Dave"
-// Prints: 'Dave'.
+// Prints: 'Dave'
 
 person.setAge(21)
-// Prints: 'Dave (age: 21)'.
+// Prints: 'Dave (age: 21)'
 ```
 
 Some things to keep in mind when making objects observable:

--- a/docs/refguide/object.md
+++ b/docs/refguide/object.md
@@ -12,23 +12,23 @@ Usage:
 
 -   `observable.object(props, annotations?, options?)`
 
-If a plain JavaScript object is passed to `observable` all properties inside will be copied into a clone and made observable.
-(A plain object is an object that wasn't created using a constructor function / but has `Object` as its prototype, or no prototype at all.)
-`observable` is by default applied recursively, so if one of the encountered values is an object or array, that value will be passed through `observable` as well.
+If a plain JavaScript object is passed to `observable`, all properties inside will be copied into a clone and made observable.
+A plain object is an object that wasn't created using a constructor function, but has `Object` as its prototype or no prototype at all.
+By default, `observable` is applied recursively. If one of the encountered values is an object or array, that value will be passed through `observable` as well.
 
-The `annotations` param can be used to override the declaration that is used for a specific property, like [`makeObservable` and `makeAutoObservable`](observable.md). See also [modifiers](modifiers.md).
+The `annotations` param can be used to override the declaration that is used for a specific property, like [`makeObservable` and `makeAutoObservable`](observable.md). Also check out [modifiers](modifiers.md).
 
 ```javascript
 import { observable, autorun, action } from "mobx"
 
 var person = observable(
     {
-        // observable properties:
+        // Observable properties:
         name: "John",
         age: 42,
         showAge: false,
 
-        // computed property:
+        // Computed property:
         get labelText() {
             return this.showAge ? `${this.name} (age: ${this.age})` : this.name
         },
@@ -42,15 +42,15 @@ var person = observable(
     }
 )
 
-// object properties don't expose an 'observe' method,
-// but don't worry, 'mobx.autorun' is even more powerful
+// Object properties don't expose an 'observe' method,
+// but don't worry, 'mobx.autorun' is even more powerful.
 autorun(() => console.log(person.labelText))
 
+// Prints: 'Dave'.
 person.name = "Dave"
-// prints: 'Dave'
 
+// etc.
 person.setAge(21)
-// etc
 ```
 
 Some things to keep in mind when making objects observable:
@@ -58,9 +58,9 @@ Some things to keep in mind when making objects observable:
 -   Only plain objects will be made observable. For non-plain objects it is considered the responsibility of the constructor to initialize the observable properties using [`makeObservable` or `makeAutoObservable`](observable.md).
 -   Property getters will be automatically turned into derived properties, just like declaring it [`computed`](computed) would do.
 -   `observable` is applied recursively to a whole object graph automatically. Both on instantiation and to any new values that will be assigned to observable properties in the future. Observable will not recurse into non-plain objects.
--   These defaults are fine in 95% of the cases, but for more fine-grained on how and which properties should be made observable, see the [modifiers](modifiers.md) section.
+-   These defaults are fine in 95% of the cases, but for more fine-grained on how and which properties should be made observable, check out the [modifiers](modifiers.md) section.
 -   Pass `{ deep: false }` as 3rd argument to disable the auto conversion of property values.
--   Pass `{ name: "my object" }` to assign a friendly debug name to this object.
+-   Pass `{ name: "my object" }` to assign a friendly debug name to an object.
 
 ## `isObservableObject`
 
@@ -72,4 +72,6 @@ Returns `true` if `value` is an observable object.
 
 ## Limitations in environments without Proxy support
 
-When passing objects through `observable`, only the properties that exist at the time of making the object observable will be observable. Properties that are added to the object at a later time won't become observable, unless [`set`](object-api.md) or [`extendObservable`](api.md#extendobservable) is used. See also [limitations without proxies](configure.md#limitations-without-proxy-support)
+When passing objects through `observable`, only the properties that exist at the time of making the object observable will be observable. Properties that are added to the object at a later time won't become observable, unless [`set`](object-api.md) or [`extendObservable`](api.md#extendobservable) is used.
+
+Check out [limitations without proxies](configure.md#limitations-without-proxy-support).

--- a/docs/refguide/object.md
+++ b/docs/refguide/object.md
@@ -16,7 +16,7 @@ If a plain JavaScript object is passed to `observable` all properties inside wil
 A plain object is an object that wasn't created using a constructor function, but has `Object` as its prototype or no prototype at all.
 By default, `observable` is applied recursively. If one of the encountered values is an object or array, that value will be passed through `observable` as well.
 
-The `annotations` param can be used to override the declaration that is used for a specific property, like [`makeObservable` and `makeAutoObservable`](observable.md). Check out the [modifiers](modifiers.md) section as well.
+The `annotations` parameter can be used to override the declarations used for specific properties, like [`makeObservable` and `makeAutoObservable`](observable.md). Check out the [modifiers](modifiers.md) section as well.
 
 ```javascript
 import { observable, autorun, action } from "mobx"

--- a/docs/refguide/object.md
+++ b/docs/refguide/object.md
@@ -46,11 +46,11 @@ var person = observable(
 // but don't worry, 'mobx.autorun' is even more powerful.
 autorun(() => console.log(person.labelText))
 
-// Prints: 'Dave'.
 person.name = "Dave"
+// Prints: 'Dave'.
 
-// Prints: 'Dave (age: 21)'.
 person.setAge(21)
+// Prints: 'Dave (age: 21)'.
 ```
 
 Some things to keep in mind when making objects observable:

--- a/docs/refguide/object.md
+++ b/docs/refguide/object.md
@@ -57,7 +57,7 @@ Some things to keep in mind when making objects observable:
 
 -   Only plain objects will be made observable. For non-plain objects it is considered the responsibility of the constructor to initialize the observable properties using [`makeObservable` or `makeAutoObservable`](observable.md).
 -   Property getters will be automatically turned into derived properties, just like declaring it [`computed`](computed) would do.
--   `observable` is automatically recursively applied to a whole object graph, both on instantiation and to any new values that will be assigned to observable properties in the future. Observable will not recurse into non-plain objects.
+-   `observable` is automatically recursively applied to a whole object graph, both on instantiation and to any new values that will be assigned to observable properties in the future. It will not recurse into non-plain objects.
 -   These defaults are fine in 95% of the cases, but for more fine-grained control on how and which properties should be made observable, check out the [modifiers](modifiers.md) section.
 -   Pass `{ deep: false }` as 3rd argument to disable the automatic conversion of property values.
 -   Pass `{ name: "my object" }` to assign a friendly debug name to the object.

--- a/docs/refguide/object.md
+++ b/docs/refguide/object.md
@@ -16,7 +16,7 @@ If a plain JavaScript object is passed to `observable` all properties inside wil
 A plain object is an object that wasn't created using a constructor function, but has `Object` as its prototype or no prototype at all.
 By default, `observable` is applied recursively. If one of the encountered values is an object or array, that value will be passed through `observable` as well.
 
-The `annotations` param can be used to override the declaration that is used for a specific property, like [`makeObservable` and `makeAutoObservable`](observable.md). Also check out [modifiers](modifiers.md).
+The `annotations` param can be used to override the declaration that is used for a specific property, like [`makeObservable` and `makeAutoObservable`](observable.md). Also check out the [modifiers](modifiers.md) section.
 
 ```javascript
 import { observable, autorun, action } from "mobx"
@@ -49,7 +49,7 @@ autorun(() => console.log(person.labelText))
 // Prints: 'Dave'.
 person.name = "Dave"
 
-// etc.
+// Prints: 'Dave (age: 21)'.
 person.setAge(21)
 ```
 
@@ -72,6 +72,6 @@ Returns `true` if `value` is an observable object.
 
 ## Limitations in environments without Proxy support
 
-When passing objects through `observable` only the properties that exist at the time of making the object observable will be observable. Properties that are added to the object at a later time won't become observable, unless [`set`](object-api.md) or [`extendObservable`](api.md#extendobservable) is used.
+When passing objects through `observable` only the properties that exist at the time of making the object observable will become observable. Properties that are added to the object at a later time won't become observable, unless [`set`](object-api.md) or [`extendObservable`](api.md#extendobservable) is used.
 
-Check out [limitations without proxies](configure.md#limitations-without-proxy-support).
+Check out the [limitations without proxies](configure.md#limitations-without-proxy-support) section.

--- a/docs/refguide/observable.md
+++ b/docs/refguide/observable.md
@@ -35,7 +35,9 @@ Their read operations will still be tracked when they are called from a reaction
 
 It can only annotate properties declared by its own class definition. If a sub or superclass introduces observable fields, it will have to call `makeObservable` for those properties itself.
 
-**TypeScript note:** when decorating private properties, you can pass the private property names as a generic argument to `makeObservable` to suppress the compile error about the field not existing, like this: `makeObservable<"myPrivateField" | "myOtherPrivateField>(this, { myPrivateField: observable })`.
+**TypeScript note:** when decorating private properties, you can pass the private property names as a generic argument to `makeObservable` to suppress the compile error about the field not existing, like this:
+
+`makeObservable<"myPrivateField" | "myOtherPrivateField>(this, { myPrivateField: observable })`.
 
 </details>
 

--- a/docs/refguide/observable.md
+++ b/docs/refguide/observable.md
@@ -231,7 +231,7 @@ Note that it is possible to pass `{ proxy: false }` as an option to `observable`
 | `flow`                             | Creates a `flow` to manage asynchronous processes. Check out [flow](action.html#-using-flow-instead-of-asyncawait) for more details. Note that the inferred return type in TypeScript might be off.                              |
 | `autoAction`                       | Should not be used explicitly, but is used under the hood by `makeAutoObservable` to mark methods that can act as action or derivation, based on their calling context.                                                     |
 
-## 🚀 The `options` argument
+## The `options` argument [🚀]
 
 The above APIs take an optional `options` argument which is an object that supports the following options:
 

--- a/docs/refguide/observable.md
+++ b/docs/refguide/observable.md
@@ -202,7 +202,7 @@ Making class members observable is considered the responsibility of the class co
 
 </details>
 
-<details id="avoid-proxies"><summary>🚀 Tip: observable (proxied) versus makeObservable (unproxied)<a href="#avoid-proxies" class="tip-anchor"></a></summary>
+<details id="avoid-proxies"><summary>[🚀] Tip: observable (proxied) versus makeObservable (unproxied)<a href="#avoid-proxies" class="tip-anchor"></a></summary>
 
 The primary difference between `make(Auto)Observable` and `observable` is that the first one modifies the object you are passing in as first argument, while `observable` creates a _clone_ that is made observable.
 

--- a/docs/refguide/observable.md
+++ b/docs/refguide/observable.md
@@ -12,8 +12,8 @@ Properties, entire objects, arrays, Maps and Sets can all be made observable.
 The basics of making objects observable is specifying an annotation per property using `makeObservable`.
 The most important annotations are:
 
--   `observable` defines a trackable field that stores state.
--   `action` marks a method as action that will modify state.
+-   `observable` defines a trackable field that stores the state.
+-   `action` marks a method as action that will modify the state.
 -   `computed` marks a getter that will derive new facts from the state and cache its output.
 
 Collections such as arrays, Maps and Sets are made observable automatically.
@@ -33,7 +33,7 @@ Their read operations will still be tracked when they are called from a reaction
 
 <details id="limitations"><summary>makeObservable limitations<a href="#limitations" class="tip-anchor"></a></summary>
 
-It can only annotate properties declared by its own class definition. If a sub- or superclass introduces observable fields, it will have to call `makeObservable` for those properties itself.
+It can only annotate properties declared by its own class definition. If a sub or superclass introduces observable fields, it will have to call `makeObservable` for those properties itself.
 
 **TypeScript note:** when decorating private properties, you can pass the private property names as a generic argument to `makeObservable` to suppress the compile error about the field not existing, like this: `makeObservable<"myPrivateField" | "myOtherPrivateField>(this, { myPrivateField: observable })`.
 
@@ -118,9 +118,9 @@ Usage:
 
 `makeAutoObservable` is like `makeObservable` on steroids, as it infers all the properties by default. You can still use `overrides` to override the default behavior with specific annotations.
 In particular `false` can be used to exclude a property or method from being processed entirely.
-See the code tabs above for an example.
+Check out the code tabs above for an example.
 The `makeAutoObservable` function can be more compact and easier to maintain than using `makeObservable`, since new members don't have to be mentioned explicitly.
-However, `makeAutoObservable` cannot be used on classes that have super- or are subclassed.
+However, `makeAutoObservable` cannot be used on classes that have super or are subclassed.
 
 Inference rules:
 
@@ -142,11 +142,11 @@ Usage:
 The `observable` annotation can also be called as a function to make an entire object observable at once.
 The `source` object will be cloned and all members will be made observable, similar to how it would be done by `makeAutoObservable`.
 Likewise, an `overrides` map can be provided to specify the annotations of specific members.
-See the above code block for an example.
+Check out the above code block for an example.
 
 The object returned by `observable` will be a Proxy, which means that properties that are added later to the object will be picked up and made observable as well (except when [proxy usage](../refguide/configure.md#proxy-support) is disabled).
 
-The `observable` method can also be called with collections types like [arrays](../refguide/api.md#observablearray), [Maps](../refguide/api.md#observablemap) and [Sets](../refguide/api.md#observableset). Those will be cloned as well and converted into their observable counterpart.
+The `observable` method can also be called with collections types like [arrays](../refguide/api.md#observablearray), [Maps](../refguide/api.md#observablemap) and [Sets](../refguide/api.md#observableset). Those will be cloned as well and converted into their observable counterparts.
 
 <details id="observable-array"><summary>Observable array example<a href="#observable-array" class="tip-anchor"></a></summary>
 
@@ -205,9 +205,9 @@ Making class members observable is considered the responsibility of the class co
 The primary difference between `make(Auto)Observable` and `observable` is that the first one modifies the object you are passing in as first argument, while `observable` creates a _clone_ that is made observable.
 
 The second difference is that `observable` creates a `Proxy` object, to be able to trap future property additions in case you use the object as a dynamic lookup map.
-If the object you want to make observable has a regular structure where all members are known up-front, we recommend to use `makeObservable` as non proxied objects are a little faster, and they are easier to inspect in the debugger / `console.log`.
+If the object you want to make observable has a regular structure where all members are known up-front, we recommend to use `makeObservable` as non proxied objects are a little faster, and they are easier to inspect in the debugger and `console.log`.
 
-Because of that, `make(Auto)Observable` is the recommended API to use in for example factory functions.
+Because of that, `make(Auto)Observable` is the recommended API to use in factory functions.
 Note that it is possible to pass `{ proxy: false }` as an option to `observable` to get a non proxied clone.
 
 </details>
@@ -226,7 +226,7 @@ Note that it is possible to pass `{ proxy: false }` as an option to `observable`
 | `computed.struct`                  | Like `computed`, except that if after recomputing the result is structurally equal to the previous result, no observers will be notified.                                                                                   |
 | `true`                             | Infer the best annotation. Check out [makeAutoObservable](#makeautoobservable) for more details.                                                                                                                                                  |
 | `false`                            | Explicitly do not annotate this property.                                                                                                                                                                                  |
-| `flow`                             | Creates a `flow` to manage asynchronous processes. Check out[flow](action.html#-using-flow-instead-of-asyncawait) for more details. Note that the inferred return type in TypeScript might be off.                              |
+| `flow`                             | Creates a `flow` to manage asynchronous processes. Check out [flow](action.html#-using-flow-instead-of-asyncawait) for more details. Note that the inferred return type in TypeScript might be off.                              |
 | `autoAction`                       | Should not be used explicitly, but is used under the hood by `makeAutoObservable` to mark methods that can act as action or derivation, based on their calling context.                                                     |
 
 ## 🚀 The `options` argument
@@ -239,7 +239,7 @@ The above APIs take an optional `options` argument which is an object that suppo
 
 ## Converting observables back to vanilla JavaScript collections
 
-Sometimes it is necessary to convert observable data structures back to their vanilla counterpart.
+Sometimes it is necessary to convert observable data structures back to their vanilla counterparts.
 For example when passing observable objects to a React component that can't track observables, or to obtain a clone that should not be further mutated.
 
 To convert a collection shallowly, the usual JavaScript mechanisms work:
@@ -255,7 +255,7 @@ For classes, it is recommend to implement a `toJSON()` method, as it will be pic
 
 ## A short note on classes
 
-So far most examples above have been leaning towards class syntax.
+So far most examples above have been leaning towards the class syntax.
 MobX is in principle unopinionated about this, and there are probably just as many MobX users that use plain objects.
 However, a slight benefit of classes is that they have more easily discoverable APIs, e.g. TypeScript.
 Also, `instanceof` checks are really powerful for type inference, and class instances aren't wrapped in `Proxy` objects, giving them a better experience in debuggers.

--- a/docs/refguide/observable.md
+++ b/docs/refguide/observable.md
@@ -9,12 +9,12 @@ hide_title: true
 # Create observable state
 
 Properties, entire objects, arrays, Maps and Sets can all be made observable.
-The basics of making objects observable is by specifying an annotation per property by using `makeObservable`.
+The basics of making objects observable is specifying an annotation per property using `makeObservable`.
 The most important annotations are:
 
--   `observable` define a trackable field that stores state.
--   `action` mark a method as action that will modify state.
--   `computed` mark a getters that will derive new facts from the state and cache its output.
+-   `observable` defines a trackable field that stores state.
+-   `action` marks a method as action that will modify state.
+-   `computed` marks a getter that will derive new facts from the state and cache its output.
 
 Collections such as arrays, Maps and Sets are made observable automatically.
 
@@ -24,18 +24,18 @@ Usage:
 
 -   `makeObservable(target, annotations?, options?)`
 
-MakeObservable can be used to trap _existing_ object properties and make them observable. Any JavaScript object (including class instances) can be passed into `target`.
+It can be used to trap _existing_ object properties and make them observable. Any JavaScript object (including class instances) can be passed into `target`.
 Typically `makeObservable` is used in the constructor of a class, and its first argument is `this`.
-The `annotations` argument then maps [annotations](#available-annotations) to map to each member (n.b.: when using [decorators](../best/decorators), the `annotations` argument can be omitted).
+The `annotations` argument maps [annotations](#available-annotations) to each member. Note that when using [decorators](../best/decorators), the `annotations` argument can be omitted.
 
 Methods that derive information and take arguments (for example `findUsersOlderThan(age: number): User[]`) don't need any annotation.
-Their read operations will still be tracked when they are called from a reaction, but their output won't be memoized to avoid memory leaks (see also [mobx-utils:computedFn](https://github.com/mobxjs/mobx-utils#computedfn)).
+Their read operations will still be tracked when they are called from a reaction, but their output won't be memoized to avoid memory leaks. Check out [MobX-utils computedFn](https://github.com/mobxjs/mobx-utils#computedfn) as well.
 
 <details id="limitations"><summary>makeObservable limitations<a href="#limitations" class="tip-anchor"></a></summary>
 
-MakeObservable can only annotate properties declared by its own class definition. If a sub- or superclass introduces observable fields, it will have to call `makeObservable` for those properties itself.
+It can only annotate properties declared by its own class definition. If a sub- or superclass introduces observable fields, it will have to call `makeObservable` for those properties itself.
 
-TypeScript note: When decorating private properties in TypeScript, you can pass the private property names as generic argument to `makeObservable` to suppress the compile error about the field not existing like this: `makeObservable<"myPrivateField" | "myOtherPrivateField>(this, { myPrivateField: observable })`
+**TypeScript note:** when decorating private properties, you can pass the private property names as a generic argument to `makeObservable` to suppress the compile error about the field not existing, like this: `makeObservable<"myPrivateField" | "myOtherPrivateField>(this, { myPrivateField: observable })`.
 
 </details>
 
@@ -116,7 +116,7 @@ Usage:
 
 -   `makeAutoObservable(target, overrides?, options?)`
 
-`makeAutoObservable` is like `makeObservable` on steroids, as it infers all properties by default. You can still use `overrides` to override the default behavior with specific annotations.
+`makeAutoObservable` is like `makeObservable` on steroids, as it infers all the properties by default. You can still use `overrides` to override the default behavior with specific annotations.
 In particular `false` can be used to exclude a property or method from being processed entirely.
 See the code tabs above for an example.
 The `makeAutoObservable` function can be more compact and easier to maintain than using `makeObservable`, since new members don't have to be mentioned explicitly.
@@ -128,9 +128,9 @@ Inference rules:
 -   Any (inherited) member that contains a `function` value will be annotated with `autoAction`.
 -   Any `get`ter will be annotated with `computed`.
 -   Any other _own_ field will be marked with `observable`.
--   Members marked with `false` in the `overrides` argument will not be annotated. Use this for for example read only fields such as identifiers.
+-   Members marked with `false` in the `overrides` argument will not be annotated. For example, using it for read only fields such as identifiers.
 
-When you call `makeObservable` or `makeAutoObservable` all properties you want to annotate
+When you call `makeObservable` or `makeAutoObservable`, all the properties you want to annotate
 _must_ exist on the instance already. Either by [declaring](https://github.com/tc39/proposal-class-fields) them (recommended, as done above) or otherwise by assigning them _before_ calling `makeAutoObservable` (declaring and annotating in one go can be done using [extendObservable](api.md#extendobservable)). Beyond that, calling and providing annotations must be done unconditionally, as this makes it possible to cache the inference results.
 
 ## `observable`
@@ -139,7 +139,7 @@ Usage:
 
 -   `observable(source, overrides?, options?)`
 
-The `observable` annotation can also be called as function to make an entire object observable at once.
+The `observable` annotation can also be called as a function to make an entire object observable at once.
 The `source` object will be cloned and all members will be made observable, similar to how it would be done by `makeAutoObservable`.
 Likewise, an `overrides` map can be provided to specify the annotations of specific members.
 See the above code block for an example.
@@ -184,19 +184,19 @@ todos.shift()
 
 Observable arrays have some additional nifty utility functions:
 
--   `clear()` Remove all current entries from the array.
--   `replace(newItems)` Replaces all existing entries in the array with new ones.
--   `remove(value)` Remove a single item by value from the array. Returns `true` if the item was found and removed.
+-   `clear()` removes all current entries from the array.
+-   `replace(newItems)` replaces all existing entries in the array with new ones.
+-   `remove(value)` removes a single item by value from the array. Returns `true` if the item was found and removed.
 
 </details>
 
 <details id="non-convertibles"><summary>Primitives and class instances are never converted to observables<a href="#non-convertibles" class="tip-anchor"></a></summary>
 
-Class instances will never be made observable automatically by passing them to `observable` or assigning them to an `observable` property.
-Making class members observable is considered the responsibility of the class constructor.
-
 Primitive values cannot be made observable by MobX since they are immutable in JavaScript (but they can be [boxed](../refguide/api.md#observablebox)).
 Although there is typically no use for this mechanism outside libraries.
+
+Class instances will never be made observable automatically by passing them to `observable` or assigning them to an `observable` property.
+Making class members observable is considered the responsibility of the class constructor.
 
 </details>
 
@@ -205,9 +205,10 @@ Although there is typically no use for this mechanism outside libraries.
 The primary difference between `make(Auto)Observable` and `observable` is that the first one modifies the object you are passing in as first argument, while `observable` creates a _clone_ that is made observable.
 
 The second difference is that `observable` creates a `Proxy` object, to be able to trap future property additions in case you use the object as a dynamic lookup map.
-If the object you want to make observable has a regular structure where all members are known up-front, we recommend to use `makeObservable`: Non proxied objects are a little faster, and they are easier to inspect in the debugger / `console.log`.
-So `make(Auto)Observable` is the recommended API to use in for example factory functions.
-Note that it is possible to pass `{ proxy: false }` as option to `observable` to get an non-proxied clone.
+If the object you want to make observable has a regular structure where all members are known up-front, we recommend to use `makeObservable` as non proxied objects are a little faster, and they are easier to inspect in the debugger / `console.log`.
+
+Because of that, `make(Auto)Observable` is the recommended API to use in for example factory functions.
+Note that it is possible to pass `{ proxy: false }` as an option to `observable` to get a non proxied clone.
 
 </details>
 
@@ -216,32 +217,32 @@ Note that it is possible to pass `{ proxy: false }` as option to `observable` to
 | Annotation                         | Description                                                                                                                                                                                                                |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `observable`<br/>`observable.deep` | Defines a trackable field that stores state. Any value assigned to an `observable` field will be made recursively observable as well, if possible. That is, if and only if the value is a plain object, array, Map or Set. |
-| `observable.ref`                   | Like `observable`, but only reassignments will be tracked. The assigned values themselves won't be made observable automatically. Use this if you intend to store for example immutable data in an observable field.       |
-| `observable.shallow`               | Like `observable.ref` but for collections; any collection assigned will be made observable, but the contents of the collection itself won't become observable.                                                             |
+| `observable.ref`                   | Like `observable`, but only reassignments will be tracked. The assigned values themselves won't be made observable automatically. For example, use this if you intend to store immutable data in an observable field.       |
+| `observable.shallow`               | Like `observable.ref` but for collections. Any collection assigned will be made observable, but the contents of the collection itself won't become observable.                                                             |
 | `observable.struct`                | Like `observable`, except that any assigned value that is structurally equal to the current value will be ignored.                                                                                                         |
-| `action`                           | Mark a method as action that will modify state. See [action](../refguide/action.md) for details.                                                                                                                           |
+| `action`                           | Mark a method as an action that will modify the state. Check out [action](../refguide/action.md) for more details.                                                                                                                           |
 | `action.bound`                     | Like action, but will also bind the action to the instance so that `this` will always be set.                                                                                                                              |
-| `computed`                         | Can be used on a [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) to declare it as a derived value that can be cached. See [computed](../refguide/computed.md) for details.       |
-| `computed.struct`                  | Like `computed`, except that if after recomputing the result is structurally equal to the previous result, no observers will be notified                                                                                   |
-| `true`                             | Infer the best annotation. See [makeAutoObservable](#makeautoobservable).                                                                                                                                                  |
+| `computed`                         | Can be used on a [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) to declare it as a derived value that can be cached. Check out [computed](../refguide/computed.md) for more details.       |
+| `computed.struct`                  | Like `computed`, except that if after recomputing the result is structurally equal to the previous result, no observers will be notified.                                                                                   |
+| `true`                             | Infer the best annotation. Check out [makeAutoObservable](#makeautoobservable) for more details.                                                                                                                                                  |
 | `false`                            | Explicitly do not annotate this property.                                                                                                                                                                                  |
-| `flow`                             | Creates a `flow` to manage asynchronous processes. For more details see [flow](action.html#-using-flow-instead-of-asyncawait). Note that the inferred return type in typescript might be off.                              |
-| `autoAction`                       | Should not be used explicitly, but is used under the hood by `makeAutoObservable` to mark methods that can act as action or derivation, based on their calling context                                                     |
+| `flow`                             | Creates a `flow` to manage asynchronous processes. Check out[flow](action.html#-using-flow-instead-of-asyncawait) for more details. Note that the inferred return type in TypeScript might be off.                              |
+| `autoAction`                       | Should not be used explicitly, but is used under the hood by `makeAutoObservable` to mark methods that can act as action or derivation, based on their calling context.                                                     |
 
 ## 🚀 The `options` argument
 
 The above APIs take an optional `options` argument which is an object that supports the following options:
 
--   `autoBind: true`. Automatically binds all created actions to the instance.
--   `deep: false`. Use `observable.ref` by default, rather than `observable` to create new observable members
--   `name: <string>`. Gives the object a debug name that is printed in error messages and reflection APIs.
+-   `autoBind: true` automatically binds all created actions to the instance.
+-   `deep: false` uses `observable.ref` by default, rather than `observable` to create new observable members.
+-   `name: <string>` gives the object a debug name that is printed in error messages and reflection APIs.
 
 ## Converting observables back to vanilla JavaScript collections
 
 Sometimes it is necessary to convert observable data structures back to their vanilla counterpart.
-For example when passing observable objects to a React component that can't track observables, or to obtain a clone that should not further be mutated.
+For example when passing observable objects to a React component that can't track observables, or to obtain a clone that should not be further mutated.
 
-To convert a collection shallowly the usual JavaScript mechanisms work:
+To convert a collection shallowly, the usual JavaScript mechanisms work:
 
 ```javascript
 const plainObject = { ...observableObject }
@@ -250,13 +251,12 @@ const plainMap = new Map(observableMap)
 ```
 
 To convert a data tree recursively to plain objects, the [`toJS`](api.md#tojs) utility can be used.
-For classes, it is recommend to implement a `toJSON()` method, as that one will be picked up by `JSON.stringify`.
+For classes, it is recommend to implement a `toJSON()` method, as it will be picked up by `JSON.stringify`.
 
 ## A short note on classes
 
 So far most examples above have been leaning towards class syntax.
 MobX is in principle unopinionated about this, and there are probably just as many MobX users that use plain objects.
-However, a slight benefit of classes is that they have more easily discoverable APIs icmw. TypeScript.
-Also, `instanceof` checks are really powerful for type inference, and class instances aren't wrapped in `Proxy` objects giving them a better experience in debuggers.
-But heavy inheritance patterns can become foot-guns easily.
-So if you use classes, keep them simple.
+However, a slight benefit of classes is that they have more easily discoverable APIs, e.g. TypeScript.
+Also, `instanceof` checks are really powerful for type inference, and class instances aren't wrapped in `Proxy` objects, giving them a better experience in debuggers.
+But heavy inheritance patterns can easily become foot-guns, so if you use classes, keep them simple.

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -11,7 +11,7 @@ _⚠️ **Warning**: intercept and observe are low level utilities, and should n
 
 `observe` and `intercept` can be used to monitor the changes of a single observable. They **_don't_** track nested observables.
 
--    `intercept` can be used to detect and modify mutations before they are applied to the observable (validation, normalization or cancellation).
+-    `intercept` can be used to detect and modify mutations before they are applied to the observable (validating, normalizing or cancelling).
 -    `observe` allows you to intercept changes after they have been made.
 
 ## Intercept

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -7,21 +7,19 @@ hide_title: true
 
 # Intercept & Observe 🚀
 
-_Warning: intercept and observe are low level utilities, and should not be needed in practice. Use some form of [reaction](autorun.md) instead. For example `observe` doesn't respect transactions, and doesn't support deep observing changes. Using those utilities is an anti-pattern. If you intend to use `observe` to get access to the old- and new value, use [`reaction`](api.md#reaction) instead._
+_⚠️ Warning: intercept and observe are low level utilities, and should not be needed in practice. Use some form of [reaction](autorun.md) instead. `observe` doesn't respect transactions and doesn't support deep observing of changes. Using these utilities is an anti-pattern. If you intend to use `observe` to get access to the old and new value, use [`reaction`](api.md#reaction) instead. ⚠️_
 
-`observe` and `intercept` can be used to monitor the changes of a single observable (they **_don't_** track nested observables).
+`observe` and `intercept` can be used to monitor the changes of a single observable. They **_don't_** track nested observables.
 
-`intercept` can be used to detect and modify mutations before they are applied to the observable. This is useful for useful for validation, normalization or cancellation.
-
-`observe` allows you to intercept changes after they have been made.
+`intercept` can be used to detect and modify mutations before they are applied to the observable (useful for validation, normalization or cancellation), and `observe` allows you to intercept changes after they have been made.
 
 ## Intercept
 
 Usage: `intercept(target, propertyName?, interceptor)`
 
-_Please avoid this API, it basically provides a bit of aspect-oriented programming, creating flows that are really hard to debug. Rather, do things like data-validation *before* updating any state, rather than during._
+_Please avoid this API. It basically provides a bit of aspect-oriented programming, creating flows that are really hard to debug. Instead, do things like data validation **before** updating any state, rather than during._
 
--   `target`: the observable to guard
+-   `target`: the observable to guard.
 -   `propertyName`: optional parameter to specify a specific property to intercept. Note that `intercept(user.name, interceptor)` is fundamentally different from `intercept(user, "name", interceptor)`. The first tries to add an interceptor to the _current_ `value` inside `user.name` (which might not be an observable at all), the latter intercepts changes to the `name` _property_ of `user`.
 -   `interceptor`: callback that is invoked for _each_ change that is made to the observable. Receives a single change object describing the mutation.
 
@@ -30,13 +28,13 @@ Therefore it should do one of the following things:
 
 1. Return the received `change` object as-is from the function, in which case the mutation will be applied.
 2. Modify the `change` object and return it, for example to normalize the data. Not all fields are modifiable, see below.
-3. Return `null`, this indicates that the change can be ignored and shouldn't be applied. This is a powerful concept to make your objects for example temporarily immutable.
-4. Throw an exception, for example if some invariant isn't met.
+3. Return `null`, this indicates that the change can be ignored and shouldn't be applied. This is a powerful concept with which you can for example make your objects temporarily immutable.
+4. Throw an exception, if for example some invariant isn't met.
 
 The function returns a `disposer` function that can be used to cancel the interceptor when invoked.
 It is possible to register multiple interceptors to the same observable.
 They will be chained in registration order.
-If one of the interceptors returns `null` or throw an exception, the other interceptors won't be evaluated anymore.
+If one of the interceptors returns `null` or throws an exception, the other interceptors won't be evaluated anymore.
 It is also possible to register an interceptor both on a parent object and on an individual property.
 In that case the parent object interceptors are run before the property interceptors.
 
@@ -47,20 +45,23 @@ const theme = observable({
 
 const disposer = intercept(theme, "backgroundColor", change => {
     if (!change.newValue) {
-        // ignore attempts to unset the background color
+        // Ignore attempts to unset the background color.
         return null
     }
     if (change.newValue.length === 6) {
-        // correct missing '#' prefix
+        // Correct missing '#' prefix.
         change.newValue = "#" + change.newValue
         return change
     }
     if (change.newValue.length === 7) {
-        // this must be a properly formatted color code!
+        // This must be a properly formatted color code!
         return change
     }
-    if (change.newValue.length > 10) disposer() // stop intercepting future changes
-    throw new Error("This doesn't like a color at all: " + change.newValue)
+    if (change.newValue.length > 10) {
+        // Stop intercepting future changes.
+        disposer()
+    }
+    throw new Error("This doesn't look like a color at all: " + change.newValue)
 })
 ```
 
@@ -68,19 +69,19 @@ const disposer = intercept(theme, "backgroundColor", change => {
 
 Usage: `observe(target, propertyName?, listener, invokeImmediately?)`
 
-_See above notice, please avoid this API, and use `reaction` instead_
+_See above notice, please avoid this API and use `reaction` instead._
 
--   `target`: the observable to observe
+-   `target`: the observable to observe.
 -   `propertyName`: optional parameter to specify a specific property to observe. Note that `observe(user.name, listener)` is fundamentally different from `observe(user, "name", listener)`. The first observes the _current_ `value` inside `user.name` (which might not be an observable at all), the latter observes the `name` _property_ of `user`.
--   `listener`: callback that will be invoked for _each_ change that is made to the observable. Receives a single change object describing the mutation, except for boxed observables, which will invoke the `listener` two parameters: `newValue, oldValue`.
--   `invokeImmediately`: by default false. Set it to true if you want `observe` to invoke `listener` directly with the state of the observable (instead of waiting for the first change). Not supported (yet) by all kinds of observables.
+-   `listener`: callback that will be invoked for _each_ change that is made to the observable. Receives a single change object describing the mutation, except for boxed observables, which will invoke the `listener` with two parameters: `newValue, oldValue`.
+-   `invokeImmediately`: false by default. Set it to true if you want `observe` to invoke the `listener` directly with the state of the observable, instead of waiting for the first change. Not supported (yet) by all kinds of observables.
 
 The function returns a `disposer` function that can be used to cancel the observer.
 Note that `transaction` does not affect the working of the `observe` method(s).
 This means that even inside a transaction `observe` will fire its listeners for each mutation.
-Hence `autorun` is usually a more powerful and declarative alternative to `observe`.
+Hence [`autorun`](autorun.md) is usually a more powerful and declarative alternative to `observe`.
 
-_`observe` reacts to *mutations*, when they are being made, while reactions like `autorun` or `reaction` react to *new values* when they become available. In many cases the latter is sufficient_
+_`observe` reacts to *mutations*, when they are being made, while reactions like `autorun` or `reaction` react to *new values* when they become available. In many cases the latter is sufficient._
 
 Example:
 
@@ -96,13 +97,13 @@ const disposer = observe(person, change => {
     console.log(change.type, change.name, "from", change.oldValue, "to", change.object[change.name])
 })
 
+// Prints "update firstName from Maarten to Martin".
 person.firstName = "Martin"
-// Prints: 'update firstName from Maarten to Martin'
 
+// Ignore any future updates.
 disposer()
-// Ignore any future updates
 
-// observe a single field
+// Observe a single field.
 const disposer2 = observe(person, "lastName", change => {
     console.log("LastName changed to ", change.newValue)
 })
@@ -114,37 +115,37 @@ Related blog: [Object.observe is dead. Long live mobx.observe](https://medium.co
 
 The callbacks of `intercept` and `observe` will receive an event object which has at least the following properties:
 
--   `object`: the observable triggering the event
--   `debugObjectName`: the name of the observable triggering the event (for debugging)
--   `observableKind`: the type of the observable (object,array,map,set,value,computed)
--   `type`: (string) the type of the current event
+-   `object`: the observable triggering the event.
+-   `debugObjectName`: the name of the observable triggering the event (for debugging).
+-   `observableKind`: the type of the observable (value, set, array, object, map, computed).
+-   `type` (string): the type of the current event.
 
 These are the additional fields that are available per type:
 
-| observable type              | event type | property     | description                                                                                      | available during intercept | can be modified by intercept |
-| ---------------------------- | ---------- | ------------ | ------------------------------------------------------------------------------------------------ | -------------------------- | ---------------------------- |
-| Object                       | add        | name         | name of the property being added                                                                 | √                          |                              |
-|                              |            | newValue     | the new value being assigned                                                                     | √                          | √                            |
-|                              | update\*   | name         | name of the property being updated                                                               | √                          |                              |
-|                              |            | newValue     | the new value being assigned                                                                     | √                          | √                            |
-|                              |            | oldValue     | the value that is replaced                                                                       |                            |                              |
-| Array                        | splice     | index        | starting index of the splice. Splices are also fired by `push`, `unshift`, `replace` etc.        | √                          |                              |
-|                              |            | removedCount | amount of items being removed                                                                    | √                          | √                            |
-|                              |            | added        | array with items being added                                                                     | √                          | √                            |
-|                              |            | removed      | array with items that were removed                                                               |                            |                              |
-|                              |            | addedCount   | amount of items that were added                                                                  |                            |                              |
-|                              | update     | index        | index of the single entry that is being updated                                                  | √                          |                              |
-|                              |            | newValue     | the newValue that is / will be assigned                                                          | √                          | √                            |
-|                              |            | oldValue     | the old value that was replaced                                                                  |                            |                              |
-| Map                          | add        | name         | the name of the entry that was added                                                             | √                          |                              |
-|                              |            | newValue     | the new value that is being assigned                                                             | √                          | √                            |
-|                              | update     | name         | the name of the entry that is being updated                                                      | √                          |                              |
-|                              |            | newValue     | the new value that is being assigned                                                             | √                          | √                            |
-|                              |            | oldValue     | the value that has been replaced                                                                 |                            |                              |
-|                              | delete     | name         | the name of the entry that is being removed                                                      | √                          |                              |
-|                              |            | oldValue     | the value of the entry that was removed                                                          |                            |                              |
-| Boxed & computed observables | create     | newValue     | the value that was assigned during creation. Only available as `spy` event for boxed observables |                            |                              |
-|                              | update     | newValue     | the new value being assigned                                                                     | √                          | √                            |
-|                              |            | oldValue     | the previous value of the observable                                                             |                            |                              |
+| Observable type              | Event type | Property     | Description                                                                                       | Available during intercept | Can be modified by intercept |
+| ---------------------------- | ---------- | ------------ | ------------------------------------------------------------------------------------------------- | -------------------------- | ---------------------------- |
+| Object                       | add        | name         | Name of the property being added.                                                                 | √                          |                              |
+|                              |            | newValue     | The new value being assigned.                                                                     | √                          | √                            |
+|                              | update\*   | name         | Name of the property being updated.                                                               | √                          |                              |
+|                              |            | newValue     | The new value being assigned.                                                                     | √                          | √                            |
+|                              |            | oldValue     | The value that is replaced.                                                                       |                            |                              |
+| Array                        | splice     | index        | Starting index of the splice. Splices are also fired by `push`, `unshift`, `replace` etc.         | √                          |                              |
+|                              |            | removedCount | Amount of items being removed.                                                                    | √                          | √                            |
+|                              |            | added        | Array with items being added.                                                                     | √                          | √                            |
+|                              |            | removed      | Array with items that were removed.                                                               |                            |                              |
+|                              |            | addedCount   | Amount of items that were added.                                                                  |                            |                              |
+|                              | update     | index        | Index of the single entry being updated.                                                          | √                          |                              |
+|                              |            | newValue     | The newValue that is / will be assigned.                                                          | √                          | √                            |
+|                              |            | oldValue     | The old value that was replaced.                                                                  |                            |                              |
+| Map                          | add        | name         | The name of the entry that was added.                                                             | √                          |                              |
+|                              |            | newValue     | The new value that is being assigned.                                                             | √                          | √                            |
+|                              | update     | name         | The name of the entry that is being updated.                                                      | √                          |                              |
+|                              |            | newValue     | The new value that is being assigned.                                                             | √                          | √                            |
+|                              |            | oldValue     | The value that has been replaced.                                                                 |                            |                              |
+|                              | delete     | name         | The name of the entry that is being removed.                                                      | √                          |                              |
+|                              |            | oldValue     | The value of the entry that was removed.                                                          |                            |                              |
+| Boxed & computed observables | create     | newValue     | The value that was assigned during creation. Only available as `spy` event for boxed observables. |                            |                              |
+|                              | update     | newValue     | The new value being assigned.                                                                     | √                          | √                            |
+|                              |            | oldValue     | The previous value of the observable.                                                             |                            |                              |
 
-_\* Note that object `update` events won't fire for updated computated values (as those aren't mutations). But it is possible to observe them by explicitly subscribing to the specific property using `observe(object, 'computedPropertyName', listener)`._
+**Note:** object `update` events won't fire for updated computed values (as those aren't mutations). But it is possible to observe them by explicitly subscribing to the specific property using `observe(object, 'computedPropertyName', listener)`._

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -7,11 +7,12 @@ hide_title: true
 
 # Intercept & Observe 🚀
 
-_⚠️ Warning: intercept and observe are low level utilities, and should not be needed in practice. Use some form of [reaction](autorun.md) instead. `observe` doesn't respect transactions and doesn't support deep observing of changes. Using these utilities is an anti-pattern. If you intend to use `observe` to get access to the old and new value, use [`reaction`](api.md#reaction) instead. ⚠️_
+_⚠️ **Warning**: intercept and observe are low level utilities, and should not be needed in practice. Use some form of [reaction](autorun.md) instead. `observe` doesn't respect transactions and doesn't support deep observing of changes. Using these utilities is an anti-pattern. If you intend to use `observe` to get access to the old and new value, use [`reaction`](api.md#reaction) instead. ⚠️_
 
 `observe` and `intercept` can be used to monitor the changes of a single observable. They **_don't_** track nested observables.
 
-`intercept` can be used to detect and modify mutations before they are applied to the observable (useful for validation, normalization or cancellation), and `observe` allows you to intercept changes after they have been made.
+-    `intercept` can be used to detect and modify mutations before they are applied to the observable (useful for validation, normalization or cancellation).
+-    `observe` allows you to intercept changes after they have been made.
 
 ## Intercept
 
@@ -20,7 +21,7 @@ Usage: `intercept(target, propertyName?, interceptor)`
 _Please avoid this API. It basically provides a bit of aspect-oriented programming, creating flows that are really hard to debug. Instead, do things like data validation **before** updating any state, rather than during._
 
 -   `target`: the observable to guard.
--   `propertyName`: optional parameter to specify a specific property to intercept. Note that `intercept(user.name, interceptor)` is fundamentally different from `intercept(user, "name", interceptor)`. The first tries to add an interceptor to the _current_ `value` inside `user.name` (which might not be an observable at all), the latter intercepts changes to the `name` _property_ of `user`.
+-   `propertyName`: optional parameter to specify a specific property to intercept. Note that `intercept(user.name, interceptor)` is fundamentally different from `intercept(user, "name", interceptor)`. The first tries to add an interceptor to the _current_ `value` inside `user.name`, which might not be an observable at all. The latter intercepts changes to the `name` _property_ of `user`.
 -   `interceptor`: callback that is invoked for _each_ change that is made to the observable. Receives a single change object describing the mutation.
 
 The `intercept` should tell MobX what needs to happen with the current change.
@@ -69,19 +70,19 @@ const disposer = intercept(theme, "backgroundColor", change => {
 
 Usage: `observe(target, propertyName?, listener, invokeImmediately?)`
 
-_See above notice, please avoid this API and use `reaction` instead._
+_See above notice, please avoid this API and use [`reaction`](api.md#reaction) instead._
 
 -   `target`: the observable to observe.
--   `propertyName`: optional parameter to specify a specific property to observe. Note that `observe(user.name, listener)` is fundamentally different from `observe(user, "name", listener)`. The first observes the _current_ `value` inside `user.name` (which might not be an observable at all), the latter observes the `name` _property_ of `user`.
+-   `propertyName`: optional parameter to specify a specific property to observe. Note that `observe(user.name, listener)` is fundamentally different from `observe(user, "name", listener)`. The first observes the _current_ `value` inside `user.name`, which might not be an observable at all. The latter observes the `name` _property_ of `user`.
 -   `listener`: callback that will be invoked for _each_ change that is made to the observable. Receives a single change object describing the mutation, except for boxed observables, which will invoke the `listener` with two parameters: `newValue, oldValue`.
--   `invokeImmediately`: false by default. Set it to true if you want `observe` to invoke the `listener` directly with the state of the observable, instead of waiting for the first change. Not supported (yet) by all kinds of observables.
+-   `invokeImmediately`: _false_ by default. Set it to _true_ if you want `observe` to invoke the `listener` directly with the state of the observable, instead of waiting for the first change. Not supported (yet) by all kinds of observables.
 
 The function returns a `disposer` function that can be used to cancel the observer.
 Note that `transaction` does not affect the working of the `observe` method(s).
 This means that even inside a transaction `observe` will fire its listeners for each mutation.
 Hence [`autorun`](autorun.md) is usually a more powerful and declarative alternative to `observe`.
 
-_`observe` reacts to *mutations*, when they are being made, while reactions like `autorun` or `reaction` react to *new values* when they become available. In many cases the latter is sufficient._
+_`observe` reacts to **mutations** when they are being made, while reactions like `autorun` or `reaction` react to **new values** when they become available. In many cases the latter is sufficient._
 
 Example:
 
@@ -129,7 +130,7 @@ These are the additional fields that are available per type:
 |                              | update\*   | name         | Name of the property being updated.                                                               | √                          |                              |
 |                              |            | newValue     | The new value being assigned.                                                                     | √                          | √                            |
 |                              |            | oldValue     | The value that is replaced.                                                                       |                            |                              |
-| Array                        | splice     | index        | Starting index of the splice. Splices are also fired by `push`, `unshift`, `replace` etc.         | √                          |                              |
+| Array                        | splice     | index        | Starting index of the splice. Splices are also fired by `push`, `unshift`, `replace`, etc.        | √                          |                              |
 |                              |            | removedCount | Amount of items being removed.                                                                    | √                          | √                            |
 |                              |            | added        | Array with items being added.                                                                     | √                          | √                            |
 |                              |            | removed      | Array with items that were removed.                                                               |                            |                              |
@@ -139,13 +140,13 @@ These are the additional fields that are available per type:
 |                              |            | oldValue     | The old value that was replaced.                                                                  |                            |                              |
 | Map                          | add        | name         | The name of the entry that was added.                                                             | √                          |                              |
 |                              |            | newValue     | The new value that is being assigned.                                                             | √                          | √                            |
-|                              | update     | name         | The name of the entry that is being updated.                                                      | √                          |                              |
+|                              | update     | name         | The name of the entry being updated.                                                              | √                          |                              |
 |                              |            | newValue     | The new value that is being assigned.                                                             | √                          | √                            |
 |                              |            | oldValue     | The value that has been replaced.                                                                 |                            |                              |
-|                              | delete     | name         | The name of the entry that is being removed.                                                      | √                          |                              |
+|                              | delete     | name         | The name of the entry being removed.                                                              | √                          |                              |
 |                              |            | oldValue     | The value of the entry that was removed.                                                          |                            |                              |
 | Boxed & computed observables | create     | newValue     | The value that was assigned during creation. Only available as `spy` event for boxed observables. |                            |                              |
 |                              | update     | newValue     | The new value being assigned.                                                                     | √                          | √                            |
 |                              |            | oldValue     | The previous value of the observable.                                                             |                            |                              |
 
-**Note:** object `update` events won't fire for updated computed values (as those aren't mutations). But it is possible to observe them by explicitly subscribing to the specific property using `observe(object, 'computedPropertyName', listener)`._
+**Note:** object `update` events won't fire for updated computed values (as those aren't mutations). But it is possible to observe them by explicitly subscribing to the specific property using `observe(object, 'computedPropertyName', listener)`.

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -100,7 +100,7 @@ const disposer = observe(person, change => {
 })
 
 person.firstName = "Martin"
-// Prints: 'update firstName from Maarten to Martin'.
+// Prints: 'update firstName from Maarten to Martin'
 
 // Ignore any future updates.
 disposer()

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -102,8 +102,8 @@ const disposer = observe(person, change => {
 person.firstName = "Martin"
 // Prints: 'update firstName from Maarten to Martin'.
 
-disposer()
 // Ignore any future updates.
+disposer()
 
 // Observe a single field.
 const disposer2 = observe(person, "lastName", change => {

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -5,13 +5,13 @@ hide_title: true
 
 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CEBD4KQ7&placement=mobxjsorg" id="_carbonads_js"></script>
 
-# Intercept & Observe 🚀
+# Intercept & Observe [🚀]
 
-_⚠️ **Warning**: intercept and observe are low level utilities, and should not be needed in practice. Use some form of [reaction](autorun.md) instead. `observe` doesn't respect transactions and doesn't support deep observing of changes. Using these utilities is an anti-pattern. If you intend to use `observe` to get access to the old and new value, use [`reaction`](api.md#reaction) instead. ⚠️_
+_⚠️ **Warning**: intercept and observe are low level utilities, and should not be needed in practice. Use some form of [reaction](autorun.md) instead. `observe` doesn't respect transactions and doesn't support deep observing of changes. Using these utilities is an anti-pattern. If you intend to get access to the old and new value using `observe`, use [`reaction`](api.md#reaction) instead. ⚠️_
 
 `observe` and `intercept` can be used to monitor the changes of a single observable. They **_don't_** track nested observables.
 
--    `intercept` can be used to detect and modify mutations before they are applied to the observable (useful for validation, normalization or cancellation).
+-    `intercept` can be used to detect and modify mutations before they are applied to the observable (validation, normalization or cancellation).
 -    `observe` allows you to intercept changes after they have been made.
 
 ## Intercept

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -94,11 +94,12 @@ const person = observable({
     lastName: "Luther"
 })
 
+// Observe all fields.
 const disposer = observe(person, change => {
     console.log(change.type, change.name, "from", change.oldValue, "to", change.object[change.name])
 })
 
-// Prints "update firstName from Maarten to Martin".
+// Prints: 'update firstName from Maarten to Martin'.
 person.firstName = "Martin"
 
 // Ignore any future updates.

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -99,11 +99,11 @@ const disposer = observe(person, change => {
     console.log(change.type, change.name, "from", change.oldValue, "to", change.object[change.name])
 })
 
-// Prints: 'update firstName from Maarten to Martin'.
 person.firstName = "Martin"
+// Prints: 'update firstName from Maarten to Martin'.
 
-// Ignore any future updates.
 disposer()
+// Ignore any future updates.
 
 // Observe a single field.
 const disposer2 = observe(person, "lastName", change => {

--- a/docs/refguide/observe.md
+++ b/docs/refguide/observe.md
@@ -7,7 +7,7 @@ hide_title: true
 
 # Intercept & Observe [🚀]
 
-_⚠️ **Warning**: intercept and observe are low level utilities, and should not be needed in practice. Use some form of [reaction](autorun.md) instead. `observe` doesn't respect transactions and doesn't support deep observing of changes. Using these utilities is an anti-pattern. If you intend to get access to the old and new value using `observe`, use [`reaction`](api.md#reaction) instead. ⚠️_
+_⚠️ **Warning**: intercept and observe are low level utilities, and should not be needed in practice. Use some form of [reaction](autorun.md) instead, as `observe` doesn't respect transactions and doesn't support deep observing of changes. Using these utilities is an anti-pattern. If you intend to get access to the old and new value using `observe`, use [`reaction`](api.md#reaction) instead. ⚠️_
 
 `observe` and `intercept` can be used to monitor the changes of a single observable. They **_don't_** track nested observables.
 

--- a/docs/refguide/on-become-observed.md
+++ b/docs/refguide/on-become-observed.md
@@ -13,9 +13,9 @@ Usage:
 -   `onBecomeObserved(observable, property?, listener: () => void): (() => void)`
 -   `onBecomeUnobserved(observable, property?, listener: () => void): (() => void)`
 
-Functions `onBecomeObserved` and `onBecomeUnobserved` can be used to attach lazy behavior or side-effects to existing observables. They are hooks into the observability system of MobX and get notified when the observables _start_ and _stop_ being observed.
+Functions `onBecomeObserved` and `onBecomeUnobserved` can be used to attach lazy behavior or side-effects to existing observables. They are hooks into the observability system of MobX and get notified when the observables _start_ and _stop_ being observed. The return value is a _disposing_ function that will detach the _listener_.
 
-You can use them to, for example, execute lazy operations or perform network fetches only when the observed value is actually in use. The return value is a _diposer-function_ that will detach the _listener_.
+In the example below we use them to perform network fetches only when the observed value is actually in use.
 
 ```javascript
 export class City {

--- a/docs/refguide/on-become-observed.md
+++ b/docs/refguide/on-become-observed.md
@@ -13,7 +13,7 @@ Usage:
 -   `onBecomeObserved(observable, property?, listener: () => void): (() => void)`
 -   `onBecomeUnobserved(observable, property?, listener: () => void): (() => void)`
 
-Functions `onBecomeObserved` and `onBecomeUnobserved` can be used to attach lazy behavior or side-effects to existing observables. They are hooks into the observability system of MobX and get notified when the observables _start_ and _stop_ being observed. The return value is a _disposing_ function that will detach the _listener_.
+Functions `onBecomeObserved` and `onBecomeUnobserved` can be used to attach lazy behavior or side-effects to existing observables. They are hooks into the observability system of MobX and get notified when the observables _start_ and _stop_ being observed. They both return a _disposer_ function that detaches the _listener_.
 
 In the example below we use them to perform network fetches only when the observed value is actually in use.
 

--- a/docs/refguide/on-become-observed.md
+++ b/docs/refguide/on-become-observed.md
@@ -13,7 +13,7 @@ Usage:
 -   `onBecomeObserved(observable, property?, listener: () => void): (() => void)`
 -   `onBecomeUnobserved(observable, property?, listener: () => void): (() => void)`
 
-Functions `onBecomeObserved` and `onBecomeUnobserved` can be used to attach lazy behavior or side-effects to existing observables. They are hooks into the observability system of MobX and get notified when the observables _start_ and _stop_ being observed. They both return a _disposer_ function that detaches the _listener_.
+Functions `onBecomeObserved` and `onBecomeUnobserved` can be used to attach lazy behavior or side-effects to existing observables. They are hooks into the observability system of MobX and get notified when the observables _start_ and _stop_ becoming observed. They both return a _disposer_ function that detaches the _listener_.
 
 In the example below we use them to perform network fetches only when the observed value is actually in use.
 


### PR DESCRIPTION
Evening!

I've updated the docs below:

- [x] docs/refguide/set.md
- [x] docs/refguide/on-become-observed.md
- [x] docs/refguide/observe.md
- [x] docs/refguide/object-api.md
- [x] docs/refguide/object.md
- [x] docs/refguide/modifiers.md
- [x] docs/refguide/extending.md
- [x] docs/refguide/observable.md
- [x] docs/refguide/configure.md

And some more, but those were mainly code comments that I skipped previously, and updates to already passed docs so they match the same overall style:

- warnings with icons and bold text (⚠️ **Warning**: ⚠️)
- check out instead of also see / see / see also
- uniform [🚀] instead of 🚀 in the contents, haven't touched the menus
  - beginning of list (e.g. Tip:) and ending of heading
- etc.

**Q**: Can `docs/refguide/toJS.md` be removed in favor of `docs/refguide/api.md#tojs` since the former is never used in the docs, but the latter is once?

_Sorry about my estimation of completion time being off by a metric ton. I'll continue creating PRs until I reach the end (5 files remaining)._

<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2460"><img src="https://gitpod.io/api/apps/github/pbs/github.com/zangornjak/mobx.git/7212900144df83e1564fd63761a6a01f004bfb06.svg" /></a>

