### PR TITLE
Docs fix : fix a broken link to download js from unpkg cdn

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ There are two types of React bindings, `mobx-react-lite` supports only functiona
 
 **NPM:** `npm install --save mobx`
 
-**CDN:** https://cdnjs.com/libraries/mobx / https://unpkg.com/mobx/lib/mobx.umd.js
+**CDN:** https://cdnjs.com/libraries/mobx / https://unpkg.com/mobx/dist/mobx.umd.production.min.js
 
 ## Use spec compliant transpilation for class properties
 


### PR DESCRIPTION
Docs fix:

In Mobx's [Installation document](https://mobx.js.org/installation.html), the link to download a js file from unpkg is broken. 

The link is currently heading to `mobx.umd.js` and needed to fix a correct path. But, I can't find a proper path of `mobx.umd.js` and changed to `mobx.umd.production.min.js` instead.