### PR TITLE
Documentation: Add installation.md note about Next.js

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,6 +38,8 @@ For verification insert this piece of code at the beginning of your sources (eg.
 if (!new class { x }().hasOwnProperty('x')) throw new Error('Transpiler is not configured correctly');
 ```
 
+Note that for Next.js you must [customize Babel](https://nextjs.org/docs/advanced-features/customizing-babel-config) instead of TypeScript, even if your project is set up to use TypeScript. 
+
 ## MobX on older JavaScript environments
 
 By default, MobX uses proxies for optimal performance and compatibility. However, on older JavaScript engines `Proxy` is not available (check out [Proxy support](https://kangax.github.io/compat-table/es6/#test-Proxy)). Examples of such are Internet Explorer (before Edge), Node.js < 6, iOS < 10, Android before RN 0.59, or Android on iOS.


### PR DESCRIPTION
This adds a note for Next.js users, who (unintuitively) must configure babel (which is normally not needed at all) even if their project uses typescript. I think this is worth including because Next.js is relatively popular, and following the instructions as stated here simply doesn't work for unclear reasons. I spent the better part of an evening debugging this, only to eventually figure out that Next.js uses babel for compilation even if the project is set up with/written in typescript and doesn't have a babel config file yet.

Had I not had an evening free that I felt like spending on this, I probably would have given up entirely on MobX, as this was my first project to try it out and it seemed to just not work when used as directed (as all typescript-declared class fields without initial values were just mysteriously not tracked by makeAutoObservable)

See https://github.com/mobxjs/mobx/discussions/2831#discussioncomment-1937782 for related discussion / my journey in debugging this