### PR TITLE
docs: fix typo at TodoList constructor

### DIFF
--- a/docs/the-gist-of-mobx.md
+++ b/docs/the-gist-of-mobx.md
@@ -99,11 +99,12 @@ class TodoList {
     get unfinishedTodoCount() {
         return this.todos.filter(todo => !todo.finished).length
     }
-    constructor() {
+    constructor(todos) {
         makeObservable(this, {
             todos: observable,
             unfinishedTodoCount: computed
         })
+        this.todos = todos;
     }
 }
 ```


### PR DESCRIPTION
Hello

While reading [The gist of MobX](https://mobx.js.org/the-gist-of-mobx.html#31-model-derived-values-using-computed), I found a small typo in the `TodoList` constructor. It does not have `this.todos` initialization. 
Meanwhile, [codesandbox](https://codesandbox.io/s/concepts-principles-il8lt?file=/src/index.js:718-737), which is provided at [the end of the documentation](https://mobx.js.org/the-gist-of-mobx.html#try-it-out), has initialization of `this.todos`