### PR TITLE
Do not create generic arguments if keepDecorators passed

### DIFF
--- a/.changeset/gorgeous-coats-rest.md
+++ b/.changeset/gorgeous-coats-rest.md
@@ -1,6 +1,5 @@
 ---
 "mobx-undecorate": patch
-"mobx": patch
 ---
 
 Do not create generic arguments if `keepDecorators` passed

--- a/.changeset/gorgeous-coats-rest.md
+++ b/.changeset/gorgeous-coats-rest.md
@@ -1,0 +1,6 @@
+---
+"mobx-undecorate": patch
+"mobx": patch
+---
+
+Do not create generic arguments if `keepDecorators` passed

--- a/packages/mobx-undecorate/__tests__/undecorate.spec.ts
+++ b/packages/mobx-undecorate/__tests__/undecorate.spec.ts
@@ -875,39 +875,78 @@ describe("decorate", () => {
     })
 })
 
-test("handle privates in classes", () => {
-    expect(
-        convert(
-            `
-            import { observable, decorate, computed, action } from "mobx"
+describe("privates", () => {
+    test("create generic arguments for makeObservable", () => {
+        expect(
+            convert(
+                `
+                import { observable, decorate, computed, action } from "mobx"
+    
+    class TryToGetThis {
+        @observable
+        private privateField1: number = 1
+        @observable
+        protected privateField2 = 1
+        @observable
+        public publicField: string = "test"
+      }
+                `
+            )
+        ).toMatchInlineSnapshot(`
+            "import { observable, computed, action, makeObservable } from \\"mobx\\"
 
-class TryToGetThis {
-    @observable
-    private privateField1: number = 1
-    @observable
-    protected privateField2 = 1
-    @observable
-    public publicField: string = "test"
-  }
-            `
-        )
-    ).toMatchInlineSnapshot(`
-        "import { observable, computed, action, makeObservable } from \\"mobx\\"
+            class TryToGetThis {
+                        private privateField1: number = 1;
+                        protected privateField2 = 1;
+                        public publicField: string = \\"test\\";
 
-        class TryToGetThis {
-          private privateField1: number = 1;
-          protected privateField2 = 1;
-          public publicField: string = \\"test\\";
+                        constructor() {
+                                    makeObservable<TryToGetThis, \\"privateField1\\" | \\"privateField2\\">(this, {
+                                                privateField1: observable,
+                                                privateField2: observable,
+                                                publicField: observable
+                                    });
+                        }
+            }"
+        `)
+    })
 
-          constructor() {
-            makeObservable<TryToGetThis, \\"privateField1\\" | \\"privateField2\\">(this, {
-              privateField1: observable,
-              privateField2: observable,
-              publicField: observable
-            });
-          }
-        }"
-    `)
+    test("do not create generic arguments for makeObservable - keepDecorators", () => {
+        expect(
+            convert(
+                `
+                import { observable, decorate, computed, action } from "mobx"
+    
+    class TryToGetThis {
+        @observable
+        private privateField1: number = 1
+        @observable
+        protected privateField2 = 1
+        @observable
+        public publicField: string = "test"
+      }
+                `,
+                {
+                    keepDecorators: true
+                }
+            )
+        ).toMatchInlineSnapshot(`
+            "import { observable, computed, action, makeObservable } from \\"mobx\\"
+
+            class TryToGetThis {
+                        @observable
+                        private privateField1: number = 1
+                        @observable
+                        protected privateField2 = 1
+                        @observable
+                        public publicField: string = \\"test\\"
+
+                        constructor() {
+                                    makeObservable(this);
+                        }
+            }"
+        `)
+    })
 })
 
 describe("@observer", () => {

--- a/packages/mobx-undecorate/src/undecorate.ts
+++ b/packages/mobx-undecorate/src/undecorate.ts
@@ -319,7 +319,7 @@ export default function transform(
                 options?.keepDecorators ? [j.thisExpression()] : [j.thisExpression(), members]
             )
         )
-        if (privates.length) {
+        if (privates.length && !options?.keepDecorators) {
             // @ts-ignore
             initializeObservablesCall.expression.typeArguments = j.tsTypeParameterInstantiation([
                 j.tsTypeReference(j.identifier(clazz.id!.name)),


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

If `keepDecorators` flag is passed to `mobx-undecorate` there is no need to create generic arguments for `makeObservable`.