### PR TITLE
Fire observe callback immediately when computed value changes

### DIFF
--- a/packages/mobx/__tests__/v4/base/observables.js
+++ b/packages/mobx/__tests__/v4/base/observables.js
@@ -64,7 +64,76 @@ test("basic2", function () {
     expect(mobx._isComputingDerivation()).toBe(false)
 })
 
-test("computed with asStructure modifier", function () {
+test("computed with asStructure modifier - reaction", function () {
+    const x1 = observable.box(3)
+    const x2 = observable.box(5)
+    const y = m.computed(
+        function () {
+            return {
+                sum: x1.get() + x2.get()
+            }
+        },
+        { compareStructural: true }
+    )
+    const b = []
+    m.reaction(
+        () => y.get(),
+        v => b.push(v),
+        { fireImmediately: true }
+    )
+
+    expect(8).toBe(y.get().sum)
+
+    x1.set(4)
+    expect(9).toBe(y.get().sum)
+
+    m.transaction(function () {
+        // swap values, computation result is structurally unchanged
+        x1.set(5)
+        x2.set(4)
+    })
+
+    expect(b).toEqual([{ sum: 8 }, { sum: 9 }])
+    expect(mobx._isComputingDerivation()).toBe(false)
+})
+
+test("computed with asStructure modifier - reaction + get computed value", function () {
+    const x1 = observable.box(3)
+    const x2 = observable.box(5)
+    const y = m.computed(
+        function () {
+            return {
+                sum: x1.get() + x2.get()
+            }
+        },
+        { compareStructural: true }
+    )
+    const b = []
+    m.reaction(
+        () => y.get(),
+        v => b.push(v),
+        { fireImmediately: true }
+    )
+
+    expect(8).toBe(y.get().sum)
+
+    x1.set(4)
+    expect(9).toBe(y.get().sum)
+
+    m.transaction(function () {
+        // swap values
+        x1.set(5)
+        y.get() // interferes with `compareStructural: true`
+        x2.set(4)
+    })
+
+    // Reaction is fired twice for `{ sum: 9 }` because of intermediate
+    // `y.get()`
+    expect(b).toEqual([{ sum: 8 }, { sum: 9 }, { sum: 9 }])
+    expect(mobx._isComputingDerivation()).toBe(false)
+})
+
+test("computed with asStructure modifier - observe", function () {
     const x1 = observable.box(3)
     const x2 = observable.box(5)
     const y = m.computed(
@@ -84,12 +153,13 @@ test("computed with asStructure modifier", function () {
     expect(9).toBe(y.get().sum)
 
     m.transaction(function () {
-        // swap values, computation results is structuraly unchanged
+        // swap values
         x1.set(5)
         x2.set(4)
     })
 
-    expect(b.toArray()).toEqual([{ sum: 8 }, { sum: 9 }])
+    // transaction is ignored because `observe` fires immediately
+    expect(b.toArray()).toEqual([{ sum: 8 }, { sum: 9 }, { sum: 10 }, { sum: 9 }])
     expect(mobx._isComputingDerivation()).toBe(false)
 })
 
@@ -222,7 +292,40 @@ test("readme1", function (done) {
     }
 })
 
-test("batch", function () {
+test("batch - reaction", function () {
+    const a = observable.box(2)
+    const b = observable.box(3)
+    const c = computed(function () {
+        return a.get() * b.get()
+    })
+    const d = computed(function () {
+        return c.get() * b.get()
+    })
+    const buf = []
+    m.reaction(
+        () => d.get(),
+        x => buf.push(x)
+    )
+
+    a.set(4)
+    b.set(5)
+    // Note, 60 should not happen! (that is d begin computed before c after update of b)
+    expect(buf).toEqual([36, 100])
+
+    const x = mobx.transaction(function () {
+        a.set(2)
+        b.set(3)
+        a.set(6)
+        expect(d.value_).toBe(100) // not updated; in transaction
+        expect(d.get()).toBe(54) // consistent due to inspection
+        return 2
+    })
+
+    expect(x).toBe(2) // test return value
+    expect(buf).toEqual([36, 100, 54]) // only one new value for d
+})
+
+test("batch - observe", function () {
     const a = observable.box(2)
     const b = observable.box(3)
     const c = computed(function () {
@@ -243,13 +346,13 @@ test("batch", function () {
         a.set(2)
         b.set(3)
         a.set(6)
-        expect(d.value_).toBe(100) // not updated; in transaction
+        expect(d.value_).toBe(54) // updated despite transaction
         expect(d.get()).toBe(54) // consistent due to inspection
         return 2
     })
 
     expect(x).toBe(2) // test return value
-    expect(buf.toArray()).toEqual([36, 100, 54]) // only one new value for d
+    expect(buf.toArray()).toEqual([36, 100, 50, 18, 54]) // transaction is ignored by `observe`
 })
 
 test("transaction with inspection", function () {
@@ -746,7 +849,47 @@ test("multiple view dependencies", function () {
     expect(buffer).toEqual([8, 11, 14])
 })
 
-test("nested observable2", function () {
+test("nested observable2 - reaction", function () {
+    const factor = observable.box(0)
+    const price = observable.box(100)
+    let totalCalcs = 0
+    let innerCalcs = 0
+
+    const total = computed(function () {
+        totalCalcs += 1 // outer observable shouldn't recalc if inner observable didn't publish a real change
+        return (
+            price.get() *
+            computed(function () {
+                innerCalcs += 1
+                return factor.get() % 2 === 0 ? 1 : 3
+            }).get()
+        )
+    })
+
+    const b = []
+    m.reaction(
+        () => total.get(),
+        function (x) {
+            b.push(x)
+        },
+        { fireImmediately: true }
+    )
+
+    expect(innerCalcs).toBe(1)
+
+    price.set(150)
+    factor.set(7) // triggers innerCalc twice, because changing the outcome triggers the outer calculation which recreates the inner calculation
+    factor.set(5) // doesn't trigger outer calc
+    factor.set(3) // doesn't trigger outer calc
+    factor.set(4) // triggers innerCalc twice
+    price.set(20)
+
+    expect(b).toEqual([100, 150, 450, 150, 20])
+    expect(innerCalcs).toBe(9)
+    expect(totalCalcs).toBe(5)
+})
+
+test("nested observable2 - observe", function () {
     const factor = observable.box(0)
     const price = observable.box(100)
     let totalCalcs = 0
@@ -772,19 +915,21 @@ test("nested observable2", function () {
         true
     )
 
+    expect(innerCalcs).toBe(2) // TODO: Why are there 2 and not 1 inner calls here?
+
     price.set(150)
     factor.set(7) // triggers innerCalc twice, because changing the outcome triggers the outer calculation which recreates the inner calculation
-    factor.set(5) // doesn't trigger outer calc
+    factor.set(5) // triggers outer calc because
     factor.set(3) // doesn't trigger outer calc
     factor.set(4) // triggers innerCalc twice
     price.set(20)
 
     expect(b).toEqual([100, 150, 450, 150, 20])
-    expect(innerCalcs).toBe(9)
-    expect(totalCalcs).toBe(5)
+    expect(innerCalcs).toBe(10) // TODO: Why are there 10 and not 9 inner calls here?
+    expect(totalCalcs).toBe(6) // TODO: Why are there 6 and not 5 outer calls here?
 })
 
-test("observe", function () {
+test("autorun", function () {
     const x = observable.box(3)
     const x2 = computed(function () {
         return x.get() * 2

--- a/packages/mobx/__tests__/v4/base/observe.ts
+++ b/packages/mobx/__tests__/v4/base/observe.ts
@@ -1,4 +1,4 @@
-import { observable, observe, computed } from "../mobx4"
+import { observable, observe, computed, runInAction } from "../mobx4"
 
 test("observe object and map properties", function () {
     const map = observable.map({ a: 1 })
@@ -52,4 +52,37 @@ test("observe computed values", () => {
     f.set(10)
 
     expect(events).toEqual([[6, 0]])
+})
+
+test("observe computed value (fireImmediately)", () => {
+    const events: string[] = []
+
+    const v = observable.box(0)
+    const c = computed(() => v.get())
+
+    c.observe_(e => {
+        events.push(`observe ${e.oldValue} -> ${e.newValue}`)
+    }, true)
+
+    expect(events).toEqual(["observe undefined -> 0"])
+})
+
+test("observe computed value ignores transaction", () => {
+    const events: string[] = []
+
+    const v = observable.box(0)
+    const c = computed(() => v.get())
+
+    c.observe_(e => {
+        events.push(`observe ${e.oldValue} -> ${e.newValue}`)
+    })
+
+    runInAction(() => {
+        events.push("action start")
+        v.set(1)
+        v.set(2)
+        events.push("action end")
+    })
+
+    expect(events).toEqual(["action start", "observe 0 -> 1", "observe 1 -> 2", "action end"])
 })

--- a/packages/mobx/src/core/globalstate.ts
+++ b/packages/mobx/src/core/globalstate.ts
@@ -1,4 +1,4 @@
-import { IDerivation, IObservable, Reaction, die, getGlobal } from "../internal"
+import { IDerivation, IObservable, Reaction, die, getGlobal, Lambda } from "../internal"
 import { ComputedValue } from "./computedvalue"
 
 /**
@@ -70,6 +70,12 @@ export class MobXGlobals {
      * @type {IObservable[]}
      */
     pendingUnobservations: IObservable[] = []
+
+    /**
+     * List of scheduled, not yet executed, eager reactions (executed
+     * immediately ignoring transactions)
+     */
+    pendingListeners: Lambda[] = []
 
     /**
      * List of scheduled, not yet executed, reactions.

--- a/packages/mobx/src/core/observable.ts
+++ b/packages/mobx/src/core/observable.ts
@@ -196,6 +196,16 @@ export function propagateChanged(observable: IObservable) {
         }
         d.dependenciesState_ = IDerivationState_.STALE_
     })
+
+    // Call all pending eager reactions
+    while (true) {
+        const listener = globalState.pendingListeners.pop()
+        if (listener) {
+            listener()
+        } else {
+            break
+        }
+    }
     // invariantLOS(observable, "changed end");
 }
 


### PR DESCRIPTION
When observing observable state, `observe` fired the callback immediately (ignoring transactions) when the state changed, but when observing a computed value the callback was fired only after the outermost transaction had completed. This PR makes `observe`'s behavior consistent for both observable state and computed values.

In case this PR is considered a breaking change and not a fix, the `observe_` method of `IComputedValue` (and similarly the `observe` function) could be overloaded:

```ts
observe_(listener: (change: IComputedDidChange<T>) => void, fireImmediately?: boolean): Lambda
observe_(
  listener: (change: IComputedDidChange<T>) => void,
  options?: {
    fireImmediately?: boolean
    eager?: boolean
  }
): Lambda
```

This way, by default `autorun` would be used (as before) which respects transactions whereas `observe(someComputedValue, change => { ... }, { eager: true })` would use the new behavior that is consistent with using `observe` on observable state.

Fixes #2795.

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

There are 2 performance drops, I'm not sure whether they can be avoided or not.