### PR TITLE
detect globalThis

### DIFF
--- a/.changeset/shy-mangos-shake.md
+++ b/.changeset/shy-mangos-shake.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+use globalThis in global detection

--- a/packages/mobx/src/utils/global.ts
+++ b/packages/mobx/src/utils/global.ts
@@ -4,6 +4,9 @@ declare const self: any
 const mockGlobal = {}
 
 export function getGlobal() {
+    if (typeof globalThis !== "undefined") {
+        return globalThis
+    }
     if (typeof window !== "undefined") {
         return window
     }


### PR DESCRIPTION
`globalThis` is a __standard__ global right now
should use it whenever available

The current code fails in sandbox environments where only standard `globaThis` exists (regression from 5.x which works fine)
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
