### PR TITLE
chore: keep homepage identically

### DIFF
--- a/packages/mobx-react-lite/package.json
+++ b/packages/mobx-react-lite/package.json
@@ -35,7 +35,7 @@
     "bugs": {
         "url": "https://github.com/mobxjs/mobx/issues"
     },
-    "homepage": "https://mobx.js.org",
+    "homepage": "https://mobx.js.org/",
     "dependencies": {},
     "peerDependencies": {
         "mobx": "^6.1.0",

--- a/packages/mobx-react-lite/package.json
+++ b/packages/mobx-react-lite/package.json
@@ -35,7 +35,7 @@
     "bugs": {
         "url": "https://github.com/mobxjs/mobx/issues"
     },
-    "homepage": "https://mobx.js.org/",
+    "homepage": "https://mobx.js.org",
     "dependencies": {},
     "peerDependencies": {
         "mobx": "^6.1.0",

--- a/packages/mobx-react/package.json
+++ b/packages/mobx-react/package.json
@@ -34,7 +34,7 @@
     "bugs": {
         "url": "https://github.com/mobxjs/mobx/issues"
     },
-    "homepage": "http://mobx.js.org/",
+    "homepage": "https://mobx.js.org/",
     "dependencies": {
         "mobx-react-lite": "^3.2.0"
     },

--- a/packages/mobx-react/package.json
+++ b/packages/mobx-react/package.json
@@ -34,7 +34,7 @@
     "bugs": {
         "url": "https://github.com/mobxjs/mobx/issues"
     },
-    "homepage": "https://mobx.js.org/",
+    "homepage": "https://mobx.js.org",
     "dependencies": {
         "mobx-react-lite": "^3.2.0"
     },


### PR DESCRIPTION
Keep all subpackage homepage is same as mobx: `https://mobx.js.org/`