### PR TITLE
Fix/lint constructor overloads

### DIFF
--- a/.changeset/gentle-weeks-rescue.md
+++ b/.changeset/gentle-weeks-rescue.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-mobx": patch
+---
+
+fix(lint): fix 'missing-make-observable' rule with constructor overloads

--- a/packages/eslint-plugin-mobx/__tests__/missing-make-observable.js
+++ b/packages/eslint-plugin-mobx/__tests__/missing-make-observable.js
@@ -56,6 +56,18 @@ class C {
 }
 `).map(code => ({ code }))
 
+const valid4 = fields.map(field => `
+class C {     
+  ${field}
+
+  constructor(aString: string);
+  constructor(aNum: number);
+  constructor(stringOrNum: string | number) {
+    makeObservable(this, null, { name: 'foo' }) 
+  }      
+}
+`).map(code => ({ code }))
+
 const invalid1 = fields.map(field => ({
   code: `
 class C {
@@ -152,6 +164,7 @@ tester.run("missing-make-observable", rule, {
     ...valid1,
     valid2,
     ...valid3,
+    ...valid4,
   ],
   invalid: [
     ...invalid1,

--- a/packages/eslint-plugin-mobx/src/missing-make-observable.js
+++ b/packages/eslint-plugin-mobx/src/missing-make-observable.js
@@ -11,7 +11,8 @@ function create(context) {
       const clazz = findAncestor(decorator, node => node.type === 'ClassDeclaration' || node.type === 'ClassExpression');
       if (!clazz) return;
       // ClassDeclaration > ClassBody > []
-      const constructor = clazz.body.body.find(node => node.kind === 'constructor');
+      const constructor = clazz.body.body.find(node => node.kind === 'constructor' && node.value.type === 'FunctionExpression') ??
+        clazz.body.body.find(node => node.kind === 'constructor');
       // MethodDefinition > FunctionExpression > BlockStatement > []
       const isMakeObservable = node => node.expression?.callee?.name === 'makeObservable' && node.expression?.arguments[0]?.type === 'ThisExpression';
       const makeObservable = constructor?.value.body?.body.find(isMakeObservable)?.expression;


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->
Fix the 'missing-make-observable' rule for overloaded constructors. The rule would always take the first ctor even if that is just the definition.

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->
