### PR TITLE
#2527 Consolidate behavior of React.forwardRef & observer

### DIFF
--- a/.changeset/clever-gorillas-warn.md
+++ b/.changeset/clever-gorillas-warn.md
@@ -2,4 +2,4 @@
 "mobx-react": minor
 ---
 
--   `observer(forwardRef(fn))` no longer generates extra `<Observer>` element and applies `memo` correctly
+`observer(forwardRef(fn))` no longer generates extra `<Observer>` element and applies `memo` correctly

--- a/.changeset/clever-gorillas-warn.md
+++ b/.changeset/clever-gorillas-warn.md
@@ -1,0 +1,5 @@
+---
+"mobx-react": minor
+---
+
+-   `observer(forwardRef(fn))` no longer generates extra `<Observer>` element and applies `memo` correctly

--- a/.changeset/soft-jeans-stare.md
+++ b/.changeset/soft-jeans-stare.md
@@ -1,0 +1,7 @@
+---
+"mobx-react-lite": minor
+---
+
+-   support `observable(forwardRef(fn))`,
+-   deprecate `observable(fn, { forwardRef: true })`
+-   solve #2527, #3267

--- a/.changeset/soft-jeans-stare.md
+++ b/.changeset/soft-jeans-stare.md
@@ -2,6 +2,4 @@
 "mobx-react-lite": minor
 ---
 
--   support `observable(forwardRef(fn))`,
--   deprecate `observable(fn, { forwardRef: true })`
--   solve #2527, #3267
+support `observable(forwardRef(fn))`, deprecate `observable(fn, { forwardRef: true })`, solve #2527, #3267

--- a/packages/mobx-react-lite/__tests__/observer.test.tsx
+++ b/packages/mobx-react-lite/__tests__/observer.test.tsx
@@ -481,7 +481,7 @@ function runTestSuite(mode: "observer" | "useObserver") {
 runTestSuite("observer")
 runTestSuite("useObserver")
 
-test("useImperativeHandle and forwardRef should work with observer", () => {
+test("observer(cmp, { forwardRef: true }) + useImperativeHandle", () => {
     interface IMethods {
         focus(): void
     }
@@ -505,6 +505,38 @@ test("useImperativeHandle and forwardRef should work with observer", () => {
             return <input ref={inputRef} defaultValue={props.value} />
         },
         { forwardRef: true }
+    )
+
+    const cr = React.createRef<IMethods>()
+    render(<FancyInput ref={cr} value="" />)
+    expect(cr).toBeTruthy()
+    expect(cr.current).toBeTruthy()
+    expect(typeof cr.current!.focus).toBe("function")
+})
+
+test("observer(forwardRef(cmp)) + useImperativeHandle", () => {
+    interface IMethods {
+        focus(): void
+    }
+
+    interface IProps {
+        value: string
+    }
+
+    const FancyInput = observer(
+        React.forwardRef((props: IProps, ref: React.Ref<IMethods>) => {
+            const inputRef = React.useRef<HTMLInputElement>(null)
+            React.useImperativeHandle(
+                ref,
+                () => ({
+                    focus: () => {
+                        inputRef.current!.focus()
+                    }
+                }),
+                []
+            )
+            return <input ref={inputRef} defaultValue={props.value} />
+        })
     )
 
     const cr = React.createRef<IMethods>()

--- a/packages/mobx-react/__tests__/observer.test.tsx
+++ b/packages/mobx-react/__tests__/observer.test.tsx
@@ -742,7 +742,7 @@ test("use PureComponent", () => {
     try {
         observer(
             class X extends React.PureComponent {
-                return() {
+                render() {
                     return <div />
                 }
             }

--- a/packages/mobx-react/src/observer.tsx
+++ b/packages/mobx-react/src/observer.tsx
@@ -1,19 +1,8 @@
 import * as React from "react"
-import { observer as observerLite, Observer } from "mobx-react-lite"
+import { observer as observerLite } from "mobx-react-lite"
 
 import { makeClassComponentObserver } from "./observerClass"
 import { IReactComponent } from "./types/IReactComponent"
-
-const hasSymbol = typeof Symbol === "function" && Symbol.for
-
-// Using react-is had some issues (and operates on elements, not on types), see #608 / #609
-const ReactForwardRefSymbol = hasSymbol
-    ? Symbol.for("react.forward_ref")
-    : typeof React.forwardRef === "function" && React.forwardRef((props: any) => null)["$$typeof"]
-
-const ReactMemoSymbol = hasSymbol
-    ? Symbol.for("react.memo")
-    : typeof React.memo === "function" && React.memo((props: any) => null)["$$typeof"]
 
 /**
  * Observer function / decorator
@@ -21,38 +10,18 @@ const ReactMemoSymbol = hasSymbol
 export function observer<T extends IReactComponent>(component: T): T {
     if (component["isMobxInjector"] === true) {
         console.warn(
-            "Mobx observer: You are trying to use 'observer' on a component that already has 'inject'. Please apply 'observer' before applying 'inject'"
+            "Mobx observer: You are trying to use `observer` on a component that already has `inject`. Please apply `observer` before applying `inject`"
         )
     }
 
-    if (ReactMemoSymbol && component["$$typeof"] === ReactMemoSymbol) {
-        throw new Error(
-            "Mobx observer: You are trying to use 'observer' on a function component wrapped in either another observer or 'React.memo'. The observer already applies 'React.memo' for you."
-        )
-    }
-
-    // Unwrap forward refs into `<Observer>` component
-    // we need to unwrap the render, because it is the inner render that needs to be tracked,
-    // not the ForwardRef HoC
-    if (ReactForwardRefSymbol && component["$$typeof"] === ReactForwardRefSymbol) {
-        const baseRender = component["render"]
-        if (typeof baseRender !== "function")
-            throw new Error("render property of ForwardRef was not a function")
-        return React.forwardRef(function ObserverForwardRef() {
-            const args = arguments
-            return <Observer>{() => baseRender.apply(undefined, args)}</Observer>
-        }) as T
-    }
-
-    // Function component
     if (
-        typeof component === "function" &&
-        (!component.prototype || !component.prototype.render) &&
-        !component["isReactClass"] &&
-        !Object.prototype.isPrototypeOf.call(React.Component, component)
+        Object.prototype.isPrototypeOf.call(React.Component, component) ||
+        Object.prototype.isPrototypeOf.call(React.PureComponent, component)
     ) {
-        return observerLite(component as React.StatelessComponent<any>) as T
+        // Class component
+        return makeClassComponentObserver(component as React.ComponentClass<any, any>) as T
+    } else {
+        // Function component
+        return observerLite(component as React.FunctionComponent<any>) as T
     }
-
-    return makeClassComponentObserver(component as React.ComponentClass<any, any>) as T
 }


### PR DESCRIPTION
Solves #2527, #3267

### mobx-react-lite
Added support for `observable(forwardRef(fn))`
Deprecated  `observable(fn, { forwardRef: true })` - prints warning on devel.
`observer(memo(fn))` now throws (previously only `mobx-react`'s `observer` was throwing)

### mobx-react
 `observer(forwardRef(fn))` delegates to `mobx-react-lite`, it no longer generates extra `<Observer>` element and it applies `memo` correctly (previously these were not memoized)

I would appreciate if someone could check if typing is correct.

