### PR TITLE
Fix type inference of observe function (Close #3179)

### DIFF
--- a/.changeset/moody-kids-punch.md
+++ b/.changeset/moody-kids-punch.md
@@ -1,0 +1,5 @@
+---
+"mobx": minor
+---
+
+Fix type inference of observe function

--- a/.changeset/moody-kids-punch.md
+++ b/.changeset/moody-kids-punch.md
@@ -1,5 +1,5 @@
 ---
-"mobx": minor
+"mobx": patch
 ---
 
 Fix type inference of observe function

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -2115,6 +2115,11 @@ test("TS - type inference of observe function", () => {
     observe(store.set, argument => {
         assert<IsExact<typeof argument, ISetDidChange<number>>>(true)
     })
+
+    // set created with observable.set
+    observe(store.setMobxFactory, argument => {
+        assert<IsExact<typeof argument, ISetDidChange<number>>>(true)
+    })
 })
 
 test("TS - type inference of reaction opts.equals", () => {

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -25,10 +25,12 @@ import {
     createAtom,
     runInAction,
     flow,
+    IMapDidChange,
+    IValueDidChange,
+    ISetDidChange,
     flowResult
 } from "../../../src/mobx"
 import * as mobx from "../../../src/mobx"
-// @ts-ignore
 import { assert, IsExact } from "conditional-type-checks"
 
 const v = observable.box(3)
@@ -2071,6 +2073,48 @@ test("type inference of the action callback", () => {
             assert<IsExact<typeof a3, boolean>>(true)
         })
     }
+})
+
+test("TS - type inference of observe function", () => {
+    const store = observable({
+        map: new Map<string, number>([["testKey", 1]]),
+        mapMobxFactory: observable.map<string, number>([["testKey", 1]]),
+        regularObject: { numberKey: 1, stringKey: "string" },
+        set: new Set<number>(),
+        setMobxFactory: observable.set<number>()
+    })
+
+    // Regular object
+    observe(store.regularObject, argument => {
+        assert<IsExact<typeof argument, IObjectDidChange>>(true)
+    })
+
+    observe(store.regularObject, "numberKey", argument => {
+        assert<IsExact<typeof argument, IValueDidChange<number>>>(true)
+    })
+
+    // Regular map
+    observe(store.map, argument => {
+        assert<IsExact<typeof argument, IMapDidChange<string, number>>>(true)
+    })
+
+    observe(store.map, "testKey", argument => {
+        assert<IsExact<typeof argument, IValueDidChange<number>>>(true)
+    })
+
+    // Map created with observable.map
+    observe(store.mapMobxFactory, argument => {
+        assert<IsExact<typeof argument, IMapDidChange<string, number>>>(true)
+    })
+
+    observe(store.mapMobxFactory, "testKey", argument => {
+        assert<IsExact<typeof argument, IValueDidChange<number>>>(true)
+    })
+
+    // Regular set
+    observe(store.set, argument => {
+        assert<IsExact<typeof argument, ISetDidChange<number>>>(true)
+    })
 })
 
 test("TS - type inference of reaction opts.equals", () => {

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -2116,7 +2116,7 @@ test("TS - type inference of observe function", () => {
         assert<IsExact<typeof argument, ISetDidChange<number>>>(true)
     })
 
-    // set created with observable.set
+    // Set created with observable.set
     observe(store.setMobxFactory, argument => {
         assert<IsExact<typeof argument, ISetDidChange<number>>>(true)
     })

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -28,6 +28,8 @@ import {
     IMapDidChange,
     IValueDidChange,
     ISetDidChange,
+    ISetWillChange,
+    IValueWillChange,
     flowResult
 } from "../../../src/mobx"
 import * as mobx from "../../../src/mobx"
@@ -206,32 +208,6 @@ test("scope", () => {
     t.equal(x3.z, 8)
 })
 
-test("typing", () => {
-    const ar: IObservableArray<number> = observable([1, 2])
-    mobx.intercept(ar, (c: IArrayWillChange<number> | IArrayWillSplice<number>) => {
-        // console.log(c.type)
-        return null
-    })
-    mobx.observe(ar, (d: IArrayDidChange<number>) => {
-        // console.log(d.type)
-    })
-
-    const ar2: IObservableArray<number> = observable([1, 2])
-    mobx.intercept(ar2, (c: IArrayWillChange<number> | IArrayWillSplice<number>) => {
-        // console.log(c.type)
-        return null
-    })
-    mobx.observe(ar2, (d: IArrayDidChange<number>) => {
-        // console.log(d.type)
-    })
-
-    const x: IObservableValue<number> = observable.box(3)
-})
-
-const state: any = observable({
-    authToken: null
-})
-
 test("box", () => {
     class Box {
         uninitialized: any
@@ -280,6 +256,8 @@ test("box", () => {
     t.deepEqual(ar.slice(), [40, 20, 60, 210, 420])
     box.addSize()
     expect(ar.slice()).toEqual([40, 20, 60, 210, 420, 700])
+
+    const x: IObservableValue<number> = observable.box(3)
 })
 
 test("computed setter should succeed", () => {
@@ -2075,50 +2053,81 @@ test("type inference of the action callback", () => {
     }
 })
 
-test("TS - type inference of observe function", () => {
+test("TS - type inference of observe & intercept functions", () => {
     const store = observable({
         map: new Map<string, number>([["testKey", 1]]),
-        mapMobxFactory: observable.map<string, number>([["testKey", 1]]),
         regularObject: { numberKey: 1, stringKey: "string" },
-        set: new Set<number>(),
-        setMobxFactory: observable.set<number>()
+        set: new Set<number>()
     })
+    const mapMobxFactory = observable.map<string, number>([["testKey", 1]])
+    const setMobxFactory = observable.set<number>()
 
-    // Regular object
-    observe(store.regularObject, argument => {
+    // Observe regular object
+    mobx.observe(store.regularObject, argument => {
         assert<IsExact<typeof argument, IObjectDidChange>>(true)
     })
 
-    observe(store.regularObject, "numberKey", argument => {
+    // Observe regular object key
+    mobx.observe(store.regularObject, "numberKey", argument => {
         assert<IsExact<typeof argument, IValueDidChange<number>>>(true)
     })
 
-    // Regular map
-    observe(store.map, argument => {
+    // Intercept regular object key
+    mobx.intercept(store.regularObject, "numberKey", argument => {
+        assert<IsExact<typeof argument, IValueWillChange<number>>>(true)
+        return null
+    })
+
+    // Observe regular map
+    mobx.observe(store.map, argument => {
         assert<IsExact<typeof argument, IMapDidChange<string, number>>>(true)
     })
 
-    observe(store.map, "testKey", argument => {
+    // Observe regular map key
+    mobx.observe(store.map, "testKey", argument => {
         assert<IsExact<typeof argument, IValueDidChange<number>>>(true)
     })
 
-    // Map created with observable.map
-    observe(store.mapMobxFactory, argument => {
+    // Intercept regular map key
+    mobx.intercept(store.map, "testKey", argument => {
+        assert<IsExact<typeof argument, IValueWillChange<number>>>(true)
+        return null
+    })
+
+    // Observe map created with observable.map
+    mobx.observe(mapMobxFactory, argument => {
         assert<IsExact<typeof argument, IMapDidChange<string, number>>>(true)
     })
 
-    observe(store.mapMobxFactory, "testKey", argument => {
+    // Observe map key created with observable.map
+    mobx.observe(mapMobxFactory, "testKey", argument => {
         assert<IsExact<typeof argument, IValueDidChange<number>>>(true)
     })
 
-    // Regular set
-    observe(store.set, argument => {
+    // Observe regular set
+    mobx.observe(store.set, argument => {
         assert<IsExact<typeof argument, ISetDidChange<number>>>(true)
     })
 
-    // Set created with observable.set
-    observe(store.setMobxFactory, argument => {
+    // Intercept regular set
+    mobx.intercept(store.set, argument => {
+        assert<IsExact<typeof argument, ISetWillChange<number>>>(true)
+        return null
+    })
+
+    // Observe set created with observable.set
+    mobx.observe(setMobxFactory, argument => {
         assert<IsExact<typeof argument, ISetDidChange<number>>>(true)
+    })
+
+    const ar: IObservableArray<number> = observable([1, 2])
+    mobx.observe(ar, d => {
+        assert<IsExact<typeof d, IArrayDidChange<number>>>(true)
+    })
+
+    mobx.intercept(ar, c => {
+        assert<IsExact<typeof c, IArrayWillChange<number> | IArrayWillSplice<number>>>(true)
+        return null
     })
 })
 

--- a/packages/mobx/src/api/intercept.ts
+++ b/packages/mobx/src/api/intercept.ts
@@ -24,15 +24,15 @@ export function intercept<T>(
     handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>
 ): Lambda
 export function intercept<K, V>(
-    observableMap: ObservableMap<K, V>,
+    observableMap: ObservableMap<K, V> | Map<K, V>,
     handler: IInterceptor<IMapWillChange<K, V>>
 ): Lambda
 export function intercept<V>(
-    observableMap: ObservableSet<V>,
+    observableSet: ObservableSet<V> | Set<V>,
     handler: IInterceptor<ISetWillChange<V>>
 ): Lambda
 export function intercept<K, V>(
-    observableMap: ObservableMap<K, V>,
+    observableMap: ObservableMap<K, V> | Map<K, V>,
     property: K,
     handler: IInterceptor<IValueWillChange<V>>
 ): Lambda
@@ -40,7 +40,7 @@ export function intercept(object: object, handler: IInterceptor<IObjectWillChang
 export function intercept<T extends object, K extends keyof T>(
     object: T,
     property: K,
-    handler: IInterceptor<IValueWillChange<any>>
+    handler: IInterceptor<IValueWillChange<T[K]>>
 ): Lambda
 export function intercept(thing, propOrHandler?, handler?): Lambda {
     if (isFunction(handler)) return interceptProperty(thing, propOrHandler, handler)

--- a/packages/mobx/src/api/observe.ts
+++ b/packages/mobx/src/api/observe.ts
@@ -25,17 +25,17 @@ export function observe<T>(
     fireImmediately?: boolean
 ): Lambda
 export function observe<V>(
-    observableMap: ObservableSet<V>,
+    observableMap: ObservableSet<V> | Set<V>,
     listener: (change: ISetDidChange<V>) => void,
     fireImmediately?: boolean
 ): Lambda
 export function observe<K, V>(
-    observableMap: ObservableMap<K, V>,
+    observableMap: ObservableMap<K, V> | Map<K, V>,
     listener: (change: IMapDidChange<K, V>) => void,
     fireImmediately?: boolean
 ): Lambda
 export function observe<K, V>(
-    observableMap: ObservableMap<K, V>,
+    observableMap: ObservableMap<K, V> | Map<K, V>,
     property: K,
     listener: (change: IValueDidChange<V>) => void,
     fireImmediately?: boolean

--- a/packages/mobx/src/api/observe.ts
+++ b/packages/mobx/src/api/observe.ts
@@ -7,7 +7,9 @@ import {
     IObservableValue,
     IValueDidChange,
     Lambda,
+    ObservableMap,
     getAdministration,
+    ObservableSet,
     ISetDidChange,
     isFunction
 } from "../internal"
@@ -23,17 +25,18 @@ export function observe<T>(
     fireImmediately?: boolean
 ): Lambda
 export function observe<V>(
-    observableSet: Set<V>,
+    // ObservableSet/ObservableMap are required despite they implement Set/Map: https://github.com/mobxjs/mobx/pull/3180#discussion_r746542929
+    observableSet: ObservableSet<V> | Set<V>,
     listener: (change: ISetDidChange<V>) => void,
     fireImmediately?: boolean
 ): Lambda
 export function observe<K, V>(
-    observableMap: Map<K, V>,
+    observableMap: ObservableMap<K, V> | Map<K, V>,
     listener: (change: IMapDidChange<K, V>) => void,
     fireImmediately?: boolean
 ): Lambda
 export function observe<K, V>(
-    observableMap: Map<K, V>,
+    observableMap: ObservableMap<K, V> | Map<K, V>,
     property: K,
     listener: (change: IValueDidChange<V>) => void,
     fireImmediately?: boolean

--- a/packages/mobx/src/api/observe.ts
+++ b/packages/mobx/src/api/observe.ts
@@ -7,9 +7,7 @@ import {
     IObservableValue,
     IValueDidChange,
     Lambda,
-    ObservableMap,
     getAdministration,
-    ObservableSet,
     ISetDidChange,
     isFunction
 } from "../internal"
@@ -25,17 +23,17 @@ export function observe<T>(
     fireImmediately?: boolean
 ): Lambda
 export function observe<V>(
-    observableMap: ObservableSet<V> | Set<V>,
+    observableSet: Set<V>,
     listener: (change: ISetDidChange<V>) => void,
     fireImmediately?: boolean
 ): Lambda
 export function observe<K, V>(
-    observableMap: ObservableMap<K, V> | Map<K, V>,
+    observableMap: Map<K, V>,
     listener: (change: IMapDidChange<K, V>) => void,
     fireImmediately?: boolean
 ): Lambda
 export function observe<K, V>(
-    observableMap: ObservableMap<K, V> | Map<K, V>,
+    observableMap: Map<K, V>,
     property: K,
     listener: (change: IValueDidChange<V>) => void,
     fireImmediately?: boolean


### PR DESCRIPTION
### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`npm run perf`)

Fixes: https://github.com/mobxjs/mobx/issues/3179

Both Map & Set resulted in wrong type inference. Now the correct type inference is covered with tests.