### PR TITLE
Fix: Inherited annotated fields are not assignable

### DIFF
--- a/.changeset/great-pants-do.md
+++ b/.changeset/great-pants-do.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix: Inherited annotated fields are not assignable

--- a/packages/mobx/__tests__/v5/base/make-observable.ts
+++ b/packages/mobx/__tests__/v5/base/make-observable.ts
@@ -1423,3 +1423,29 @@ test("makeAutoObservable + production build #2751", () => {
     expect(mobx.isObservableObject(foo)).toBe(true)
     expect(mobx.isObservableProp(foo, "x")).toBe(true)
 })
+
+// Makes sure that we don't define properties on proto as non-writable,
+// as that would prevent initializing prop on instance via assigment.
+test("inherited fields are assignable before makeObservable", () => {
+    class Foo {
+        constructor() {
+            this.action = () => {}
+            this.flow = function* flow() {}
+            makeObservable(this, {
+                action,
+                flow
+            })
+        }
+
+        action() {}
+        *flow() {}
+    }
+
+    const foo1 = new Foo()
+    expect(isAction(foo1.action)).toBe(true)
+    expect(isFlow(foo1.flow)).toBe(true)
+
+    const foo2 = new Foo()
+    expect(isAction(foo2.action)).toBe(true)
+    expect(isFlow(foo2.flow)).toBe(true)
+})

--- a/packages/mobx/src/types/actionannotation.ts
+++ b/packages/mobx/src/types/actionannotation.ts
@@ -52,7 +52,7 @@ function make_(adm: ObservableObjectAdministration, key: PropertyKey): void {
                     annotated = true
                     break
                 }
-                const actionDescriptor = createActionDescriptor(adm, this, key, descriptor)
+                const actionDescriptor = createActionDescriptor(adm, this, key, descriptor, false)
                 defineProperty(source, key, actionDescriptor)
                 annotated = true
             }
@@ -99,7 +99,9 @@ function createActionDescriptor(
     adm: ObservableObjectAdministration,
     annotation: Annotation,
     key: PropertyKey,
-    descriptor: PropertyDescriptor
+    descriptor: PropertyDescriptor,
+    // provides ability to disable safeDescriptors for prototypes
+    safeDescriptors: boolean = globalState.safeDescriptors
 ) {
     assertActionDescriptor(adm, annotation, key, descriptor)
     let { value } = descriptor
@@ -114,11 +116,11 @@ function createActionDescriptor(
         ),
         // Non-configurable for classes
         // prevents accidental field redefinition in subclass
-        configurable: globalState.safeDescriptors ? adm.isPlainObject_ : true,
+        configurable: safeDescriptors ? adm.isPlainObject_ : true,
         // https://github.com/mobxjs/mobx/pull/2641#issuecomment-737292058
         enumerable: false,
         // Non-obsevable, therefore non-writable
         // Also prevents rewriting in subclass constructor
-        writable: globalState.safeDescriptors ? false : true
+        writable: safeDescriptors ? false : true
     }
 }

--- a/packages/mobx/src/types/flowannotation.ts
+++ b/packages/mobx/src/types/flowannotation.ts
@@ -35,7 +35,7 @@ function make_(adm: ObservableObjectAdministration, key: PropertyKey): void {
                     annotated = true
                     break
                 }
-                const flowDescriptor = createFlowDescriptor(adm, this, key, descriptor)
+                const flowDescriptor = createFlowDescriptor(adm, this, key, descriptor, false)
                 defineProperty(source, key, flowDescriptor)
             } else {
                 const flowDescriptor = createFlowDescriptor(adm, this, key, descriptor)
@@ -89,18 +89,20 @@ function createFlowDescriptor(
     adm: ObservableObjectAdministration,
     annotation: Annotation,
     key: PropertyKey,
-    descriptor: PropertyDescriptor
+    descriptor: PropertyDescriptor,
+    // provides ability to disable safeDescriptors for prototypes
+    safeDescriptors: boolean = globalState.safeDescriptors
 ): PropertyDescriptor {
     assertFlowDescriptor(adm, annotation, key, descriptor)
     return {
         value: flow(descriptor.value),
         // Non-configurable for classes
         // prevents accidental field redefinition in subclass
-        configurable: globalState.safeDescriptors ? adm.isPlainObject_ : true,
+        configurable: safeDescriptors ? adm.isPlainObject_ : true,
         // https://github.com/mobxjs/mobx/pull/2641#issuecomment-737292058
         enumerable: false,
         // Non-obsevable, therefore non-writable
         // Also prevents rewriting in subclass constructor
-        writable: globalState.safeDescriptors ? false : true
+        writable: safeDescriptors ? false : true
     }
 }


### PR DESCRIPTION
Non-writable actions and flows defined on prototype prevented initializing the prop via assigment inside constructor.
Since this PR, things defined on prototype won't use safe descriptors.
This doesn't mean that we support runtime prototype modifications, but we assume that doing so isn't common enough to justify this safety measure, while preventing other potentially valid usages.
