### PR TITLE
fix: avoid infinite render call if static rendering is used

### DIFF
--- a/packages/mobx-react/src/observerClass.ts
+++ b/packages/mobx-react/src/observerClass.ts
@@ -69,7 +69,7 @@ export function makeClassComponentObserver(
         if (!isUsingStaticRendering()) {
             this.render = createReactiveRender.call(this, originalRender)
         }
-        return this.render()
+        return originalRender.call(this)
     }
     patch(target, "componentDidMount", function () {
         this[mobxIsUnmounted] = false


### PR DESCRIPTION
Should fix #3448 (After #3395 started facing SSR infinite render loop that leads to "Maximum call stack size exceeded")