### PR TITLE
fix: mobx should be one of the dependencies.

### DIFF
--- a/packages/mobx-react/package-lock.json
+++ b/packages/mobx-react/package-lock.json
@@ -1,0 +1,18 @@
+{
+    "name": "mobx-react",
+    "version": "7.0.5",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "mobx": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.0.4.tgz",
+            "integrity": "sha512-wT2QJT9tW19VSHo9x7RPKU3z/I2Ps6wUS8Kb1OO+kzmg7UY3n4AkcaYG6jq95Lp1R9ohjC/NGYuT2PtuvBjhFg=="
+        },
+        "mobx-react-lite": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.1.6.tgz",
+            "integrity": "sha512-MM3x9BLt5nC7iE/ILA5n2+hfrplEKYbFjqROEuGkzBdZP/KD+Z44+2gseczRrTG0xFuiPWfEzgT68+6/zqOiEw=="
+        }
+    }
+}

--- a/packages/mobx-react/package.json
+++ b/packages/mobx-react/package.json
@@ -36,6 +36,7 @@
     },
     "homepage": "http://mobx.js.org/",
     "dependencies": {
+        "mobx": "^6.0.4",
         "mobx-react-lite": "^3.1.6"
     },
     "peerDependencies": {
@@ -51,7 +52,6 @@
         }
     },
     "devDependencies": {
-        "mobx": "^6.0.4",
         "mobx-react-lite": "^3.1.6"
     },
     "keywords": [


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
Because the `mobx` involved by `mobx-react`.So it's should be one of the dependencies. Not devDependencies.