### PR TITLE
Fix #1653

### DIFF
--- a/.changeset/odd-maps-dress.md
+++ b/.changeset/odd-maps-dress.md
@@ -1,0 +1,7 @@
+---
+"mobx": patch
+---
+
+Fix error stringification on minified build
+Fix `isObservableProp` not supporting `Symbols`
+Fix `makeAutoObservable` not ignoring `inferredAnnotationsSymbol`

--- a/packages/mobx/__tests__/v5/base/make-observable.ts
+++ b/packages/mobx/__tests__/v5/base/make-observable.ts
@@ -16,7 +16,8 @@ import {
     _getAdministration,
     configure,
     flow,
-    override
+    override,
+    $mobx
 } from "../../../src/mobx"
 
 test("makeObservable picks up decorators", () => {
@@ -1408,4 +1409,17 @@ test("@override must override", () => {
     }).toThrow(
         /^\[MobX\] 'Child\.prototype\.action' is decorated with 'override', but no such decorated member was found on prototype\./
     )
+})
+
+test("makeAutoObservable + production build #2751", () => {
+    const mobx = require(`../../../dist/mobx.cjs.production.min.js`)
+    class Foo {
+        x = "x"
+        constructor() {
+            mobx.makeAutoObservable(this)
+        }
+    }
+    const foo = new Foo()
+    expect(mobx.isObservableObject(foo)).toBe(true)
+    expect(mobx.isObservableProp(foo, "x")).toBe(true)
 })

--- a/packages/mobx/src/api/isobservable.ts
+++ b/packages/mobx/src/api/isobservable.ts
@@ -10,7 +10,7 @@ import {
     isStringish
 } from "../internal"
 
-function _isObservable(value, property?: string): boolean {
+function _isObservable(value, property?: PropertyKey): boolean {
     if (!value) return false
     if (property !== undefined) {
         if (__DEV__ && (isObservableMap(value) || isObservableArray(value)))
@@ -40,7 +40,7 @@ export function isObservable(value: any): boolean {
     return _isObservable(value)
 }
 
-export function isObservableProp(value: any, propName: string): boolean {
+export function isObservableProp(value: any, propName: PropertyKey): boolean {
     if (__DEV__ && !isStringish(propName)) return die(`expected a property name as second argument`)
     return _isObservable(value, propName)
 }

--- a/packages/mobx/src/api/makeObservable.ts
+++ b/packages/mobx/src/api/makeObservable.ts
@@ -68,7 +68,7 @@ export function makeAutoObservable<T extends object, AdditionalKeys extends Prop
                 adm.make_(key, target[inferredAnnotationsSymbol][key])
             }
         } else {
-            const ignoreKeys = { [$mobx]: 1, constructor: 1 }
+            const ignoreKeys = { [$mobx]: 1, [inferredAnnotationsSymbol]: 1, constructor: 1 }
             const make = key => {
                 if (ignoreKeys[key]) return
                 ignoreKeys[key] = 1

--- a/packages/mobx/src/errors.ts
+++ b/packages/mobx/src/errors.ts
@@ -1,7 +1,7 @@
 const niceErrors = {
     0: `Invalid value for configuration 'enforceActions', expected 'never', 'always' or 'observed'`,
-    1(annotationType, fieldName) {
-        return `Cannot apply '${annotationType}' to '${fieldName}': Field not found.`
+    1(annotationType, key: PropertyKey) {
+        return `Cannot apply '${annotationType}' to '${key.toString()}': Field not found.`
     },
     5: "'keys()' can only be used on observable objects, arrays, sets and maps",
     6: "'values()' can only be used on observable objects, arrays, sets and maps",
@@ -73,7 +73,7 @@ export function die(error: string | keyof typeof errors, ...args: any[]): never 
     throw new Error(
         typeof error === "number"
             ? `[MobX] minified error nr: ${error}${
-                  args.length ? " " + args.join(",") : ""
+                  args.length ? " " + args.map(String).join(",") : ""
               }. Find the full error at: https://github.com/mobxjs/mobx/blob/main/packages/mobx/src/errors.ts`
             : `[MobX] ${error}`
     )


### PR DESCRIPTION
Fix error stringification on minified build
Fix `isObservableProp` not supporting `Symbols`
Fix `makeAutoObservable` not ignoring `inferredAnnotationsSymbol`
Fixes #2751