### PR TITLE
Fix #2542 makeAutoObservable not respecting deep option

### DIFF
--- a/.changeset/pink-apricots-sparkle.md
+++ b/.changeset/pink-apricots-sparkle.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fixed [2542](https://github.com/mobxjs/mobx/issues/2542), makeAutoObservable not respecting deep option [@urugator](https://github.com/urugator)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # mobx
 
-## Unreleased
-
--   Fixed [2542](https://github.com/mobxjs/mobx/issues/2542), makeAutoObservable not respecting deep option [@urugator](https://github.com/urugator)
-
 ## 6.0.1
 
 -   Fixed issue in TS typings of `makeObservable` in combination with a member named `toString()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mobx
 
+## Unreleased
+
+-   Fixed [2542](https://github.com/mobxjs/mobx/issues/2542), makeAutoObservable not respecting deep option [@urugator](https://github.com/urugator)
+
 ## 6.0.1
 
 -   Fixed issue in TS typings of `makeObservable` in combination with a member named `toString()`

--- a/src/api/makeObservable.ts
+++ b/src/api/makeObservable.ts
@@ -255,9 +255,12 @@ function extractAnnotationsFromObject(
     options: CreateObservableOptions | undefined
 ) {
     const autoBind = !!options?.autoBind
-    const defaultAnnotation: Annotation = options?.deep
-        ? observable.deep
-        : options?.defaultDecorator ?? observable.deep
+    const defaultAnnotation: Annotation =
+        options?.deep === undefined
+            ? options?.defaultDecorator ?? observable.deep
+            : options?.deep
+            ? observable.deep
+            : observable.ref
     Object.entries(getOwnPropertyDescriptors(target)).forEach(([key, descriptor]) => {
         if (key in collector || key === "constructor") return
         collector[key] = getInferredAnnotation(descriptor, defaultAnnotation, autoBind)

--- a/test/v5/base/make-observable.ts
+++ b/test/v5/base/make-observable.ts
@@ -3,6 +3,7 @@ import {
     action,
     computed,
     observable,
+    isObservable,
     isObservableObject,
     isObservableProp,
     isComputedProp,
@@ -520,4 +521,16 @@ test("#2457", () => {
     expect(isObservableObject(t)).toBe(true)
     expect(isObservableProp(t, "value1")).toBe(true)
     expect(isComputedProp(t, "value1Computed")).toBe(true)
+})
+
+test("makeAutoObservable respects options.deep #2542'", () => {
+    const o = makeAutoObservable({ nested: {} }, {}, { deep: false })
+    expect(isObservable(o)).toBe(true)
+    expect(isObservableProp(o, "nested")).toBe(true)
+    expect(isObservable(o.nested)).toBe(false)
+
+    const deepO = makeAutoObservable({ nested: {} }, {}, { deep: true })
+    expect(isObservable(deepO)).toBe(true)
+    expect(isObservableProp(deepO, "nested")).toBe(true)
+    expect(isObservable(deepO.nested)).toBe(true)
 })


### PR DESCRIPTION
Fixes #2542
`options.deep` takes a precedence over `options.defaultDecorator`