### PR TITLE
Have cancelled when reject with an error

### DIFF
--- a/.changeset/fuzzy-suits-sniff.md
+++ b/.changeset/fuzzy-suits-sniff.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Have cancelled when reject with an error rather than a string

--- a/packages/mobx/src/api/when.ts
+++ b/packages/mobx/src/api/when.ts
@@ -72,7 +72,7 @@ function whenPromise(
         let disposer = _when(predicate, resolve, { ...opts, onError: reject })
         cancel = () => {
             disposer()
-            reject("WHEN_CANCELLED")
+            reject(new Error("WHEN_CANCELLED"))
         }
     })
     ;(res as any).cancel = cancel


### PR DESCRIPTION
Similar to #3056, when a `when` is cancelled, the promise is rejected with a plain string of `WHEN_CANCELLED`. When such rejection is not handled, they would trigger an `unhandledrejection` event which may have a global hook registered for catching any unexpected error. In a large code base, it is pretty hard to know where a cancel happens when such rejection is caught and whether there needs something to be done to handle it.

This PR changes the string to an error, matching what we have with `WHEN_TIMEOUT`. Note that I don't create the error on start of the function this time because I expect `cancel` call itself would have stack that's good enough to identify the location, unlike `WHEN_TIMEOUT` which has the error thrown out from a top level timeout.

Again, creating an error with stack may slightly regress performance, but this time it only happens when it's cancelled, and `when` is probably not very performance critical in general.

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
