### PR TITLE
Fix pathing issue in mobx-undecorate

### DIFF
--- a/packages/mobx-undecorate/cli.js
+++ b/packages/mobx-undecorate/cli.js
@@ -3,7 +3,7 @@ const { spawn } = require("child_process")
 const path = require("path")
 
 spawn(
-    path.join("node_modules", ".bin", "jscodeshift"),
+    path.join("jscodeshift"),
     [
         "--extensions=js,jsx,ts,tsx",
         ...process.argv.filter(arg => arg.startsWith("--")),


### PR DESCRIPTION
When I ran mobx-undecorate I got:

```js
node_modules/.bin/jscodeshift: No such file or directory
```

Because it was already in node_modules (since the instructions say one should run `npx mobx-undercorate`).

This fixed it (locally). Not sure if this is a general fix, another approach would be to `stat` both paths first or run `npm bin jscodeshift` first.

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
