### PR TITLE
Make all builtin comparers generic

### DIFF
--- a/.changeset/hungry-baboons-shout.md
+++ b/.changeset/hungry-baboons-shout.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix builtin comparers to be generic

--- a/packages/mobx/src/utils/comparer.ts
+++ b/packages/mobx/src/utils/comparer.ts
@@ -19,7 +19,9 @@ function shallowComparer<T>(a: T, b: T): boolean {
 function defaultComparer<T>(a: T, b: T): boolean {
     if (Object.is) return Object.is(a, b)
 
-    return a === b ? (a as any) !== 0 || 1 / (a as any) === 1 / (b as any) : a !== a && b !== b
+    return a === b
+        ? (a as any) !== 0 || 1 / (a as any) === 1 / (b as any)
+        : a !== a && b !== b
 }
 
 export const comparer = {

--- a/packages/mobx/src/utils/comparer.ts
+++ b/packages/mobx/src/utils/comparer.ts
@@ -4,24 +4,22 @@ export interface IEqualsComparer<T> {
     (a: T, b: T): boolean
 }
 
-function identityComparer(a: any, b: any): boolean {
+function identityComparer<T>(a: T, b: T): boolean {
     return a === b
 }
 
-function structuralComparer(a: any, b: any): boolean {
+function structuralComparer<T>(a: T, b: T): boolean {
     return deepEqual(a, b)
 }
 
-function shallowComparer(a: any, b: any): boolean {
+function shallowComparer<T>(a: T, b: T): boolean {
     return deepEqual(a, b, 1)
 }
 
-function defaultComparer(a: any, b: any): boolean {
+function defaultComparer<T>(a: T, b: T): boolean {
     if (Object.is) return Object.is(a, b)
 
-    return a === b
-        ? a !== 0 || 1 / a === 1 / b
-        : a !== a && b !== b
+    return a === b ? (a as any) !== 0 || 1 / (a as any) === 1 / (b as any) : a !== a && b !== b
 }
 
 export const comparer = {


### PR DESCRIPTION
Without this change, if someone were to use the `comparer.structural` (or for that matter any other one) function. Then typescript (versions tested were 4.4 and 4.5) would assume `T = any` for reactions. Which is not ideal.

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->

This change I believe is already covered by unit tests. Though I am a bit unsure if/where this change should be made part of docs.