### PR TITLE
Use up-to-date reproduction codesandbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -27,7 +27,7 @@ A description of what happened, including a screenshot or copy-paste of any rela
 **How to reproduce the issue:**
 
 <!--
-If possible, please create a reproduction using https://codesandbox.io/s/minimal-mobx-react-project-ppgml and link to it here. If the issue is more complicated or not reproducible with React, feel free to create your CodeSandbox or your own GitHub repo with the code.
+If possible, please create a reproduction using https://codesandbox.io/s/magical-dhawan-jq8t5?file=/index.js and link to it here. If the issue is more complicated or not reproducible with React, feel free to create your CodeSandbox or your own GitHub repo with the code.
 
 Instructions for how the issue can be reproduced by a maintainer or contributor. Be as specific as possible, and only mention what is necessary to reproduce the bug. If possible, try to isolate the exact circumstances in which the bug occurs and avoid speculation over what the cause might be. Help us so we can help you quickly.
 -->


### PR DESCRIPTION
Related issue: https://github.com/mobxjs/mobx/issues/2777

Changes summary:
- Update mobx, mobx-react, and react
- Replace obsolete `decorate` with `makeAutoObservable`