### PR TITLE
Fix example updateTodoFromServer

### DIFF
--- a/docs/defining-data-stores.md
+++ b/docs/defining-data-stores.md
@@ -107,7 +107,7 @@ export class TodoStore {
     // exists once. Might either construct a new Todo, update an existing one,
     // or remove a Todo if it has been deleted on the server.
     updateTodoFromServer(json) {
-        const todo = this.todos.find(todo => todo.id === json.id)
+        let todo = this.todos.find(todo => todo.id === json.id)
         if (!todo) {
             todo = new Todo(this, json.id)
             this.todos.push(todo)


### PR DESCRIPTION
Hi there,

The new documentation is great! Here's a tiny improvement: `todo` cannot be const because it's reassigned two lines below if it doesn't exist.

This PR changes only documentation.

PS: When creating this PR, I see the old "MobX6 is WIP" PR template. You may want to update that template now.
