### PR TITLE
fix the mobx doc edit button jump link

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -43,7 +43,7 @@ const siteConfig = {
     // URL for editing docs, usage example: editUrl + 'en/doc1.md'.
     // If this field is omitted, there will be no "Edit this Doc" button
     // for each document.
-    editUrl: "https://github.com/mobxjs/mobx/edit/mobx6/docs/",
+    editUrl: "https://github.com/mobxjs/mobx/edit/main/docs/",
 
     // For top-level user or org sites, the organization is still the same.
     // e.g., for the https://JoelMarcey.github.io site, it would be set like...


### PR DESCRIPTION
### current edit button click behavior
click it ->
![2021-02-22 11 35 48](https://user-images.githubusercontent.com/14012511/108654066-e0fd1980-7502-11eb-955c-db58648647b4.png)

jump to 404 ->
![2021-02-22 11 36 10](https://user-images.githubusercontent.com/14012511/108654167-1275e500-7503-11eb-875a-4e36ab2ab677.png)

### change the jump link
```diff
-   editUrl: "https://github.com/mobxjs/mobx/edit/mobx6/docs/",
+   editUrl: "https://github.com/mobxjs/mobx/edit/main/docs/",
```

