### PR TITLE
Fix `isPlainObject` (#3197)

### DIFF
--- a/.changeset/real-kangaroos-type.md
+++ b/.changeset/real-kangaroos-type.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+fix `isPlainObject` impl (fixes #3197)

--- a/packages/mobx/__tests__/v5/base/make-observable.ts
+++ b/packages/mobx/__tests__/v5/base/make-observable.ts
@@ -1654,3 +1654,18 @@ test("makeObservable throws when mixing @decorators with annotations", () => {
 
     expect(() => new Test()).toThrow(/makeObservable second arg must be nullish when using decorators/);
 })
+
+test("makeAutoObservable + Object.create #3197", () => {
+    const proto = {
+        action() { },
+        *flow() { },
+        get computed() { return null },
+    };
+    const o = Object.create(proto);
+    o.observable = 5;
+    makeAutoObservable(o);
+    expect(isAction(proto.action)).toBe(true);
+    expect(isFlow(proto.flow)).toBe(true);
+    expect(isComputedProp(o, "computed")).toBe(true);
+    expect(isObservableProp(o, "observable")).toBe(true);
+});

--- a/packages/mobx/src/utils/utils.ts
+++ b/packages/mobx/src/utils/utils.ts
@@ -34,7 +34,7 @@ export function warnAboutProxyRequirement(msg: string) {
     if (__DEV__ && globalState.verifyProxies) {
         die(
             "MobX is currently configured to be able to run in ES5 mode, but in ES5 MobX won't be able to " +
-                msg
+            msg
         )
     }
 }
@@ -55,7 +55,7 @@ export function once(func: Lambda): Lambda {
     }
 }
 
-export const noop = () => {}
+export const noop = () => { }
 
 export function isFunction(fn: any): fn is Function {
     return typeof fn === "function"
@@ -84,7 +84,8 @@ export function isPlainObject(value) {
     if (!isObject(value)) return false
     const proto = Object.getPrototypeOf(value)
     if (proto == null) return true
-    return proto.constructor?.toString() === plainObjectString
+    const protoConstructor = Object.hasOwnProperty.call(proto, 'constructor') && proto.constructor;
+    return typeof protoConstructor === "function" && protoConstructor.toString() === plainObjectString
 }
 
 // https://stackoverflow.com/a/37865170
@@ -153,8 +154,8 @@ export const ownKeys: (target: any) => PropertyKey[] =
     typeof Reflect !== "undefined" && Reflect.ownKeys
         ? Reflect.ownKeys
         : hasGetOwnPropertySymbols
-        ? obj => Object.getOwnPropertyNames(obj).concat(Object.getOwnPropertySymbols(obj) as any)
-        : /* istanbul ignore next */ Object.getOwnPropertyNames
+            ? obj => Object.getOwnPropertyNames(obj).concat(Object.getOwnPropertySymbols(obj) as any)
+            : /* istanbul ignore next */ Object.getOwnPropertyNames
 
 export function stringifyKey(key: any): string {
     if (typeof key === "string") return key

--- a/packages/mobx/src/utils/utils.ts
+++ b/packages/mobx/src/utils/utils.ts
@@ -84,7 +84,7 @@ export function isPlainObject(value) {
     if (!isObject(value)) return false
     const proto = Object.getPrototypeOf(value)
     if (proto == null) return true
-    const protoConstructor = Object.hasOwnProperty.call(proto, 'constructor') && proto.constructor;
+    const protoConstructor = Object.hasOwnProperty.call(proto, "constructor") && proto.constructor;
     return typeof protoConstructor === "function" && protoConstructor.toString() === plainObjectString
 }
 


### PR DESCRIPTION
Fixes #3197

`isPlainObject` compares stringified proto constructor with `Object` constructor, however we did not make sure that the `constructor` is actually own property of the prototype. Therefore in cases where constructor was not defined, like `Object.create({})`, we were comparing constructor inherited from `Object`, leading to false positive.

lodash impl for reference:
https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12036