### PR TITLE
Updating changelog url for migrating from 4 to 5

### DIFF
--- a/docs/migrating-from-4-or-5.md
+++ b/docs/migrating-from-4-or-5.md
@@ -10,7 +10,7 @@ hide_title: true
 
 MobX 6 is quite different from MobX 5. This pages covers a migration guide from MobX 4 and 5 to 6, and an extensive list of all the changes.
 
-For a better understanding, check out the MobX 6.0 [CHANGELOG](https://github.com/mobxjs/mobx/blob/mobx6/CHANGELOG.md#600).
+For a better understanding, check out the MobX 6.0 [CHANGELOG](https://github.com/mobxjs/mobx/blob/main/packages/mobx/CHANGELOG.md#600).
 
 _⚠️ **Warning**: Depending on factors like the size and complexity of your code base, your MobX usage patterns, and the quality of your automated tests, this migration guide might take you anywhere between an hour and a couple of days. Please refrain from upgrading if you don't trust your Continuous Integration or QA / test procedures enough to pick up any unexpected breakages. Unexpected behavioral changes might be caused by changes in MobX itself or the changes needed to your Babel / TypeScript build configuration. ⚠️_
 


### PR DESCRIPTION
- Updating changelog url for migrating from 4 to 5

👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.
