### PR TITLE
docs: Update react-integration.md

### DIFF
--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -245,7 +245,7 @@ as follows, because the `.secondsPassed` is not read inside the `observer` compo
 ```javascript
 const TimerView = observer(({ secondsPassed }) => <span>Seconds passed: {secondsPassed}</span>)
 
-React.render(<TimerViewer secondPassed={myTimer.secondsPassed} />, document.body)
+React.render(<TimerViewer secondsPassed={myTimer.secondsPassed} />, document.body)
 ```
 
 Note that this is a different mindset from other libraries like `react-redux`, where it is a good practice to dereference early and pass primitives down, to better leverage memoization.


### PR DESCRIPTION
Fix a typo in the example demonstrating dereferencing before `observable` is called.