### PR TITLE
forceUpdate fix and refactor, alternative to #2982

### DIFF
--- a/.changeset/plenty-rice-love.md
+++ b/.changeset/plenty-rice-love.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+Allow force update to be called infinitely times

--- a/packages/mobx-react-lite/src/useObserver.ts
+++ b/packages/mobx-react-lite/src/useObserver.ts
@@ -1,6 +1,5 @@
 import { Reaction } from "mobx"
 import React from "react"
-
 import { printDebugValue } from "./utils/printDebugValue"
 import {
     addReactionToTrack,
@@ -8,7 +7,6 @@ import {
     recordReactionAsCommitted
 } from "./utils/reactionCleanupTracking"
 import { isUsingStaticRendering } from "./staticRendering"
-import { useForceUpdate } from "./utils/utils"
 
 function observerComponentNameFor(baseComponentName: string) {
     return `observer${baseComponentName}`
@@ -25,8 +23,9 @@ export function useObserver<T>(fn: () => T, baseComponentName: string = "observe
     }
 
     const [objectRetainedByReact] = React.useState(new ObjectToBeRetainedByReact())
-
-    const forceUpdate = useForceUpdate()
+    // Force update, see #2982
+    const [, setState] = React.useState()
+    const forceUpdate = () => setState([] as any)
 
     // StrictMode/ConcurrentMode/Suspense may mean that our component is
     // rendered and abandoned multiple times, so we need to track leaked

--- a/packages/mobx-react-lite/src/utils/utils.ts
+++ b/packages/mobx-react-lite/src/utils/utils.ts
@@ -1,17 +1,3 @@
-import { useCallback, useState } from "react"
-
-const EMPTY_ARRAY: any[] = []
-
-export function useForceUpdate() {
-    const [, setTick] = useState(0)
-
-    const update = useCallback(() => {
-        setTick(tick => tick + 1)
-    }, EMPTY_ARRAY)
-
-    return update
-}
-
 const deprecatedMessages: string[] = []
 
 export function useDeprecated(msg: string) {


### PR DESCRIPTION
1. **removed `useForceUpdate` abstraction**
It was used on single place and impl is trivial.
2. **removed `useCallback`**
`forceUpdate` isn't passed anywhere where it could break memoization, therefore no need for `useCallback`.
The closure is recreated every render one way or another.
3. **Replace increment with unique reference, see #2982.** 
The choice to use `[]` is arbitrary. Feel free to change to whatever performs better.
