### PR TITLE
docs: load all items in a single transaction

### DIFF
--- a/docs/defining-data-stores.md
+++ b/docs/defining-data-stores.md
@@ -96,8 +96,8 @@ export class TodoStore {
     loadTodos() {
         this.isLoading = true
         this.transportLayer.fetchTodos().then(fetchedTodos => {
-            fetchedTodos.forEach(json => this.updateTodoFromServer(json))
             runInAction(() => {
+                fetchedTodos.forEach(json => this.updateTodoFromServer(json))
                 this.isLoading = false
             })
         })


### PR DESCRIPTION
Change example code to run all calls to updateTodoFromServer (one per item in the result set) in a single transaction.