### PR TITLE
replace the deprecated react type definition with recommended type def

### DIFF
--- a/.changeset/brown-camels-smash.md
+++ b/.changeset/brown-camels-smash.md
@@ -1,0 +1,6 @@
+---
+"mobx-react": patch
+"mobx-react-lite": patch
+---
+
+replace the deprecated react type definition with recommended type definition

--- a/packages/mobx-react-lite/src/observer.ts
+++ b/packages/mobx-react-lite/src/observer.ts
@@ -8,7 +8,7 @@ export interface IObserverOptions {
 }
 
 export function observer<P extends object, TRef = {}>(
-    baseComponent: React.RefForwardingComponent<TRef, P>,
+    baseComponent: React.ForwardRefRenderFunction<TRef, P>,
     options: IObserverOptions & { forwardRef: true }
 ): React.MemoExoticComponent<
     React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
@@ -20,13 +20,13 @@ export function observer<P extends object>(
 ): React.FunctionComponent<P>
 
 export function observer<
-    C extends React.FunctionComponent<any> | React.RefForwardingComponent<any>,
+    C extends React.FunctionComponent<any> | React.ForwardRefRenderFunction<any>,
     Options extends IObserverOptions
 >(
     baseComponent: C,
     options?: Options
 ): Options extends { forwardRef: true }
-    ? C extends React.RefForwardingComponent<infer TRef, infer P>
+    ? C extends React.ForwardRefRenderFunction<infer TRef, infer P>
         ? C &
               React.MemoExoticComponent<
                   React.ForwardRefExoticComponent<
@@ -38,7 +38,7 @@ export function observer<
 
 // n.b. base case is not used for actual typings or exported in the typing files
 export function observer<P extends object, TRef = {}>(
-    baseComponent: React.RefForwardingComponent<TRef, P> | React.FunctionComponent<P>,
+    baseComponent: React.ForwardRefRenderFunction<TRef, P> | React.FunctionComponent<P>,
     options?: IObserverOptions
 ) {
     // The working of observer is explained step by step in this talk: https://www.youtube.com/watch?v=cPF4iBedoF0&feature=youtu.be&t=1307

--- a/packages/mobx-react/src/inject.ts
+++ b/packages/mobx-react/src/inject.ts
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { ClassAttributes } from "react"
 import { observer } from "./observer"
 import { copyStaticProperties } from "./utils/utils"
 import { MobXProviderContext } from "./Provider"
@@ -53,7 +53,7 @@ function getInjectName(component: IReactComponent<any>, injectNames: string): st
 
 function grabStoresByName(
     storeNames: Array<string>
-): (baseStores: IValueMap, nextProps: React.Props<any>) => React.PropsWithRef<any> | undefined {
+): (baseStores: IValueMap, nextProps: ClassAttributes<any>) => React.PropsWithRef<any> | undefined {
     return function (baseStores, nextProps) {
         storeNames.forEach(function (storeName) {
             if (

--- a/packages/mobx-react/src/observer.tsx
+++ b/packages/mobx-react/src/observer.tsx
@@ -51,7 +51,7 @@ export function observer<T extends IReactComponent>(component: T): T {
         !component["isReactClass"] &&
         !Object.prototype.isPrototypeOf.call(React.Component, component)
     ) {
-        return observerLite(component as React.StatelessComponent<any>) as T
+        return observerLite(component as React.FunctionComponent<any>) as T
     }
 
     return makeClassComponentObserver(component as React.ComponentClass<any, any>) as T

--- a/packages/mobx-react/src/observerClass.ts
+++ b/packages/mobx-react/src/observerClass.ts
@@ -1,4 +1,4 @@
-import { PureComponent, Component } from "react"
+import { PureComponent, Component, ClassAttributes } from "react"
 import {
     createAtom,
     _allowStateChanges,
@@ -145,7 +145,7 @@ function makeComponentReactive(render: any) {
     return reactiveRender.call(this)
 }
 
-function observerSCU(nextProps: React.Props<any>, nextState: any): boolean {
+function observerSCU(nextProps: ClassAttributes<any>, nextState: any): boolean {
     if (isUsingStaticRendering()) {
         console.warn(
             "[mobx-react] It seems that a re-rendering of a React component is triggered while in static (server-side) mode. Please make sure components are rendered only once server-side."


### PR DESCRIPTION
### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

### PR Backgroud
When I try to solve this problem #2721 , I noticed that mobx-react(and lite) source code use 
deprecated react type definition, Such as `RefForwardingComponent ` `React.Props`
and `StatelessComponent `, so I created a PR to replace these with official recommended type def.

### @types/react source code
#### StatelessComponent
```ts
  /**
   * @deprecated as of recent React versions, function components can no
   * longer be considered 'stateless'. Please use `FunctionComponent` instead.
   *
   * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
   */
  type StatelessComponent<P = {}> = FunctionComponent<P>;
```
#### RefForwardingComponent
```ts
  /**
   * @deprecated Use ForwardRefRenderFunction. forwardRef doesn't accept a
   *             "real" component.
   */
  interface RefForwardingComponent <T, P = {}> extends ForwardRefRenderFunction<T, P> {}
```
#### React.Props
```ts
  /**
   * @deprecated. This was used to allow clients to pass `ref` and `key`
   * to `createElement`, which is no longer necessary due to intersection
   * types. If you need to declare a props object before passing it to
   * `createElement` or a factory, use `ClassAttributes<T>`:
   *
   * ```ts
   * var b: Button | null;
   * var props: ButtonProps & ClassAttributes<Button> = {
   *     ref: b => button = b, // ok!
   *     label: "I'm a Button"
   * };
   * ```
   */
  interface Props<T> {
      children?: ReactNode;
      key?: Key;
      ref?: LegacyRef<T>;
  }
```
