### PR TITLE
inject shouldn't change original displayName of component that uses forwardRef

### DIFF
--- a/.changeset/rich-buttons-call.md
+++ b/.changeset/rich-buttons-call.md
@@ -1,0 +1,5 @@
+---
+"mobx-react": minor
+---
+
+inject shouldn't change original displayName of component that uses forwardRef

--- a/packages/mobx-react/__tests__/inject.test.tsx
+++ b/packages/mobx-react/__tests__/inject.test.tsx
@@ -102,6 +102,17 @@ describe("inject based context", () => {
         expect(C.displayName).toBe("inject(ComponentC)")
     })
 
+    test.only("shouldn't change original displayName of component that uses forwardRef", () => {
+        const FancyComp = React.forwardRef((_: any, ref: React.Ref<HTMLDivElement>) => {
+            return <div ref={ref} />
+        })
+        FancyComp.displayName = "FancyComp"
+
+        inject("bla")(FancyComp)
+
+        expect(FancyComp.displayName).toBe("FancyComp")
+    })
+
     // FIXME: see other comments related to error catching in React
     // test does work as expected when running manually
     test("store should be available", () => {

--- a/packages/mobx-react/src/utils/utils.ts
+++ b/packages/mobx-react/src/utils/utils.ts
@@ -56,6 +56,7 @@ const hoistBlackList = {
     getDerivedStateFromError: 1,
     getDerivedStateFromProps: 1,
     mixins: 1,
+    displayName: 1,
     propTypes: 1
 }
 


### PR DESCRIPTION
I think it's best to use `hoist-non-react-statics` https://github.com/mridgway/hoist-non-react-statics, but it was intentionally removed some time ago.

Fixes: #2829.