### PR TITLE
Documentation: Add rule for Computed Values

### DIFF
--- a/docs/computeds.md
+++ b/docs/computeds.md
@@ -92,6 +92,7 @@ When using computed values there are a couple of best practices to follow:
 
 1. They should not have side effects or update other observables.
 2. Avoid creating and returning new observables.
+3. They should not depend on non-observable values.
 
 ## Tips
 


### PR DESCRIPTION
If a computed value depends on a value that is not observable, the cache will not be invalidated when that value changes.

For example:

```javascript
window.x = true;

class MyState {
  a = "a";
  b = "b";

  constructor() {
    makeAutoObservable(this);
  }

  get foo() {
    if (window.x)
      return this.a;
    else
      return this.b;
  }
}
```

In this code, only `a` is registered as a dependency of the computed value `foo`, even though `foo` also depends on `x` and `b`.

(And oh boy, I learned that the hard way...)