### PR TITLE
doc: babel assumptions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,8 +22,17 @@ There are two types of React bindings, `mobx-react-lite` supports only functiona
 
 ⚠️ **Warning:** When using MobX with TypeScript and Babel, and you plan to use classes; make sure to update your configuration to use a TC-39 spec compliant transpilation for class fields, since this is not the default. Without this, class fields cannot be made observable before they are initialized.
 
--   For Babel: Make sure to use at least version 7.12. Use the plugin `["@babel/plugin-proposal-class-properties", { "loose": false }]`
--   For TypeScript, set the compiler option `"useDefineForClassFields": true`
+-   **TypeScript**: Set the compiler option `"useDefineForClassFields": true`.
+-   **Babel**: Make sure to use at least version 7.12, with the following configuration:
+    ```json
+    {
+        "plugins": [["@babel/plugin-proposal-class-properties", { "loose": false }]],
+        // Babel >= 7.13.0 (https://babeljs.io/docs/en/assumptions)
+        "assumptions": {
+            "setPublicClassFields": false
+        }
+    }
+    ```
 
 ## MobX on older JavaScript environments
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -170,6 +170,10 @@
       "refguide/set": {
         "title": "Observable Sets"
       },
+      "subclassing": {
+        "title": "Subclassing",
+        "sidebar_label": "Subclassing"
+      },
       "the-gist-of-mobx": {
         "title": "The gist of MobX",
         "sidebar_label": "The gist of MobX"
@@ -181,7 +185,7 @@
     },
     "links": {
       "API Reference": "API Reference",
-      "中文": "中文",
+      "中文(寻求翻译)": "中文(寻求翻译)",
       "Sponsors": "Sponsors",
       "GitHub": "GitHub"
     },

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -185,7 +185,7 @@
     },
     "links": {
       "API Reference": "API Reference",
-      "中文(寻求翻译)": "中文(寻求翻译)",
+      "中文": "中文",
       "Sponsors": "Sponsors",
       "GitHub": "GitHub"
     },

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -52,7 +52,7 @@ const siteConfig = {
     // For no header links in the top nav bar -> headerLinks: [],
     headerLinks: [
         { doc: "api", label: "API Reference" },
-        { href: "https://zh.mobx.js.org", label: "中文(寻求翻译)" },
+        { href: "https://zh.mobx.js.org", label: "中文" },
         { doc: "backers-sponsors", label: "Sponsors" },
         { href: "https://github.com/mobxjs/mobx", label: "GitHub" }
     ],


### PR DESCRIPTION
https://babeljs.io/docs/en/assumptions

> Since Babel 7.13.0, you can specify an assumptions option in your configuration to tell Babel which assumptions it can make about your code, to better optimize the compilation result. Note: this replaces the various loose options in plugins in favor of top-level options that can apply to multiple plugins (RFC link).
