### PR TITLE
Clarify when reactions effect functions trigger.

### DIFF
--- a/docs/reactions.md
+++ b/docs/reactions.md
@@ -124,6 +124,7 @@ It is important to note that the side effect _only_ reacts to data that was _acc
 
 The typical pattern is that you produce the things you need in your side effect
 in the _data_ function, and in that way control more precisely when the effect triggers.
+By default, the result of the _data_ function has to change in order for the _effect_ function to be triggered.
 Unlike `autorun`, the side effect won't run once when initialized, but only after the data expression returns a new value for the first time.
 
 <details id="reaction-example"><summary>**Example:** the data and effect functions<a href="#reaction-example" class="tip-anchor"></a></summary>


### PR DESCRIPTION
The docs are imo not clear enough on when the effect function of a reaction triggers. 

It's only after I read the notes on the `equals` option that I got  to know that there is an 'extra' check (it being the result of the data function) that determines if an effect is triggered.  I thought after reading the docs that the effect function would always be triggered if any of the dependencies change.

This makes it very easy to create all sorts of bugs if used incorrectly:
https://codesandbox.io/s/mobx-reaction-bug-tyssu?file=/src/index.ts

I added a "By default, the result of the _data_ function has to change in order for the _effect_ function to be triggered." in order to make the behavior more clear.
