### PR TITLE
refactor(docs): replace event stop propagation with prevent default in actions page

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -140,7 +140,7 @@ const ResetButton = ({ formState }) => (
         onClick={action(e => {
             formState.resetPendingUploads()
             formState.resetValues()
-            e.stopPropagation()
+            e.preventDefault()
         })}
     >
         Reset form


### PR DESCRIPTION
Developers should avoid using `event.stopPropagation()`

See https://css-tricks.com/dangers-stopping-event-propagation/ for the dangers

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
