### PR TITLE
Fix 2686: onBecome(Un)Observed not firing for nested computeds

### DIFF
--- a/.changeset/proud-tips-bathe.md
+++ b/.changeset/proud-tips-bathe.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+fix: `onBecomeObserved` was not triggered correctly for computed dependencies of computeds. Fixes #2686, #2667

--- a/packages/mobx/__tests__/v5/base/become-observed.ts
+++ b/packages/mobx/__tests__/v5/base/become-observed.ts
@@ -397,7 +397,7 @@ test("#2686 - 3", () => {
 
     // APP
 
-    const network = observable({ model: null })
+    const network = observable({ model: null as any })
 
     // load
     const load = computed(() => {
@@ -405,10 +405,11 @@ test("#2686 - 3", () => {
         if (network.model) {
             return halfFirst(network.model)
         }
+        return undefined
     })
 
     // display
-    const result = computed(() => (load.get() ? load.get().get() : "loading"))
+    const result = computed(() => (load.get() ? load.get()!.get() : "loading"))
     autorun(() => {
         events.push("Current result: " + result.get())
     })

--- a/packages/mobx/src/core/reaction.ts
+++ b/packages/mobx/src/core/reaction.ts
@@ -94,6 +94,8 @@ export class Reaction implements IDerivation, IReactionPublic {
         if (!this.isDisposed_) {
             startBatch()
             this.isScheduled_ = false
+            const prev = globalState.trackingContext
+            globalState.trackingContext = this
             if (shouldCompute(this)) {
                 this.isTrackPending_ = true
 
@@ -110,6 +112,7 @@ export class Reaction implements IDerivation, IReactionPublic {
                     this.reportExceptionInDerivation_(e)
                 }
             }
+            globalState.trackingContext = prev
             endBatch()
         }
     }


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
