### PR TITLE
fix(undecorate): add support for default export classes + fix eslint-plugin-react compat

### DIFF
--- a/.changeset/dirty-ears-push.md
+++ b/.changeset/dirty-ears-push.md
@@ -1,0 +1,5 @@
+---
+"mobx-undecorate": minor
+---
+
+add support for default export classes + fix eslint-plugin-react compatibility

--- a/packages/mobx-undecorate/__tests__/undecorate.spec.ts
+++ b/packages/mobx-undecorate/__tests__/undecorate.spec.ts
@@ -1342,3 +1342,39 @@ test("makeObservable not added to imports #2540", () => {
         }"
     `)
 })
+
+test("class default export comp with observer and inject", () => {
+    expect(
+        convert(`
+        import {observer, inject} from 'mobx-react'
+        
+        @inject("test") @observer export default class X extends React.Component {}
+    `)
+    ).toMatchInlineSnapshot(`
+        "import {observer, inject} from 'mobx-react'
+        
+        class X extends React.Component {}
+        export default inject(\\"test\\")(observer(X));"
+    `)
+})
+
+test("class default export comp with observer and inject", () => {
+    expect(
+        convert(`
+        import {observer, inject} from 'mobx-react'
+        import {withRouter} from 'react-router-dom'
+
+        @inject("test") @observer class X extends React.Component {}
+
+        export default withRouter(X)
+
+    `)
+    ).toMatchInlineSnapshot(`
+        "import {observer, inject} from 'mobx-react'
+        import {withRouter} from 'react-router-dom'
+
+        class X extends React.Component {}
+        
+        export default withRouter(inject(\\"test\\")(observer(X)))"
+    `)
+})


### PR DESCRIPTION
Hi!

This PR is doing the following changes to `mobx/undecorate` codemod: 
- Add support for modules with default export on the same line as the class declaration.
Currently the codemod produce a broken output if you use default exports for your classes in the following way:
```js
import {observer, inject} from 'mobx-react'

@inject('test')
@observer
export default class X extends React.Component {}
```
- HoC are now separately wrapping the class at the export level, instead of at the declaration level. This fixes a bug where linting was broken after using the codemod if codebase was using `eslint-plugin-react`, because the [prop-types plugin](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md) could not anymore work (due to the HoC wrapping the entire class).

This basically means going from this transformation:
```js
import {observer, inject} from 'mobx-react'

export const X = inject('test')(observer(class X extends React.Component {}))
```

to that:

```js
import {observer, inject} from 'mobx-react'

class X extends React.Component {}

export inject('test')(observer(X))
```

This way I managed to migrate a project with ~150 components to mobx 6 👍 

That's it! Let me know what you think 😄  Hope this can help someone to migrate more easily 🙏 

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
