### PR TITLE
Fix the example code error

### DIFF
--- a/docs/understanding-reactivity.md
+++ b/docs/understanding-reactivity.md
@@ -33,10 +33,10 @@ class Message {
     author
     likes
     constructor(title, author, likes) {
-        makeAutoObservable(this)
         this.title = title
         this.author = author
         this.likes = likes
+        makeAutoObservable(this)
     }
 
     updateTitle(title) {


### PR DESCRIPTION
If `makeAutoObservable(this)` doesn't occur to the last line of the `Constructor` scope, then the properties assigned initially later will lose reaction. It's better to add "make sure `makeAutoObservable(this)` occur to the last line" to the best practice。

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [ ] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
