### PR TITLE
Create WHEN_TIMEOUT error earlier to capture useful stack

### DIFF
--- a/.changeset/many-moons-turn.md
+++ b/.changeset/many-moons-turn.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Create WHEN_TIMEOUT error earlier to capture useful stack

--- a/packages/mobx/src/api/when.ts
+++ b/packages/mobx/src/api/when.ts
@@ -33,10 +33,10 @@ export function when(predicate: any, arg1?: any, arg2?: any): any {
 function _when(predicate: () => boolean, effect: Lambda, opts: IWhenOptions): IReactionDisposer {
     let timeoutHandle: any
     if (typeof opts.timeout === "number") {
+        const error = new Error("WHEN_TIMEOUT")
         timeoutHandle = setTimeout(() => {
             if (!disposer[$mobx].isDisposed_) {
                 disposer()
-                const error = new Error("WHEN_TIMEOUT")
                 if (opts.onError) opts.onError(error)
                 else throw error
             }


### PR DESCRIPTION
Currently, the `WHEN_TIMEOUT` error is thrown from a `setTimeout`, which usually contains no stack itself, this makes it impossible to distinguish between different places throwing it, and hard to track where it is from, and thus make it a high-frequency error in our logging which is basically not actionable.

This PR creates the error earlier when the `when` starts, so that it preserves the stack on where the `when` is called.

Unconditionally creating an error might slightly regress the performance of `when`, but it only happens when `timeout` is specified. And `when` itself is probably not all that performance-critical anyway I suppose.

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
