### PR TITLE
Fix #2871 toJS throws with configure({ useProxies: "ifavailable" })

### DIFF
--- a/.changeset/fluffy-coats-fry.md
+++ b/.changeset/fluffy-coats-fry.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix [#2871](https://github.com/mobxjs/mobx/issues/2871): `toJS` throws with `configure({ useProxies: "ifavailable" })`

--- a/packages/mobx/__tests__/v5/base/tojs.js
+++ b/packages/mobx/__tests__/v5/base/tojs.js
@@ -312,7 +312,7 @@ test("#285 non-mobx class instances with toJS", () => {
 })
 
 test("verify #566 solution", () => {
-    function MyClass() {}
+    function MyClass() { }
     const a = new MyClass()
     const b = mobx.observable({ x: 3 })
     const c = mobx.observable({ a: a, b: b })
@@ -366,4 +366,15 @@ describe("recurseEverything set to true", function () {
             `"[MobX] toJS no longer supports options"`
         )
     })
+})
+
+test("Does not throw on object with configure({ useProxies: 'ifavailable'}) #2871", () => {
+    const { useProxies } = mobx._resetGlobalState;
+    mobx.configure({ useProxies: "ifavailable" })
+    expect(() => {
+        const o = mobx.observable({ key: "value" });
+        const dispose = mobx.autorun(() => mobx.toJS(o))
+        dispose();
+    }).not.toThrow();
+    mobx.configure({ useProxies })
 })

--- a/packages/mobx/src/api/tojs.ts
+++ b/packages/mobx/src/api/tojs.ts
@@ -1,12 +1,13 @@
 import {
-    keys,
     isObservable,
     isObservableArray,
     isObservableValue,
     isObservableMap,
     isObservableSet,
-    getPlainObjectKeys,
-    die
+    die,
+    IIsObservableObject,
+    $mobx,
+    objectPrototype
 } from "../internal"
 
 function cache<K, V>(map: Map<any, any>, key: K, value: V): V {
@@ -49,10 +50,11 @@ function toJSHelper(source, __alreadySeen: Map<any, any>) {
         return res
     } else {
         // must be observable object
-        keys(source) // make sure keys are observed
         const res = cache(__alreadySeen, source, {})
-        getPlainObjectKeys(source).forEach((key: any) => {
-            res[key] = toJSHelper(source[key], __alreadySeen)
+        ;((source as any) as IIsObservableObject)[$mobx].ownKeys_().forEach((key: any) => {
+            if (objectPrototype.propertyIsEnumerable.call(source, key)) {
+                res[key] = toJSHelper(source[key], __alreadySeen)
+            }
         })
         return res
     }


### PR DESCRIPTION
Fixes: #2871 in BC manner.

We may want to reconsider which kind fo keys `toJS` returns.

