### PR TITLE
Fix #3303 missing type inferrence of `observe` and `intercept` for arrays

### DIFF
--- a/.changeset/chilled-cups-raise.md
+++ b/.changeset/chilled-cups-raise.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+fix missing type inferrence of `observe` and `intercept` for arrays

--- a/packages/mobx/src/api/intercept.ts
+++ b/packages/mobx/src/api/intercept.ts
@@ -20,7 +20,7 @@ export function intercept<T>(
     handler: IInterceptor<IValueWillChange<T>>
 ): Lambda
 export function intercept<T>(
-    observableArray: IObservableArray<T>,
+    observableArray: IObservableArray<T> | Array<T>,
     handler: IInterceptor<IArrayWillChange<T> | IArrayWillSplice<T>>
 ): Lambda
 export function intercept<K, V>(

--- a/packages/mobx/src/api/observe.ts
+++ b/packages/mobx/src/api/observe.ts
@@ -20,7 +20,7 @@ export function observe<T>(
     fireImmediately?: boolean
 ): Lambda
 export function observe<T>(
-    observableArray: IObservableArray<T>,
+    observableArray: IObservableArray<T> | Array<T>,
     listener: (change: IArrayDidChange<T>) => void,
     fireImmediately?: boolean
 ): Lambda


### PR DESCRIPTION
fixes #3303

Probably just overlooked in: #3180