### PR TITLE
add throwIfNoDecoratorFound option

### DIFF
--- a/.changeset/short-dodos-act.md
+++ b/.changeset/short-dodos-act.md
@@ -1,0 +1,5 @@
+---
+"mobx": minor
+---
+
+Added throwIfNoDecorator option to makeObservable(this)

--- a/src/api/makeObservable.ts
+++ b/src/api/makeObservable.ts
@@ -190,7 +190,7 @@ type NoInfer<T> = [T][T extends any ? 0 : never]
 export function makeObservable<T, AdditionalKeys extends PropertyKey = never>(
     target: T,
     annotations?: AnnotationsMap<T, NoInfer<AdditionalKeys>>,
-    options?: CreateObservableOptions
+    options?: CreateObservableOptions & { throwIfNoDecoratorFound?: boolean }
 ): T {
     const autoBind = !!options?.autoBind
     const adm = asObservableObject(
@@ -202,10 +202,17 @@ export function makeObservable<T, AdditionalKeys extends PropertyKey = never>(
     try {
         if (!annotations) {
             const didDecorate = applyDecorators(target)
-            if (__DEV__ && !didDecorate)
-                die(
-                    `No annotations were passed to makeObservable, but no decorator members have been found either`
-                )
+            if (__DEV__ && !didDecorate) {
+                const { throwIfNoDecoratorFound } = {
+                    throwIfNoDecoratorFound: true,
+                    ...options
+                }
+                if (throwIfNoDecoratorFound) {
+                    die(
+                        `No annotations were passed to makeObservable, but no decorator members have been found either`
+                    )
+                }
+            }
             return target
         }
         const make = key => {


### PR DESCRIPTION
While adding compatibility for mobx6 to mobx-keystone I found out a case where I need to call makeObservable(this), but with no idea if `this` actually contains mobx decorators or not (since it is third party code).

That made me write this kind of hacky code:
```
      try {
        ;(mobx as any).makeObservable(instance)
      } catch (err) {
        // TODO: perhaps add an option to makeObservable so it will skip this errors
        if (
          err.message !==
          "[MobX] No annotations were passed to makeObservable, but no decorator members have been found either"
        ) {
          throw err
        }
      }
```

This PR adds an option named "throwIfNoDecoratorFound" that when false will not throw in such case.