### PR TITLE
Fix: RangeError in ObservableArray.replace for large arrays

### DIFF
--- a/.changeset/ninety-rings-move.md
+++ b/.changeset/ninety-rings-move.md
@@ -1,0 +1,5 @@
+---
+"mobx": minor
+---
+
+Fix for RangeError in ObservableArray.replace for large arrays

--- a/.changeset/ninety-rings-move.md
+++ b/.changeset/ninety-rings-move.md
@@ -1,5 +1,5 @@
 ---
-"mobx": minor
+"mobx": patch
 ---
 
 Fix for RangeError in ObservableArray.replace for large arrays

--- a/packages/mobx/__tests__/v5/base/observables.js
+++ b/packages/mobx/__tests__/v5/base/observables.js
@@ -2192,34 +2192,60 @@ test("options can be provided only once", () => {
     }).toThrow(error)
 })
 
-test("observablearray.replace", () => {
+test("ObservableArray.replace", () => {
     // both lists are small
     let ar = observable([1])
     let del = ar.replace([2])
-    expect([2]).toEqual(ar.toJSON())
-    expect([1]).toEqual(del)
+    expect(ar.toJSON()).toEqual([2])
+    expect(del).toEqual([1])
 
     // the replacement is large
     ar = observable([1])
     del = ar.replace(new Array(MAX_SPLICE_SIZE))
-    expect(MAX_SPLICE_SIZE).toEqual(ar.length)
-    expect([1]).toEqual(del)
+    expect(ar.length).toEqual(MAX_SPLICE_SIZE)
+    expect(del).toEqual([1])
 
     // the original is large
     ar = observable(new Array(MAX_SPLICE_SIZE))
     del = ar.replace([2])
-    expect([2]).toEqual(ar)
-    expect(MAX_SPLICE_SIZE).toEqual(del.length)
+    expect(ar).toEqual([2])
+    expect(del.length).toEqual(MAX_SPLICE_SIZE)
 
     // both are large; original larger than replacement
     ar = observable(new Array(MAX_SPLICE_SIZE + 1))
     del = ar.replace(new Array(MAX_SPLICE_SIZE))
-    expect(MAX_SPLICE_SIZE).toEqual(ar.length)
-    expect(MAX_SPLICE_SIZE + 1).toEqual(del.length)
+    expect(ar.length).toEqual(MAX_SPLICE_SIZE)
+    expect(del.length).toEqual(MAX_SPLICE_SIZE + 1)
 
     // both are large; replacement larger than original
     ar = observable(new Array(MAX_SPLICE_SIZE))
     del = ar.replace(new Array(MAX_SPLICE_SIZE + 1))
-    expect(MAX_SPLICE_SIZE + 1).toEqual(ar.length)
-    expect(MAX_SPLICE_SIZE).toEqual(del.length)
+    expect(ar.length).toEqual(MAX_SPLICE_SIZE + 1)
+    expect(del.length).toEqual(MAX_SPLICE_SIZE)
+})
+
+test("ObservableArray.splice", () => {
+    // Deleting 1 item from a large list
+    let ar = observable(new Array(MAX_SPLICE_SIZE + 1))
+    let del = ar.splice(1, 1)
+    expect(ar.length).toEqual(MAX_SPLICE_SIZE)
+    expect(del.length).toEqual(1)
+
+    // Deleting many items from a large list
+    ar = observable(new Array(MAX_SPLICE_SIZE + 2))
+    del = ar.splice(1, MAX_SPLICE_SIZE + 1)
+    expect(ar.length).toEqual(1)
+    expect(del.length).toEqual(MAX_SPLICE_SIZE + 1)
+
+    // Deleting 1 item from a large list and inserting many items
+    ar = observable(new Array(MAX_SPLICE_SIZE + 1))
+    del = ar.splice(1, 1, ...new Array(MAX_SPLICE_SIZE + 1))
+    expect(ar.length).toEqual(MAX_SPLICE_SIZE * 2 + 1)
+    expect(del.length).toEqual(1)
+
+    // Deleting many items from a large list and inserting many items
+    ar = observable(new Array(MAX_SPLICE_SIZE + 10))
+    del = ar.splice(1, MAX_SPLICE_SIZE + 1, ...new Array(MAX_SPLICE_SIZE + 1))
+    expect(ar.length).toEqual(MAX_SPLICE_SIZE + 10)
+    expect(del.length).toEqual(MAX_SPLICE_SIZE + 1)
 })

--- a/packages/mobx/__tests__/v5/base/observables.js
+++ b/packages/mobx/__tests__/v5/base/observables.js
@@ -2192,24 +2192,34 @@ test("options can be provided only once", () => {
     }).toThrow(error)
 })
 
