### PR TITLE
fix: mobx-undecorate don't crash when node's loc is null

### DIFF
--- a/.changeset/witty-hotels-ring.md
+++ b/.changeset/witty-hotels-ring.md
@@ -1,0 +1,5 @@
+---
+"mobx-undecorate": patch
+---
+
+mobx-undecorate don't crash when node's loc is null

--- a/packages/mobx-undecorate/src/undecorate.ts
+++ b/packages/mobx-undecorate/src/undecorate.ts
@@ -402,15 +402,19 @@ export default function transform(
         if (process.env.NODE_ENV === "test") {
             return
         }
-        const line = lines[node.loc!.start.line - 1]
-        const shortline = line.replace(/^\s*/, "")
-        console.warn(
-            `[mobx:undecorate] ${msg} at (${fileInfo.path}:${node.loc!.start.line}:${
-                node.loc!.start.column
-            }):\n\t${shortline}\n\t${"^".padStart(
-                node.loc!.start.column + 1 - line.indexOf(shortline),
-                " "
-            )}\n`
-        )
+        if (node.loc) {
+            const line = lines[node.loc.start.line - 1]
+            const shortline = line.replace(/^\s*/, "")
+            console.warn(
+                `[mobx:undecorate] ${msg} at (${fileInfo.path}:${node.loc.start.line}:${
+                    node.loc.start.column
+                }):\n\t${shortline}\n\t${"^".padStart(
+                    node.loc.start.column + 1 - line.indexOf(shortline),
+                    " "
+                )}\n`
+            )
+        } else {
+            console.warn(`[mobx:undecorate] ${msg} at (${fileInfo.path})\n`)
+        }
     }
 }


### PR DESCRIPTION
### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)


### PR Target
fix #2747 

### PR Background
`warn` util function's params `node`'s loc is null in some scenarios.
```ts
const line = lines[node.loc!.start.line - 1]  👈   //  when `loc` is null, codemod script crash
```

### Why loc will be `null`
mobx-undecorate build on top of `jscodeshift` and use `@babel/parser` as ast parser
```js
const babylon = require("@babel/parser")
```
`jscodeshift` based on `recast`, `recast` inner logic will make loc be null in some scenarios.
https://github.com/benjamn/recast/blob/master/lib/util.ts#L180-L183
```js
  } else if (node.declaration && isExportDeclaration(node)) {
    // Nullify .loc information for the child declaration so that we never
    // try to reprint it without also reprinting the export declaration.
    node.declaration.loc = null;
```
VScode debug screenshot 👇
![2021-01-30 13 47 24](https://user-images.githubusercontent.com/14012511/106349878-8958fd00-630c-11eb-95e1-0da413582c9d.png)

### Solve it
add null check for node.loc
when `loc` is null, just `warn` important info(e.g. warn msg and fileinfo path), like this 👇
![2021-01-30 14 21 29](https://user-images.githubusercontent.com/14012511/106349592-05057a80-630a-11eb-9306-077f77688696.png)

~~I remove the `test` mode check, for avoid regressing in the future.~~
```diff
-        if (process.env.NODE_ENV === "test") {
-            return
-        }
```
~~mute `warn` log in unit test. ( won't effect other package unit test~~
~~beforeEach(() => {~~
~~jest.spyOn(console, "warn").mockImplementation(() => {})~~ 
~~})~~
👆 I'm stupid