### PR TITLE
Update react-optimizations.md

### DIFF
--- a/docs/react-optimizations.md
+++ b/docs/react-optimizations.md
@@ -109,13 +109,13 @@ const GenericNameDisplayer = observer(({ getName }) => <DisplayName name={getNam
 Then, you can use the component like this:
 
 ```javascript
-const MyComponent = observer(({ person, car }) => (
+const MyComponent = ({ person, car }) => (
     <>
         <GenericNameDisplayer getName={() => person.name} />
         <GenericNameDisplayer getName={() => car.model} />
         <GenericNameDisplayer getName={() => car.manufacturer.name} />
     </>
-))
+)
 ```
 
 This approach will allow `GenericNameDisplayer` to be reused throughout your application to render any name, and you still keep component re-rendering


### PR DESCRIPTION
`MyComponent` does not need to be an observer, just the `GenericNameDisplayer` needs to be an observer. Just clarifying this because it might be confusing to some.

To really keep re-renders to minimum, `MyComponent` could be a React.memo; let me know if I should add it.

<a href="https://gitpod.io/#https://github.com/mobxjs/mobx/pull/2535"><img src="https://gitpod.io/api/apps/github/pbs/github.com/vonovak/mobx.git/d6df3873010f8e6b1df869847cfb156e5333adc2.svg" /></a>

