### PR TITLE
Small decorators optimization

### DIFF
--- a/.changeset/few-hotels-clean.md
+++ b/.changeset/few-hotels-clean.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Decorators optimization

--- a/packages/mobx/src/api/annotation.ts
+++ b/packages/mobx/src/api/annotation.ts
@@ -19,7 +19,6 @@ export type Annotation = {
         proxyTrap: boolean
     ): boolean | null
     options_?: any
-    isDecorator_?: boolean
 }
 
 export type AnnotationMapEntry =

--- a/packages/mobx/src/api/decorators.ts
+++ b/packages/mobx/src/api/decorators.ts
@@ -38,10 +38,7 @@ export function storeAnnotation(prototype: any, key: PropertyKey, annotation: An
 
     // Ignore override
     if (!isOverride(annotation)) {
-        prototype[storedAnnotationsSymbol][key] = {
-            ...annotation,
-            isDecorator_: true
-        }
+        prototype[storedAnnotationsSymbol][key] = annotation
     }
 }
 

--- a/packages/mobx/src/types/actionannotation.ts
+++ b/packages/mobx/src/types/actionannotation.ts
@@ -62,7 +62,7 @@ function make_(adm: ObservableObjectAdministration, key: PropertyKey): void {
     }
     if (annotated) {
         recordAnnotationApplied(adm, this, key)
-    } else if (!adm.target_[storedAnnotationsSymbol]) {
+    } else if (!adm.target_[storedAnnotationsSymbol]?.[key]) {
         // Throw on missing key, except for decorators:
         // Decorator annotations are collected from whole prototype chain.
         // When called from super() some props may not exist yet.

--- a/packages/mobx/src/types/actionannotation.ts
+++ b/packages/mobx/src/types/actionannotation.ts
@@ -9,7 +9,8 @@ import {
     isFunction,
     Annotation,
     recordAnnotationApplied,
-    globalState
+    globalState,
+    storedAnnotationsSymbol
 } from "../internal"
 
 export function createActionAnnotation(name: string, options?: object): Annotation {
@@ -61,7 +62,7 @@ function make_(adm: ObservableObjectAdministration, key: PropertyKey): void {
     }
     if (annotated) {
         recordAnnotationApplied(adm, this, key)
-    } else if (!this.isDecorator_) {
+    } else if (!adm.target_[storedAnnotationsSymbol]) {
         // Throw on missing key, except for decorators:
         // Decorator annotations are collected from whole prototype chain.
         // When called from super() some props may not exist yet.

--- a/packages/mobx/src/types/computedannotation.ts
+++ b/packages/mobx/src/types/computedannotation.ts
@@ -37,7 +37,7 @@ function make_(adm: ObservableObjectAdministration, key: PropertyKey): void {
         }
         source = Object.getPrototypeOf(source)
     }
-    if (!adm.target_[storedAnnotationsSymbol]) {
+    if (!adm.target_[storedAnnotationsSymbol]?.[key]) {
         // Throw on missing key, except for decorators:
         // Decorator annotations are collected from whole prototype chain.
         // When called from super() some props may not exist yet.

--- a/packages/mobx/src/types/computedannotation.ts
+++ b/packages/mobx/src/types/computedannotation.ts
@@ -4,7 +4,8 @@ import {
     objectPrototype,
     die,
     Annotation,
-    recordAnnotationApplied
+    recordAnnotationApplied,
+    storedAnnotationsSymbol
 } from "../internal"
 
 export function createComputedAnnotation(name: string, options?: object): Annotation {
@@ -36,7 +37,7 @@ function make_(adm: ObservableObjectAdministration, key: PropertyKey): void {
         }
         source = Object.getPrototypeOf(source)
     }
-    if (!this.isDecorator_) {
+    if (!adm.target_[storedAnnotationsSymbol]) {
         // Throw on missing key, except for decorators:
         // Decorator annotations are collected from whole prototype chain.
         // When called from super() some props may not exist yet.

--- a/packages/mobx/src/types/flowannotation.ts
+++ b/packages/mobx/src/types/flowannotation.ts
@@ -9,7 +9,8 @@ import {
     isFlow,
     recordAnnotationApplied,
     isFunction,
-    globalState
+    globalState,
+    storedAnnotationsSymbol
 } from "../internal"
 
 export function createFlowAnnotation(name: string, options?: object): Annotation {
@@ -51,7 +52,7 @@ function make_(adm: ObservableObjectAdministration, key: PropertyKey): void {
     }
     if (annotated) {
         recordAnnotationApplied(adm, this, key)
-    } else if (!this.isDecorator_) {
+    } else if (!adm.target_[storedAnnotationsSymbol]) {
         // Throw on missing key, except for decorators:
         // Decorator annotations are collected from whole prototype chain.
         // When called from super() some props may not exist yet.

--- a/packages/mobx/src/types/flowannotation.ts
+++ b/packages/mobx/src/types/flowannotation.ts
@@ -52,7 +52,7 @@ function make_(adm: ObservableObjectAdministration, key: PropertyKey): void {
     }
     if (annotated) {
         recordAnnotationApplied(adm, this, key)
-    } else if (!adm.target_[storedAnnotationsSymbol]) {
+    } else if (!adm.target_[storedAnnotationsSymbol]?.[key]) {
         // Throw on missing key, except for decorators:
         // Decorator annotations are collected from whole prototype chain.
         // When called from super() some props may not exist yet.

--- a/packages/mobx/src/types/observableannotation.ts
+++ b/packages/mobx/src/types/observableannotation.ts
@@ -5,7 +5,8 @@ import {
     die,
     Annotation,
     recordAnnotationApplied,
-    objectPrototype
+    objectPrototype,
+    storedAnnotationsSymbol
 } from "../internal"
 
 export function createObservableAnnotation(name: string, options?: object): Annotation {
@@ -39,7 +40,7 @@ function make_(adm: ObservableObjectAdministration, key: PropertyKey): void {
         }
         source = Object.getPrototypeOf(source)
     }
-    if (!this.isDecorator_) {
+    if (!adm.target_[storedAnnotationsSymbol]) {
         // Throw on missing key, except for decorators:
         // Decorator annotations are collected from whole prototype chain.
         // When called from super() some props may not exist yet.

--- a/packages/mobx/src/types/observableannotation.ts
+++ b/packages/mobx/src/types/observableannotation.ts
@@ -40,7 +40,7 @@ function make_(adm: ObservableObjectAdministration, key: PropertyKey): void {
         }
         source = Object.getPrototypeOf(source)
     }
-    if (!adm.target_[storedAnnotationsSymbol]) {
+    if (!adm.target_[storedAnnotationsSymbol]?.[key]) {
         // Throw on missing key, except for decorators:
         // Decorator annotations are collected from whole prototype chain.
         // When called from super() some props may not exist yet.

--- a/packages/mobx/src/types/observableobject.ts
+++ b/packages/mobx/src/types/observableobject.ts
@@ -702,9 +702,7 @@ export function recordAnnotationApplied(
         adm.appliedAnnotations_![key] = annotation
     }
     // Remove applied decorator annotation so we don't try to apply it again in subclass constructor
-    if (annotation.isDecorator_) {
-        delete adm.target_[storedAnnotationsSymbol][key]
-    }
+    delete adm.target_[storedAnnotationsSymbol]?.[key]
 }
 
 function assertAnnotable(


### PR DESCRIPTION
Avoids an annotation object copy per decorator application.
Since mixing decorators/annotations is not officialy supported (it may actually work, but there are not tests for it), annotation itself doesn't have to know that it's decorator - ~~once target has `storedAnnotationsSymbol` - meaning at least one decorator was applied - we assume that all annotations are decorators.
If one would try to mix decorators/annotation (unsupported), this change breaks check for non-existing prop (it won't throw).
The decorator detection could be made a bit more realiable by changing `make_` to accept additional `isDecorator` param and calling: `adm.make_(key, annotations![key], !annotations)` from `makeObservable`. 
Not sure if worth it ATM, but at least good to have this noted here.~~
EDIT: Changed to check for specific key, should work equally well in this case.