### PR TITLE
Allow child classes of Map as initializers for ObservableMap

### DIFF
--- a/packages/mobx/__tests__/v5/base/map.js
+++ b/packages/mobx/__tests__/v5/base/map.js
@@ -934,13 +934,22 @@ test("#1583 map.size not reactive", () => {
     expect(sizes).toEqual([0, 1, 2])
 })
 
-test("#1858 Map should not be inherited", () => {
+test("#1858 Map should not be inherited when decorated", () => {
+    class MyMap extends Map {}
+
+    const map = new MyMap()
+    expect(() => {
+        mobx.observable(map)
+    }).toThrow("Cannot initialize from classes that inherit from Map: MyMap")
+})
+
+test("#2980 Map can be inherited when used in plain function", () => {
     class MyMap extends Map {}
 
     const map = new MyMap()
     expect(() => {
         mobx.observable.map(map)
-    }).toThrow("Cannot initialize from classes that inherit from Map: MyMap")
+    }).not.toThrow()
 })
 
 test("#2274", () => {

--- a/packages/mobx/src/api/observable.ts
+++ b/packages/mobx/src/api/observable.ts
@@ -29,7 +29,8 @@ import {
     assign,
     isStringish,
     createObservableAnnotation,
-    createAutoAnnotation
+    createAutoAnnotation,
+    die
 } from "../internal"
 
 export const OBSERVABLE = "observable"
@@ -111,7 +112,10 @@ function createObservable(v: any, arg2?: any, arg3?: any) {
     if (Array.isArray(v)) return observable.array(v, arg2)
 
     // Map
-    if (isES6Map(v)) return observable.map(v, arg2)
+    if (isES6Map(v)) {
+        if (v.constructor !== Map) die(19, v)
+        return observable.map(v, arg2)
+    }
 
     // Set
     if (isES6Set(v)) return observable.set(v, arg2)

--- a/packages/mobx/src/types/observablemap.ts
+++ b/packages/mobx/src/types/observablemap.ts
@@ -319,7 +319,6 @@ export class ObservableMap<K = any, V = any>
                 )
             else if (Array.isArray(other)) other.forEach(([key, value]) => this.set(key, value))
             else if (isES6Map(other)) {
-                if (other.constructor !== Map) die(19, other)
                 other.forEach((value, key) => this.set(key, value))
             } else if (other !== null && other !== undefined) die(20, other)
         })


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->

