### PR TITLE
Infer optional / promise action args type correctly

### DIFF
--- a/.changeset/calm-files-nail.md
+++ b/.changeset/calm-files-nail.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Infer optional / promise `action` args type correctly

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -2086,19 +2086,40 @@ test("type inference of the action callback", () => {
     )
 
     // Promises
-    // TODO: re-enable
-    // Promise.resolve(1).then(
-    //     action(arg => {
-    //         assert<IsExact<typeof arg, number>>(true)
-    //     })
-    // )
+    Promise.resolve(1).then(
+        action(arg => {
+            assert<IsExact<typeof arg, number>>(true)
+        })
+    )
 
-    // // Promises with names actions
-    // Promise.resolve(1).then(
-    //     action("named action", arg => {
-    //         assert<IsExact<typeof arg, number>>(true)
-    //     })
-    // )
+    // Promises with names actions
+    Promise.resolve(1).then(
+        action("named action", arg => {
+            assert<IsExact<typeof arg, number>>(true)
+        })
+    )
+
+    // optional
+    const optionalActionTypeInfer: {
+        a?: (a1: number, a2: string, a3: boolean) => void
+    } = {
+        a: action((a1, a2, a3) => {
+            assert<IsExact<typeof a1, number>>(true)
+            assert<IsExact<typeof a2, string>>(true)
+            assert<IsExact<typeof a3, boolean>>(true)
+        })
+    }
+
+    // optional with names actions
+    const optionalNamedActionTypeInfer: {
+        a?: (a1: number, a2: string, a3: boolean) => void
+    } = {
+        a: action("named action", (a1, a2, a3) => {
+            assert<IsExact<typeof a1, number>>(true)
+            assert<IsExact<typeof a2, string>>(true)
+            assert<IsExact<typeof a3, boolean>>(true)
+        })
+    }
 })
 
 test("TS - it should support flow as function wrapper", done => {

--- a/packages/mobx/src/api/action.ts
+++ b/packages/mobx/src/api/action.ts
@@ -19,9 +19,9 @@ const ACTION_UNNAMED = "<unnamed action>"
 
 export interface IActionFactory extends Annotation, PropertyDecorator {
     // nameless actions
-    <T extends Function>(fn: T): T
+    <T extends Function | undefined | null>(fn: T): T
     // named actions
-    <T extends Function>(name: string, fn: T): T
+    <T extends Function | undefined | null>(name: string, fn: T): T
 
     // named decorator
     (customName: string): PropertyDecorator & Annotation


### PR DESCRIPTION
### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

### PR Background
seanchas116 create this issue #2670, seanchas116 found mobx can't infer `action` callback arguments types correctly.
Previous pr #2213 #2217 (by @kubk ) fix it, but mobx6 remove it (I don't know why).
I recover it and add more unit test.

### 🚨 Attention🚨 
```js
// Promises
// TODO: re-enable
// Promise.resolve(1).then(
//     action(arg => {
//         assert<IsExact<typeof arg, number>>(true)
//     })
// )
```
I noticed this comment, so maybe we need check why this unit test be disabled previously.
@FredyC @urugator 

> If this pr isn't useful, just close it 😃 
