### PR TITLE
Remove any from ObservableMap public API (Close #3286)

### DIFF
--- a/.changeset/smooth-penguins-pretend.md
+++ b/.changeset/smooth-penguins-pretend.md
@@ -1,0 +1,5 @@
+---
+"mobx": minor
+---
+
+Remove any from 'merge' and 'replace' methods of ObservableMap

--- a/packages/mobx/src/types/legacyobservablearray.ts
+++ b/packages/mobx/src/types/legacyobservablearray.ts
@@ -85,7 +85,6 @@ class LegacyObservableArray<T> extends StubArray {
         let nextIndex = 0
         return makeIterable({
             next() {
-                // @ts-ignore
                 return nextIndex < self.length
                     ? { value: self[nextIndex++], done: false }
                     : { done: true, value: undefined }

--- a/packages/mobx/src/types/observablemap.ts
+++ b/packages/mobx/src/types/observablemap.ts
@@ -313,7 +313,7 @@ export class ObservableMap<K = any, V = any>
         transaction(() => {
             if (isPlainObject(other))
                 getPlainObjectKeys(other).forEach((key: any) =>
-                    this.set(key as any as K, (other as any)[key])
+                    this.set(key as K, (other as IKeyValueMap)[key])
                 )
             else if (Array.isArray(other)) other.forEach(([key, value]) => this.set(key, value))
             else if (isES6Map(other)) {

--- a/packages/mobx/src/types/observablemap.ts
+++ b/packages/mobx/src/types/observablemap.ts
@@ -306,14 +306,14 @@ export class ObservableMap<K = any, V = any>
     }
 
     /** Merge another object into this object, returns this. */
-    merge(other: ObservableMap<K, V> | IKeyValueMap<V> | any): ObservableMap<K, V> {
+    merge(other?: IObservableMapInitialValues<K, V>): ObservableMap<K, V> {
         if (isObservableMap(other)) {
             other = new Map(other)
         }
         transaction(() => {
             if (isPlainObject(other))
                 getPlainObjectKeys(other).forEach((key: any) =>
-                    this.set(key as any as K, other[key])
+                    this.set(key as any as K, (other as any)[key])
                 )
             else if (Array.isArray(other)) other.forEach(([key, value]) => this.set(key, value))
             else if (isES6Map(other)) {
@@ -332,7 +332,7 @@ export class ObservableMap<K = any, V = any>
         })
     }
 
-    replace(values: ObservableMap<K, V> | IKeyValueMap<V> | any): ObservableMap<K, V> {
+    replace(values: IObservableMapInitialValues<K, V>): ObservableMap<K, V> {
         // Implementation requirements:
         // - respect ordering of replacement map
         // - allow interceptors to run and potentially prevent individual operations

--- a/packages/mobx/src/utils/utils.ts
+++ b/packages/mobx/src/utils/utils.ts
@@ -34,7 +34,7 @@ export function warnAboutProxyRequirement(msg: string) {
     if (__DEV__ && globalState.verifyProxies) {
         die(
             "MobX is currently configured to be able to run in ES5 mode, but in ES5 MobX won't be able to " +
-            msg
+                msg
         )
     }
 }
@@ -55,7 +55,7 @@ export function once(func: Lambda): Lambda {
     }
 }
 
-export const noop = () => { }
+export const noop = () => {}
 
 export function isFunction(fn: any): fn is Function {
     return typeof fn === "function"
@@ -80,12 +80,14 @@ export function isObject(value: any): value is Object {
     return value !== null && typeof value === "object"
 }
 
-export function isPlainObject(value) {
+export function isPlainObject(value: any) {
     if (!isObject(value)) return false
     const proto = Object.getPrototypeOf(value)
     if (proto == null) return true
-    const protoConstructor = Object.hasOwnProperty.call(proto, "constructor") && proto.constructor;
-    return typeof protoConstructor === "function" && protoConstructor.toString() === plainObjectString
+    const protoConstructor = Object.hasOwnProperty.call(proto, "constructor") && proto.constructor
+    return (
+        typeof protoConstructor === "function" && protoConstructor.toString() === plainObjectString
+    )
 }
 
 // https://stackoverflow.com/a/37865170
@@ -126,11 +128,11 @@ export function createInstanceofPredicate<T>(
     } as any
 }
 
-export function isES6Map(thing): boolean {
+export function isES6Map(thing: any): thing is Map<any, any> {
     return thing instanceof Map
 }
 
-export function isES6Set(thing): thing is Set<any> {
+export function isES6Set(thing: any): thing is Set<any> {
     return thing instanceof Set
 }
 
@@ -139,7 +141,7 @@ const hasGetOwnPropertySymbols = typeof Object.getOwnPropertySymbols !== "undefi
 /**
  * Returns the following: own enumerable keys and symbols.
  */
-export function getPlainObjectKeys(object) {
+export function getPlainObjectKeys(object: any) {
     const keys = Object.keys(object)
     // Not supported in IE, so there are not going to be symbol props anyway...
     if (!hasGetOwnPropertySymbols) return keys
@@ -154,8 +156,8 @@ export const ownKeys: (target: any) => Array<string | symbol> =
     typeof Reflect !== "undefined" && Reflect.ownKeys
         ? Reflect.ownKeys
         : hasGetOwnPropertySymbols
-            ? obj => Object.getOwnPropertyNames(obj).concat(Object.getOwnPropertySymbols(obj) as any)
-            : /* istanbul ignore next */ Object.getOwnPropertyNames
+        ? obj => Object.getOwnPropertyNames(obj).concat(Object.getOwnPropertySymbols(obj) as any)
+        : /* istanbul ignore next */ Object.getOwnPropertyNames
 
 export function stringifyKey(key: any): string {
     if (typeof key === "string") return key
@@ -163,7 +165,7 @@ export function stringifyKey(key: any): string {
     return new String(key).toString()
 }
 
-export function toPrimitive(value) {
+export function toPrimitive(value: any) {
     return value === null ? null : typeof value === "object" ? "" + value : value
 }
 


### PR DESCRIPTION
Related issue: #3286

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
Not needed
-   [ ] Verified that there is no significant performance drop (`yarn mobx test:performance`)
These changes are TS-only, they don't affect runtime performance 

### Summary
- Removed any from ObservableMap public API
- Added explicit `any` to assertion functions
- Removed obsolete `ts-ignore`
- All the codestyle changes were made by the pre-commit hook