### PR TITLE
Allows the force update to be infinitely called

### DIFF
--- a/packages/mobx-react-lite/src/utils/utils.ts
+++ b/packages/mobx-react-lite/src/utils/utils.ts
@@ -3,11 +3,9 @@ import { useCallback, useState } from "react"
 const EMPTY_ARRAY: any[] = []
 
 export function useForceUpdate() {
-    const [, setTick] = useState(0)
+    const [, setRef] = useState({})
 
-    const update = useCallback(() => {
-        setTick(tick => tick + 1)
-    }, EMPTY_ARRAY)
+    const update = useCallback(() => setRef(() => ({})), EMPTY_ARRAY)
 
     return update
 }


### PR DESCRIPTION
This use case is far-fetched but in some contexts (gaming for example) the number of iterations can go beyond the maximum value supported by javascript and end up being `Infinity` which would cause the force update to stop working
because `Infinity + 1 === Infinity` is true in javascript

I didn't added tests as I suppose we don't want to run a tests with a loop of 9007199254740991+ iterations and had some trouble mocking the tick value of `useState`
### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] ~~Updated `/docs`. For new functionality, at least `API.md` should be updated~~
-   [x] Verified that there is no significant performance drop (`npm run perf`)