-test("observablearray.replace ", () => {
-    // two paths to check:
-    // - arrays smaller MAX_SPLICE_SIZE
-    const ar1 = observable([1])
-    const del1 = ar1.replace([2])
-    expect([2]).toEqual(ar1.toJSON())
-    expect([1]).toEqual(del1)
+test("observablearray.replace", () => {
+    // both lists are small
+    let ar = observable([1])
+    let del = ar.replace([2])
+    expect([2]).toEqual(ar.toJSON())
+    expect([1]).toEqual(del)
 
-    // - arrays larger than MAX_SPLICE_SIZE
-    //   - replacement is larger than current array
-    const ar2 = observable(new Array(MAX_SPLICE_SIZE))
-    const del2 = ar2.replace(new Array(MAX_SPLICE_SIZE + 1))
-    expect(MAX_SPLICE_SIZE + 1).toEqual(ar2.length)
-    expect(MAX_SPLICE_SIZE).toEqual(del2.length)
+    // the replacement is large
+    ar = observable([1])
+    del = ar.replace(new Array(MAX_SPLICE_SIZE))
+    expect(MAX_SPLICE_SIZE).toEqual(ar.length)
+    expect([1]).toEqual(del)
 
-    //   - replacement is smaller than current array
-    const ar3 = observable(new Array(MAX_SPLICE_SIZE + 1))
-    const del3 = ar3.replace(new Array(MAX_SPLICE_SIZE))
-    expect(MAX_SPLICE_SIZE).toEqual(ar3.length)
-    expect(MAX_SPLICE_SIZE + 1).toEqual(del3.length)
+    // the original is large
+    ar = observable(new Array(MAX_SPLICE_SIZE))
+    del = ar.replace([2])
+    expect([2]).toEqual(ar)
+    expect(MAX_SPLICE_SIZE).toEqual(del.length)
+
+    // both are large; original larger than replacement
+    ar = observable(new Array(MAX_SPLICE_SIZE + 1))
+    del = ar.replace(new Array(MAX_SPLICE_SIZE))
+    expect(MAX_SPLICE_SIZE).toEqual(ar.length)
+    expect(MAX_SPLICE_SIZE + 1).toEqual(del.length)
+
+    // both are large; replacement larger than original
+    ar = observable(new Array(MAX_SPLICE_SIZE))
+    del = ar.replace(new Array(MAX_SPLICE_SIZE + 1))
+    expect(MAX_SPLICE_SIZE + 1).toEqual(ar.length)
+    expect(MAX_SPLICE_SIZE).toEqual(del.length)
 })

--- a/packages/mobx/__tests__/v5/base/observables.js
+++ b/packages/mobx/__tests__/v5/base/observables.js
@@ -15,6 +15,7 @@ const {
     isObservableProp
 } = mobx
 const utils = require("../../v5/utils/test-utils")
+const { MAX_SPLICE_SIZE } = require("../../../src/internal")
 
 const voidObserver = function () {}
 
@@ -2189,4 +2190,26 @@ test("options can be provided only once", () => {
         o.y = 0
         makeObservable(o, { y: observable }, {})
     }).toThrow(error)
+})
+
+test("observablearray.replace ", () => {
+    // two paths to check:
+    // - arrays smaller MAX_SPLICE_SIZE
+    const ar1 = observable([1])
+    const del1 = ar1.replace([2])
+    expect([2]).toEqual(ar1.toJSON())
+    expect([1]).toEqual(del1)
+
+    // - arrays larger than MAX_SPLICE_SIZE
+    //   - replacement is larger than current array
+    const ar2 = observable(new Array(MAX_SPLICE_SIZE))
+    const del2 = ar2.replace(new Array(MAX_SPLICE_SIZE + 1))
+    expect(MAX_SPLICE_SIZE + 1).toEqual(ar2.length)
+    expect(MAX_SPLICE_SIZE).toEqual(del2.length)
+
+    //   - replacement is smaller than current array
+    const ar3 = observable(new Array(MAX_SPLICE_SIZE + 1))
+    const del3 = ar3.replace(new Array(MAX_SPLICE_SIZE))
+    expect(MAX_SPLICE_SIZE).toEqual(ar3.length)
+    expect(MAX_SPLICE_SIZE + 1).toEqual(del3.length)
 })

--- a/packages/mobx/src/types/observablearray.ts
+++ b/packages/mobx/src/types/observablearray.ts
@@ -236,9 +236,12 @@ export class ObservableArrayAdministration
         if (newItems.length < MAX_SPLICE_SIZE) {
             return this.values_.splice(index, deleteCount, ...newItems)
         } else {
+            // The items removed by the splice
             const res = this.values_.slice(index, index + deleteCount)
+            // The items that that should remain at the end of the array
             let oldItems = this.values_.slice(index + deleteCount)
-            this.values_.length = index + newItems.length
+            // New length is the previous length + addition count - deletion count
+            this.values_.length += newItems.length - deleteCount
             for (let i = 0; i < newItems.length; i++) this.values_[index + i] = newItems[i]
             for (let i = 0; i < oldItems.length; i++)
                 this.values_[index + newItems.length + i] = oldItems[i]

--- a/packages/mobx/src/types/observablearray.ts
+++ b/packages/mobx/src/types/observablearray.ts
@@ -175,7 +175,8 @@ export class ObservableArrayAdministration
     }
 
     setArrayLength_(newLength: number) {
-        if (typeof newLength !== "number" || isNaN(newLength) || newLength < 0) die("Out of range: " + newLength)
+        if (typeof newLength !== "number" || isNaN(newLength) || newLength < 0)
+            die("Out of range: " + newLength)
         let currentLength = this.values_.length
         if (newLength === currentLength) return
         else if (newLength > currentLength) {
@@ -237,7 +238,7 @@ export class ObservableArrayAdministration
         } else {
             const res = this.values_.slice(index, index + deleteCount)
             let oldItems = this.values_.slice(index + deleteCount)
-            this.values_.length = index + newItems.length - deleteCount
+            this.values_.length = index + newItems.length
             for (let i = 0; i < newItems.length; i++) this.values_[index + i] = newItems[i]
             for (let i = 0; i < oldItems.length; i++)
                 this.values_[index + newItems.length + i] = oldItems[i]


### PR DESCRIPTION
Hello! I noticed an error in my application when working with long lists, traced it back down to here.
Here's a minimal repro (included in the new test case) https://codesandbox.io/s/inspiring-matsumoto-kbjzc?file=/src/index.ts
It only seems to happen when both arrays are larger than `MAX_SPLICE_SIZE` and the original array is larger than its replacement

Cheers!

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->
