### PR TITLE
Fix deprecated spelling in console.warn

### DIFF
--- a/packages/mobx-react-lite/src/observer.ts
+++ b/packages/mobx-react-lite/src/observer.ts
@@ -68,7 +68,7 @@ export function observer<P extends object, TRef = {}>(
     if (process.env.NODE_ENV !== "production" && warnObserverOptionsDeprecated && options) {
         warnObserverOptionsDeprecated = false
         console.warn(
-            `[mobx-react-lite] \`observer(fn, { forwardRef: true })\` is depreacted, use \`observer(React.forwardRef(fn))\``
+            `[mobx-react-lite] \`observer(fn, { forwardRef: true })\` is deprecated, use \`observer(React.forwardRef(fn))\``
         )
     }
 


### PR DESCRIPTION
Corrected the spelling of `deprecated`