### PR TITLE
add comment to help react-native users avoid react bug with flatlist

### DIFF
--- a/docs/enabling-decorators.md
+++ b/docs/enabling-decorators.md
@@ -79,6 +79,7 @@ Install support for decorators: `npm i --save-dev @babel/plugin-proposal-class-p
 {
     "plugins": [
         ["@babel/plugin-proposal-decorators", { "legacy": true }],
+        //["@babel/plugin-transform-flow-strip-types"], //for those using react, this plugin is required to avoid a certain error in flatlists. see https://github.com/facebook/react-native/issues/21154
         ["@babel/plugin-proposal-class-properties", { "loose": false }]
         // In contrast to MobX 4/5, "loose" must be false!    ^
     ]


### PR DESCRIPTION
There's a pretty insidious bug (https://github.com/facebook/react-native/issues/21154) where after following the original instructions, the app works seemingly fine. But it's not until the cache of the webpack server is reset that you find out that everything breaks. The error is not that specfiic and trackign it down to this babel change takes a while. Hopefully this will help others out there with the same problem. 

The location / wording could use work but just wanted to get this process started

