### PR TITLE
Allow using 'as const' for creating tuples for map.replace

### DIFF
--- a/.changeset/clean-boats-repeat.md
+++ b/.changeset/clean-boats-repeat.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Allow readonly tuples as part of IObservableMapInitialValues

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -1887,6 +1887,18 @@ test("flow support throwing async generators", async () => {
     }
 })
 
+test("allow 'as const' for creating tuples for map.replace and friends", () => {
+    const map = mobx.observable.map<string, number>()
+    const srcValues = mobx.observable.array<string>()
+
+    const dispose = mobx.reaction(
+        () => Array.from(srcValues, (value, index) => [value, index] as const),
+        entries => map.replace(entries)
+    )
+
+    dispose()
+})
+
 test("toJS bug #1413 (TS)", () => {
     class X {
         test = {

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -1887,16 +1887,19 @@ test("flow support throwing async generators", async () => {
     }
 })
 
-test("allow 'as const' for creating tuples for map.replace and friends", () => {
+test("allow 'as const' for creating tuples for map.replace()", () => {
     const map = mobx.observable.map<string, number>()
     const srcValues = mobx.observable.array<string>()
+    const newValues = Array.from(srcValues, (value, index) => [value, index] as const)
 
-    const dispose = mobx.reaction(
-        () => Array.from(srcValues, (value, index) => [value, index] as const),
-        entries => map.replace(entries)
-    )
+    map.replace(newValues)
+})
 
-    dispose()
+test("allow 'as const' for creating tuples for observable.map()", () => {
+    const srcValues = mobx.observable.array<string>()
+    const newValues = Array.from(srcValues, (value, index) => [value, index] as const)
+
+    mobx.observable.map(newValues)
 })
 
 test("toJS bug #1413 (TS)", () => {

--- a/packages/mobx/src/types/observablemap.ts
+++ b/packages/mobx/src/types/observablemap.ts
@@ -43,7 +43,9 @@ export interface IKeyValueMap<V = any> {
 }
 
 export type IMapEntry<K = any, V = any> = [K, V]
+export type IReadonlyMapEntry<K = any, V = any> = readonly [K, V]
 export type IMapEntries<K = any, V = any> = IMapEntry<K, V>[]
+export type IReadonlyMapEntries<K = any, V = any> = IReadonlyMapEntry<K, V>[]
 
 export type IMapDidChange<K = any, V = any> = { observableKind: "map"; debugObjectName: string } & (
     | {
@@ -81,14 +83,14 @@ export const DELETE = "delete"
 
 export type IObservableMapInitialValues<K = any, V = any> =
     | IMapEntries<K, V>
+    | IReadonlyMapEntries<K, V>
     | IKeyValueMap<V>
     | Map<K, V>
 
 // just extend Map? See also https://gist.github.com/nestharus/13b4d74f2ef4a2f4357dbd3fc23c1e54
 // But: https://github.com/mobxjs/mobx/issues/1556
 export class ObservableMap<K = any, V = any>
-    implements Map<K, V>, IInterceptable<IMapWillChange<K, V>>, IListenable
-{
+    implements Map<K, V>, IInterceptable<IMapWillChange<K, V>>, IListenable {
     [$mobx] = ObservableMapMarker
     data_: Map<K, ObservableValue<V>>
     hasMap_: Map<K, ObservableValue<boolean>> // hasMap, not hashMap >-).


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->

This is really helpful after #3287 since that PR made it so that this use case failed to type check.

I added a test to make sure that this doesn't regress.