### PR TITLE
fix: makeAutoObservable cached inferred annotations

### DIFF
--- a/.changeset/weak-flies-laugh.md
+++ b/.changeset/weak-flies-laugh.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+fix makeAutoObservable cached inferred annotations logic

--- a/packages/mobx/__tests__/v5/base/make-observable.ts
+++ b/packages/mobx/__tests__/v5/base/make-observable.ts
@@ -1514,3 +1514,24 @@ test("makeAutoObservable + symbolic keys", () => {
         expect(isAction(foo[actionSymbol])).toBe(true)
     })
 })
+
+test("makeAutoObservable cached inferred annotations #2832", () => {
+    class TestClass {
+        constructor() {
+            makeAutoObservable(this, {
+                setData: action,
+                name: observable.ref
+            })
+        }
+        name: string = "testObj"
+        data: string | null = null
+        setData = (data: string) => {
+            this.data = data
+        }
+    }
+    // @ts-ignore
+    const TestA = new TestClass()
+    const TestB = new TestClass()
+    expect(isAction(TestB["setData"])).toBe(true)
+    expect(isObservableProp(TestB, "name")).toBe(true)
+})

--- a/packages/mobx/src/api/makeObservable.ts
+++ b/packages/mobx/src/api/makeObservable.ts
@@ -60,11 +60,12 @@ export function makeAutoObservable<T extends object, AdditionalKeys extends Prop
         return extendObservable(target, target, overrides, options)
     }
 
+    const isValidOverrides = overrides && Object.keys(overrides).length > 0
     const adm: ObservableObjectAdministration = asObservableObject(target, options)[$mobx]
     startBatch()
     try {
         // Use cached inferred annotations if available (only in classes)
-        if (target[inferredAnnotationsSymbol]) {
+        if (target[inferredAnnotationsSymbol] && !isValidOverrides) {
             target[inferredAnnotationsSymbol].forEach((value, key) => adm.make_(key, value))
         } else {
             const ignoreKeys = { [$mobx]: 1, [inferredAnnotationsSymbol]: 1, constructor: 1 }


### PR DESCRIPTION
### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

### Target
fix #2832 
### Summary

#### makeAutoObservable cached inferred annotations logic
> Use cached inferred annotations if available (only in classes)
```ts
  if (target[inferredAnnotationsSymbol]) {
      target[inferredAnnotationsSymbol].forEach((value, key) => adm.make_(key, value))
  } else {
```
#### Test case code snippet
```ts
    class TestClass {
        constructor() {
            makeAutoObservable(this, {
                setData: action,
                name: observable.ref
            })
        }
        name: string = "testObj"
        data: string | null = null
        setData = (data: string) => {
            this.data = data
        }
    }
```
When you ceate `TestClass` instance once, it works fine, but then you create `TestClass` multiple times, you can found weird behavior due to `cached inferred annotations`.
```js
const A = new TestClass();
const B = new TestClass();
```
![2021-03-01 10 42 58](https://user-images.githubusercontent.com/14012511/109446447-ad7b3b80-7a7c-11eb-9368-b7bf332df9b8.png)

```ts
        // Cache the annotation.
        // Note we can do this only because annotation and field can't change.
        if (!this.isPlainObject_) {
            // We could also place it on furthest proto, shoudn't matter
            const closestProto = Object.getPrototypeOf(this.target_)
            if (!hasProp(closestProto, inferredAnnotationsSymbol)) {
                addHiddenProp(closestProto, inferredAnnotationsSymbol, new Map())
            }
            closestProto[inferredAnnotationsSymbol].set(key, annotation)
        }
```
`target[inferredAnnotationsSymbol]` only cached `inferredAnnotations` and don't cache `overrides annotations`, when we check `if (target[inferredAnnotationsSymbol]) {`, we lose `overrides annotations` actually.

### Append
My pull request is not the final solution, code review welcome, or give me a better solution, thanks. 

