### PR TITLE
support running in web-worker

### DIFF
--- a/.changeset/tame-pens-bathe.md
+++ b/.changeset/tame-pens-bathe.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Support running in a web-worker

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -1,4 +1,4 @@
 export function getGlobal(): any {
     // @ts-ignore
-    return typeof global !== "undefined" ? global : window
+    return typeof self !== "undefined" ? self : global
 }

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -1,4 +1,17 @@
-export function getGlobal(): any {
-    // @ts-ignore
-    return typeof self !== "undefined" ? self : global
+declare const window: any
+declare const self: any
+
+const mockGlobal = {}
+
+export function getGlobal() {
+    if (typeof window !== "undefined") {
+        return window
+    }
+    if (typeof global !== "undefined") {
+        return global
+    }
+    if (typeof self !== "undefined") {
+        return self
+    }
+    return mockGlobal
 }


### PR DESCRIPTION
In a web-worker environment, there is no `global` or `window`, and therefore currently mobx explodes when running in a web-worker.
This PR replaces `window` with self, as in a browser environment `self === window`.
Please let me know if something additional is needed.

Thanks!