### PR TITLE
Docs: fix broken openTarget and add prev/next button to tooltip

### DIFF
--- a/website/static/js/scripts.js
+++ b/website/static/js/scripts.js
@@ -10,7 +10,7 @@ function openTarget() {
     }
 }
 function addTooltipToRockets() {
-    var classNames = ['navGroups', 'onPageNav', 'post'];
+    var classNames = ['navGroups', 'onPageNav', 'post', 'docs-prevnext'];
     var rocketRegex = /🚀/g;
 
     for (var className of classNames) {
@@ -22,6 +22,6 @@ function addTooltipToRockets() {
 }
 window.addEventListener('hashchange', openTarget);
 window.addEventListener('DOMContentLoaded', function() {
-    openTarget();
     addTooltipToRockets();
+    openTarget();
 });


### PR DESCRIPTION
Fix bug introduced in https://github.com/mobxjs/mobx/pull/2502 and add one overlooked rocket emoji location

- `openTarget` should be executed after `addTooltipToRockets` to not break `openTargets`'s async scroll on refresh. Currently, the `details` element in `openTarget` is replaced by `addTooltipToRocket`'s innerHTML reassignment.
- add bottom prev/next doc page buttons to `addTooltipToRockets`

<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2503"><img src="https://gitpod.io/api/apps/github/pbs/github.com/jheeffer/mobx.git/7edcf6fa2269f6db0218e3cfe2e30f2e4ed3b7b8.svg" /></a>

