### PR TITLE
Idea: jsx runtime that warns about missing observer

### DIFF
--- a/packages/mobx-react/src/index.ts
+++ b/packages/mobx-react/src/index.ts
@@ -1,5 +1,6 @@
 import { observable } from "mobx"
-import { Component } from "react"
+import { Component, createElement as _createElement } from "react"
+import { checkMissingObserver } from './jsx-runtime';
 
 if (!Component) throw new Error("mobx-react requires React to be available")
 if (!observable) throw new Error("mobx-react requires mobx to be available")
@@ -23,3 +24,8 @@ export { inject } from "./inject"
 export { disposeOnUnmount } from "./disposeOnUnmount"
 export { PropTypes } from "./propTypes"
 export { IWrappedComponent } from "./types/IWrappedComponent"
+
+export function createElement(type, props, children) {
+    checkMissingObserver(type, props);
+    return _createElement(type, props, children);
+}

--- a/packages/mobx-react/src/jsx-runtime.ts
+++ b/packages/mobx-react/src/jsx-runtime.ts
@@ -1,0 +1,32 @@
+import { jsx as _jsx } from 'react/jsx-runtime';
+import { isObservable } from 'mobx';
+import { getDisplayName, mobxObserverProperty } from './observerClass';
+
+export function checkMissingObserver(type, props) {
+  if (__DEV__
+    // actual component (not string, etc)
+    && type && (typeof type === 'object' || typeof type === 'function')
+    // not an observer
+    && type[mobxObserverProperty] !== true
+  ) {
+    // Symbols are not supported by React (non-enumerables presumably neither)
+    // https://github.com/facebook/react/issues/7552#issuecomment-806020985
+    Object.keys(props).forEach(key => {
+      const prop = props[key];
+      if (isObservable(prop)) {
+        const componentName = getDisplayName(type);
+        console.warn(
+          `[mobx-react] Prop \`${key}\` is observable, but \`${componentName}\` is not an observer.`
+          + `\nEither wrap the component with \`observer\` or use \`toJS\` utility to pass non-observable copy instead, eg:`
+          + `\n\`<${componentName} ${key}={toJS(value)} />\``
+          + `\nSee: https://mobx.js.org/react-integration.html#dont-pass-observables-into-components-that-arent-observer`
+        );
+      }
+    })
+  }
+}
+
+export function jsx(type: any, props: any, key: any) {
+  checkMissingObserver(type, props);
+  return _jsx(type, props, key);
+}

--- a/packages/mobx-react/src/jsx-runtime.ts
+++ b/packages/mobx-react/src/jsx-runtime.ts
@@ -18,7 +18,7 @@ export function checkMissingObserver(type, props) {
         console.warn(
           `[mobx-react] Prop \`${key}\` is observable, but \`${componentName}\` is not an observer.`
           + `\nEither wrap the component with \`observer\` or use \`toJS\` utility to pass non-observable copy instead, eg:`
-          + `\n\`<${componentName} ${key}={toJS(value)} />\``
+          + `\n\`<NotObserver ${key}={toJS(value)} />\``
           + `\nSee: https://mobx.js.org/react-integration.html#dont-pass-observables-into-components-that-arent-observer`
         );
       }

--- a/packages/mobx-react/src/observer.tsx
+++ b/packages/mobx-react/src/observer.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { observer as observerLite, Observer } from "mobx-react-lite"
 
-import { makeClassComponentObserver } from "./observerClass"
+import { makeClassComponentObserver, mobxObserverProperty } from "./observerClass"
 import { IReactComponent } from "./types/IReactComponent"
 
 const hasSymbol = typeof Symbol === "function" && Symbol.for
@@ -51,7 +51,8 @@ export function observer<T extends IReactComponent>(component: T): T {
         !component["isReactClass"] &&
         !Object.prototype.isPrototypeOf.call(React.Component, component)
     ) {
-        return observerLite(component as React.StatelessComponent<any>) as T
+        const observerComponent = observerLite(component as React.StatelessComponent<any>) as T
+        observerComponent[mobxObserverProperty] = true;
     }
 
     return makeClassComponentObserver(component as React.ComponentClass<any, any>) as T

--- a/packages/mobx-react/src/observerClass.ts
+++ b/packages/mobx-react/src/observerClass.ts
@@ -12,7 +12,7 @@ import { isUsingStaticRendering } from "mobx-react-lite"
 import { newSymbol, shallowEqual, setHiddenProp, patch } from "./utils/utils"
 
 const mobxAdminProperty = $mobx || "$mobx"
-const mobxObserverProperty = newSymbol("isMobXReactObserver")
+export const mobxObserverProperty = newSymbol("isMobXReactObserver")
 const mobxIsUnmounted = newSymbol("isUnmounted")
 const skipRenderKey = newSymbol("skipRender")
 const isForcingUpdateKey = newSymbol("isForcingUpdate")
@@ -81,7 +81,7 @@ export function makeClassComponentObserver(
 }
 
 // Generates a friendly name for debugging
-function getDisplayName(comp: any) {
+export function getDisplayName(comp: any) {
     return (
         comp.displayName ||
         comp.name ||


### PR DESCRIPTION
With [the new JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html), we can basically provide own `createElement` implementation:
```javascript
// .babelrc
module.exports = {
  "presets": [
    [
      "@babel/preset-react",
      {        
         "importSource": "mobx-react"
      }
    ]
  ]
}
```
So the idea is to use it to make sure that observable props can be passed only to `observer`.