### PR TITLE
[Perf] Reduce useObserver gc pressure

### DIFF
--- a/.changeset/reduce-useObserver-gc-pressure.md
+++ b/.changeset/reduce-useObserver-gc-pressure.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+Reduce useObserver gc pressure

--- a/packages/mobx-react-lite/src/useObserver.ts
+++ b/packages/mobx-react-lite/src/useObserver.ts
@@ -19,12 +19,16 @@ function observerComponentNameFor(baseComponentName: string) {
  */
 class ObjectToBeRetainedByReact {}
 
+function objectToBeRetainedByReactFactory() {
+    return new ObjectToBeRetainedByReact()
+}
+
 export function useObserver<T>(fn: () => T, baseComponentName: string = "observed"): T {
     if (isUsingStaticRendering()) {
         return fn()
     }
 
-    const [objectRetainedByReact] = React.useState(new ObjectToBeRetainedByReact())
+    const [objectRetainedByReact] = React.useState(objectToBeRetainedByReactFactory)
 
     const forceUpdate = useForceUpdate()
 


### PR DESCRIPTION
Tiny performance improvement,  create ObjectToBeRetainedByReact once per component instance and not every component render

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
