### PR TITLE
Give proper typing to opts.equals of reaction

### DIFF
--- a/.changeset/wise-seals-kick.md
+++ b/.changeset/wise-seals-kick.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Give proper typing to opts.equals of reaction

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -2055,6 +2055,23 @@ test("type inference of the action callback", () => {
     }
 })
 
+test("TS - type inference of reaction opts.equals", () => {
+    const data = observable({ a: 23 })
+    mobx.reaction(
+        () => data.a,
+        a => {},
+        {
+            equals: (a, b) => {
+                assert<IsExact<typeof a, string>>(false)
+                assert<IsExact<typeof b, string>>(false)
+                assert<IsExact<typeof a, number>>(true)
+                assert<IsExact<typeof b, number>>(true)
+                return a === b
+            }
+        }
+    )
+})
+
 test("TS - it should support flow as function wrapper", done => {
     const values: number[] = []
 

--- a/packages/mobx/src/api/autorun.ts
+++ b/packages/mobx/src/api/autorun.ts
@@ -86,14 +86,14 @@ export function autorun(
     return reaction.getDisposer_()
 }
 
-export type IReactionOptions = IAutorunOptions & {
+export type IReactionOptions<T> = IAutorunOptions & {
     fireImmediately?: boolean
-    equals?: IEqualsComparer<any>
+    equals?: IEqualsComparer<T>
 }
 
 const run = (f: Lambda) => f()
 
-function createSchedulerFromOptions(opts: IReactionOptions) {
+function createSchedulerFromOptions(opts: IAutorunOptions) {
     return opts.scheduler
         ? opts.scheduler
         : opts.delay
@@ -104,7 +104,7 @@ function createSchedulerFromOptions(opts: IReactionOptions) {
 export function reaction<T>(
     expression: (r: IReactionPublic) => T,
     effect: (arg: T, prev: T, r: IReactionPublic) => void,
-    opts: IReactionOptions = EMPTY_OBJECT
+    opts: IReactionOptions<T> = EMPTY_OBJECT
 ): IReactionDisposer {
     if (__DEV__) {
         if (!isFunction(expression) || !isFunction(effect))
@@ -124,7 +124,7 @@ export function reaction<T>(
     let value: T
     let oldValue: T = undefined as any // only an issue with fireImmediately
 
-    const equals = (opts as any).compareStructural
+    const equals: IEqualsComparer<T> = (opts as any).compareStructural
         ? comparer.structural
         : opts.equals || comparer.default
 


### PR DESCRIPTION
This PR gives the `opts.equals` proper typing so that TypeScript knows that the `equals` function passed to it is comparing values of the return type of `expression` rather than `any`.