### PR TITLE
Documentation: A slight revamp of the README, wording, and clearer links

### DIFF
--- a/.changeset/red-cups-yell.md
+++ b/.changeset/red-cups-yell.md
@@ -1,0 +1,6 @@
+---
+"mobx": patch
+"mobx-react": patch
+---
+
+A slight revamp of the README, wording, and clearer links

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ MobX is made possible by the generosity of the sponsors below, and many other [i
 
 _Anything that can be derived from the application state, should be. Automatically._
 
-MobX is a battle-tested library that makes state management simple and scalable by transparently applying the principles of functional reactive programming.
+MobX is a battle-tested library that makes state management simple and scalable by transparently applying functional reactive programming.
 The philosophy behind MobX is simple:
 
 <div class="benefits">
@@ -175,6 +175,6 @@ The **[MobX Quick Start Guide](https://www.packtpub.com/product/mobx-quick-start
 
 ## Credits
 
-MobX is inspired by reactive programming principles, which are for example used in spreadsheets. It is inspired by model–view–viewmodel frameworks like [MeteorJS's Tracker](https://docs.meteor.com/api/tracker.html), [Knockout](https://knockoutjs.com/) and [Vue.js](https://vuejs.org/), but MobX brings functional reactive programming (FRP) to the next level and provides a standalone implementation. It implements FRP in a glitch-free, synchronous, predictable and efficient manner.
+MobX is inspired by reactive programming principles, which are for example used in spreadsheets. It is inspired by model–view–viewmodel frameworks like [MeteorJS's Tracker](https://docs.meteor.com/api/tracker.html), [Knockout](https://knockoutjs.com/) and [Vue.js](https://vuejs.org/), but MobX brings _Transparent Functional Reactive Programming_ (TFRP) to the next level and provides a standalone implementation. It implements TFRP in a glitch-free, synchronous, predictable and efficient manner.
 
 A ton of credit goes to [Mendix](https://github.com/mendix), for providing the flexibility and support to maintain MobX and the chance to prove the philosophy of MobX in a real, complex, performance critical applications.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,6 @@ The **[MobX Quick Start Guide](https://www.packtpub.com/product/mobx-quick-start
 
 ## Credits
 
-MobX is inspired by reactive programming principles, which are for example used in spreadsheets. It is inspired by model–view–viewmodel frameworks like [MeteorJS's Tracker](https://docs.meteor.com/api/tracker.html), [Knockout](https://knockoutjs.com/) and [Vue.js](https://vuejs.org/), but MobX brings _Transparent Functional Reactive Programming_ (TFRP) to the next level and provides a standalone implementation. It implements TFRP in a glitch-free, synchronous, predictable and efficient manner.
+MobX is inspired by reactive programming principles, which are for example used in spreadsheets. It is inspired by model–view–viewmodel frameworks like [MeteorJS's Tracker](https://docs.meteor.com/api/tracker.html), [Knockout](https://knockoutjs.com/) and [Vue.js](https://vuejs.org/), but MobX brings _transparent functional reactive programming_ (TFRP, a concept which is further explained in the [MobX book](https://www.packtpub.com/product/mobx-quick-start-guide/9781789344837)) to the next level and provides a standalone implementation. It implements TFRP in a glitch-free, synchronous, predictable and efficient manner.
 
 A ton of credit goes to [Mendix](https://github.com/mendix), for providing the flexibility and support to maintain MobX and the chance to prove the philosophy of MobX in a real, complex, performance critical applications.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,60 @@ _Simple, scalable state management._
 [![npm version](https://badge.fury.io/js/mobx.svg)](https://badge.fury.io/js/mobx)
 [![OpenCollective](https://opencollective.com/mobx/backers/badge.svg)](docs/backers-sponsors.md#backers)
 [![OpenCollective](https://opencollective.com/mobx/sponsors/badge.svg)](docs/backers-sponsors.md#sponsors)
-
 [![Discuss on Github](https://img.shields.io/badge/discuss%20on-GitHub-orange)](https://github.com/mobxjs/mobx/discussions)
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/mobx)
 
 ---
 
-> Documentation for older **unsupported** V4/V5 can be [found here](https://github.com/mobxjs/mobx/blob/mobx4and5/docs/README.md), but be sure to read about [current documentation first](https://mobx.js.org/about-this-documentation.html).
+## Documentation
+
+Documentation can be found at **[mobx.js.org](https://mobx.js.org/)**.
+
+## Introduction
+
+_Anything that can be derived from the application state, should be. Automatically._
+
+MobX is a battle-tested library that makes state management simple and scalable by transparently applying the principles of functional reactive programming.
+The philosophy behind MobX is simple:
+
+<div class="benefits">
+    <div>
+        <div class="pic">😙</div>
+        <div>
+            <h4>Straightforward</h4>
+            <p>Write minimalistic, boilerplate-free code that captures your intent.
+            Trying to update a record field? Simply use a normal JavaScript assignment —
+            the reactivity system will detect all your changes and propagate them out to where they are being used.
+            No special tools are required when updating data in an asynchronous process.
+            </p>
+        </div>
+    </div>
+    <div>
+        <div class="pic">🚅</div>
+        <div>
+            <h4>Effortless optimal rendering</h4>
+            <p>
+                All changes to and uses of your data are tracked at runtime, building a dependency tree that captures all relations between state and output.
+                This guarantees that computations that depend on your state, like React components, run only when strictly needed.
+                There is no need to manually optimize components with error-prone and sub-optimal techniques like memoization and selectors.
+            </p>
+        </div>
+    </div>
+    <div>
+        <div class="pic">🤹🏻‍♂️</div>
+        <div>
+            <h4>Architectural freedom</h4>
+            <p>
+                MobX is unopinionated and allows you to manage your application state outside of any UI framework.
+                This makes your code decoupled, portable, and above all, easily testable.
+            </p>
+        </div>
+    </div>
+</div>
+
+---
+
+## Sponsors
 
 MobX is made possible by the generosity of the sponsors below, and many other [individual backers](https://github.com/mobxjs/mobx/blob/main/docs/backers-sponsors.md#backers). Sponsoring directly impacts the longevity of this project.
 
@@ -43,47 +90,6 @@ MobX is made possible by the generosity of the sponsors below, and many other [i
 <a href="https://blokt.com/"><img src="https://mobx.js.org/assets/blokt.jpg" align="center" width="100" title="Blokt" alt="Blokt"/></a>
 
 ---
-
-## Introduction
-
-_Anything that can be derived from the application state, should be. Automatically._
-
-MobX is a battle tested library that makes state management simple and scalable by transparently applying functional reactive programming (TFRP).
-The philosophy behind MobX is simple:
-
-<div class="benefits">
-    <div>
-        <div class="pic">😙</div>
-        <div>
-            <h5>Straightforward</h5>
-            <p>Write minimalistic, boilerplate free code that captures your intent.
-            Trying to update a record field? Use the good old JavaScript assignment.
-            Updating data in an asynchronous process? No special tools are required, the reactivity system will detect all your changes and propagate them out to where they are being used.
-            </p>
-        </div>
-    </div>
-    <div>
-        <div class="pic">🚅</div>
-        <div>
-            <h5>Effortless optimal rendering</h5>
-            <p>
-                All changes to and uses of your data are tracked at runtime, building a dependency tree that captures all relations between state and output.
-                This guarantees that computations depending on your state, like React components, run only when strictly needed.
-                There is no need to manually optimize components with error-prone and sub-optimal techniques like memoization and selectors.
-            </p>
-        </div>
-    </div>
-    <div>
-        <div class="pic">🤹🏻‍♂️</div>
-        <div>
-            <h5>Architectural freedom</h5>
-            <p>
-                MobX is unopinionated and allows you to manage your application state outside of any UI framework.
-                This makes your code decoupled, portable, and above all, easily testable.
-            </p>
-        </div>
-    </div>
-</div>
 
 ## A quick example
 
@@ -127,7 +133,7 @@ setInterval(() => {
 }, 1000)
 ```
 
-The `observer` wrapper around the `TimerView` React component, will automatically detect that rendering
+The `observer` wrapper around the `TimerView` React component will automatically detect that rendering
 depends on the `timer.secondsPassed` observable, even though this relationship is not explicitly defined. The reactivity system will take care of re-rendering the component when _precisely that_ field is updated in the future.
 
 Every event (`onClick` / `setInterval`) invokes an _action_ (`myTimer.increase` / `myTimer.reset`) that updates _observable state_ (`myTimer.secondsPassed`).
@@ -137,49 +143,36 @@ Changes in the observable state are propagated precisely to all _computations_ a
 
 This conceptual picture can be applied to the above example, or any other application using MobX.
 
-To learn about the core concepts of MobX using a larger example, check out [The gist of MobX](https://mobx.js.org/the-gist-of-mobx.html) section, or take the [10 minute interactive introduction to MobX and React](https://mobx.js.org/getting-started).
+## Getting started
+
+To learn about the core concepts of MobX using a larger example, check out **[The gist of MobX](https://mobx.js.org/the-gist-of-mobx.html)** page, or take the **[10 minute interactive introduction to MobX and React](https://mobx.js.org/getting-started)**.
 The philosophy and benefits of the mental model provided by MobX are also described in great detail in the blog posts [UI as an afterthought](https://michel.codes/blogs/ui-as-an-afterthought) and [How to decouple state and UI (a.k.a. you don’t need componentWillMount)](https://hackernoon.com/how-to-decouple-state-and-ui-a-k-a-you-dont-need-componentwillmount-cc90b787aa37).
 
-<div class="cheat"><a href="https://gum.co/fSocU"><button title="Download the MobX 6 cheat sheet and sponsor the project">Download the MobX 6 cheat sheet</button></a></div>
+## Further resources
 
-## What others are saying...
-
-> Guise, #mobx isn't pubsub, or your grandpa's observer pattern. Nay, it is a carefully orchestrated observable dimensional portal fueled by the power cosmic. It doesn't do change detection, it's actually a level 20 psionic with soul knife, slashing your viewmodel into submission.
-
-> After using #mobx for lone projects for a few weeks, it feels awesome to introduce it to the team. Time: 1/2, Fun: 2X
-
-> Working with #mobx is basically a continuous loop of me going “this is way too simple, it definitely won’t work” only to be proven wrong
-
-> I have built big apps with MobX already and comparing to the one before that which was using Redux, it is simpler to read and much easier to reason about.
-
-> The #mobx is the way I always want things to be! It's really surprising simple and fast! Totally awesome! Don't miss it!
-
-## Further resources and documentation
-
--   [MobX cheat sheet (also sponsors the project)](https://gum.co/fSocU)
+-   The [MobX cheat sheet](https://gum.co/fSocU) (£5) is both useful and sponsors the project
 -   [10 minute interactive introduction to MobX and React](https://mobx.js.org/getting-started)
 -   [Egghead.io course, based on MobX 3](https://egghead.io/courses/manage-complex-state-in-react-apps-with-mobx)
+-   The [MobX awesome list](https://github.com/mobxjs/awesome-mobx#awesome-mobx) – a long list of MobX resources and example projects
 
 ### The MobX book
 
-[<img src="https://mobx.js.org/assets/book.jpg" height="80px"/> ](https://books.google.nl/books?id=ALFmDwAAQBAJ&pg=PP1&lpg=PP1&dq=michel+weststrate+mobx+quick+start+guide:+supercharge+the+client+state+in+your+react+apps+with+mobx&source=bl&ots=D460fxti0F&sig=ivDGTxsPNwlOjLHrpKF1nweZFl8&hl=nl&sa=X&ved=2ahUKEwiwl8XO--ncAhWPmbQKHWOYBqIQ6AEwAnoECAkQAQ#v=onepage&q=michel%20weststrate%20mobx%20quick%20start%20guide%3A%20supercharge%20the%20client%20state%20in%20your%20react%20apps%20with%20mobx&f=false)
+<a href="https://www.packtpub.com/product/mobx-quick-start-guide/9781789344837"><img src="https://mobx.js.org/assets/book.jpg" height="120px" /></a>
 
-Created by [Pavan Podila](https://twitter.com/pavanpodila) and [Michel Weststrate](https://twitter.com/mweststrate).
+The **[MobX Quick Start Guide](https://www.packtpub.com/product/mobx-quick-start-guide/9781789344837)** ($24.99) by [Pavan Podila](https://twitter.com/pavanpodila) and [Michel Weststrate](https://twitter.com/mweststrate) is available as an [ebook](https://www.packtpub.com/product/mobx-quick-start-guide/9781789344837), [paperback](https://www.amazon.com/MobX-Quick-Start-Guide-Supercharge/dp/1789344832), and on the [O'Reilly platform](https://www.oreilly.com/library/view/mobx-quick-start/9781789344837/) (see [preview](https://books.google.com/books?id=ALFmDwAAQBAJ&printsec=frontcover#v=onepage&q&f=false)).
 
 ### Videos
 
--   [Introduction to MobX & React in 2020](https://www.youtube.com/watch?v=pnhIJA64ByY) by Leigh Halliday, _17min_.
--   [ReactNext 2016: Real World MobX](https://www.youtube.com/watch?v=Aws40KOx90U) by Michel Weststrate, _40min_, [slides](https://docs.google.com/presentation/d/1DrI6Hc2xIPTLBkfNH8YczOcPXQTOaCIcDESdyVfG_bE/edit?usp=sharing).
--   [CityJS 2020: MobX, from mutable to immutable, to observable data](https://www.youtube.com/watch?v=ZHxFrbK3VB0&feature=emb_logo) by Michel Weststrate, _30min_.
--   [OpenSourceNorth: Practical React with MobX (ES5)](https://www.youtube.com/watch?v=XGwuM_u7UeQ) by Matt Ruby, _42min_.
--   [HolyJS 2019: MobX and the unique symbiosis of predictability and speed](https://www.youtube.com/watch?v=NBYbBbjZeX4&list=PL8sJahqnzh8JJD7xahG5zXkjfM5GOgcPA&index=21&t=0s) by Michel Weststrate, _59min_.
--   [React Amsterdam 2016: State Management Is Easy](https://www.youtube.com/watch?v=ApmSsu3qnf0&feature=youtu.be) by Michel Weststrate, _20min_, [slides](https://speakerdeck.com/mweststrate/state-management-is-easy-introduction-to-mobx).
--   {🚀} [React Live 2019: Reinventing MobX](https://www.youtube.com/watch?v=P_WqKZxpX8g) by Max Gallo, _27min_.
-
-And an all around [MobX awesome list](https://github.com/mobxjs/awesome-mobx#awesome-mobx).
+-   [Introduction to MobX & React in 2020](https://www.youtube.com/watch?v=pnhIJA64ByY) by Leigh Halliday, _17 min_.
+-   [ReactNext 2016: Real World MobX](https://www.youtube.com/watch?v=Aws40KOx90U) by Michel Weststrate, _40 min_, [slides](https://docs.google.com/presentation/d/1DrI6Hc2xIPTLBkfNH8YczOcPXQTOaCIcDESdyVfG_bE/edit?usp=sharing).
+-   [CityJS 2020: MobX, from mutable to immutable, to observable data](https://youtu.be/sP7dtZm_Wx0?t=27050) by Michel Weststrate, _30 min_.
+-   [OpenSourceNorth: Practical React with MobX (ES5)](https://www.youtube.com/watch?v=XGwuM_u7UeQ) by Matt Ruby, _42 min_.
+-   [HolyJS 2019: MobX and the unique symbiosis of predictability and speed](https://www.youtube.com/watch?v=NBYbBbjZeX4&list=PL8sJahqnzh8JJD7xahG5zXkjfM5GOgcPA&index=21&t=0s) by Michel Weststrate, _59 min_.
+-   [React Amsterdam 2016: State Management Is Easy](https://www.youtube.com/watch?v=ApmSsu3qnf0&feature=youtu.be) by Michel Weststrate, _20 min_, [slides](https://speakerdeck.com/mweststrate/state-management-is-easy-introduction-to-mobx).
+-   {🚀} [React Live 2019: Reinventing MobX](https://www.youtube.com/watch?v=P_WqKZxpX8g) by Max Gallo, _27 min_.
 
 ## Credits
 
-MobX is inspired by reactive programming principles as found in the spreadsheets. It is inspired by MVVM frameworks like MeteorJS tracker, knockout and Vue.js, but MobX brings _Transparent Functional Reactive Programming_ to the next level and provides a standalone implementation. It implements TFRP in a glitch-free, synchronous, predictable and efficient manner.
+MobX is inspired by reactive programming principles, which are for example used in spreadsheets. It is inspired by model–view–viewmodel frameworks like [MeteorJS's Tracker](https://docs.meteor.com/api/tracker.html), [Knockout](https://knockoutjs.com/) and [Vue.js](https://vuejs.org/), but MobX brings functional reactive programming (FRP) to the next level and provides a standalone implementation. It implements FRP in a glitch-free, synchronous, predictable and efficient manner.
 
-A ton of credits goes to [Mendix](https://github.com/mendix), for providing the flexibility and support to maintain MobX and the chance to proof the philosophy of MobX in a real, complex, performance critical applications.
+A ton of credit goes to [Mendix](https://github.com/mendix), for providing the flexibility and support to maintain MobX and the chance to prove the philosophy of MobX in a real, complex, performance critical applications.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,39 @@ _Simple, scalable state management._
 
 Documentation can be found at **[mobx.js.org](https://mobx.js.org/)**.
 
+---
+
+## Sponsors
+
+MobX is made possible by the generosity of the sponsors below, and many other [individual backers](https://github.com/mobxjs/mobx/blob/main/docs/backers-sponsors.md#backers). Sponsoring directly impacts the longevity of this project.
+
+**🥇 Gold sponsors (\$3000+ total contribution):** <br/>
+<a href="https://mendix.com/"><img src="https://mobx.js.org/assets/mendix-logo.png" align="center" width="100" title="Mendix" alt="Mendix" /></a>
+<a href="https://frontendmasters.com/"><img src="https://mobx.js.org/assets/frontendmasters.jpg" align="center" width="100" title="Frontend Masters" alt="Frontend Masters"></a>
+<a href="https://opensource.facebook.com/"><img src="https://mobx.js.org/assets/fbos.jpeg" align="center" width="100" title="Facebook Open Source" alt="Facebook Open Source" /></a>
+<a href="http://auctionfrontier.com/"><img src="https://mobx.js.org/assets/auctionfrontier.jpeg" align="center" width="100" title="Auction Frontier" alt="Auction Frontier"></a>
+<a href="https://www.guilded.gg/"><img src="https://mobx.js.org/assets/guilded.jpg" align="center" width="100" title="Guilded" alt="Guilded" /></a>
+<a href="https://coinbase.com/"><img src="https://mobx.js.org/assets/coinbase.jpeg" align="center" width="100" title="Coinbase" alt="Coinbase" /></a>
+<a href="https://www.canva.com/"><img src="https://mobx.js.org/assets/canva.png" align="center" width="100" title="Canva" alt="Canva" /></a>
+
+**🥈 Silver sponsors (\$100+ per month):**<br/>
+<a href="https://www.codefirst.co.uk/"><img src="https://mobx.js.org/assets/codefirst.png" align="center" width="100" title="CodeFirst" alt="CodeFirst"/></a>
+<a href="https://www.dcsl.com/"><img src="https://mobx.js.org/assets/dcsl.png" align="center" width="100" title="DCSL Guidesmiths" alt="DCSL Guidesmiths"/></a>
+<a href="https://www.bugsnag.com/platforms/react-error-reporting?utm_source=MobX&utm_medium=Website&utm_content=open-source&utm_campaign=2019-community&utm_term=20190913"><img src="https://mobx.js.org/assets/bugsnag.jpg" align="center" width="100" title="Bugsnag" alt="Bugsnag"/></a>
+<a href="https://curology.com/blog/tech"><img src="https://mobx.js.org/assets/curology.png" align="center" width="100" title="Curology" alt="Curology"/></a>
+<a href="https://modulz.app/"><img src="https://mobx.js.org/assets/modulz.png" align="center" width="100" title="Modulz" alt="Modulz"/></a>
+<a href="https://space307.com/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/space307.png" align="center" width="100" title="Space307" alt="Space307"/></a>
+<a href="https://casinosites.ltd.uk/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/casino2.png" align="center" width="100" title="Casino Sites" alt="Casino Sites"/></a>
+
+**🥉 Bronze sponsors (\$500+ total contributions):**<br/>
+<a href="https://mantro.net/jobs/warlock"><img src="https://mobx.js.org/assets/mantro.png" align="center" width="100" title="mantro GmbH" alt="mantro GmbH"></a>
+<a href="https://www.algolia.com/"><img src="https://mobx.js.org/assets/algolia.jpg" align="center" width="100" title="Algolia" alt="Algolia" /></a>
+<a href="https://talentplot.com/"><img src="https://mobx.js.org/assets/talentplot.png" align="center" width="100" title="talentplot" alt="talentplot"></a>
+<a href="https://careers.dazn.com/"><img src="https://mobx.js.org/assets/dazn.png" align="center" width="100" title="DAZN" alt="DAZN"></a>
+<a href="https://blokt.com/"><img src="https://mobx.js.org/assets/blokt.jpg" align="center" width="100" title="Blokt" alt="Blokt"/></a>
+
+---
+
 ## Introduction
 
 _Anything that can be derived from the application state, should be. Automatically._
@@ -57,37 +90,6 @@ The philosophy behind MobX is simple:
         </div>
     </div>
 </div>
-
----
-
-## Sponsors
-
-MobX is made possible by the generosity of the sponsors below, and many other [individual backers](https://github.com/mobxjs/mobx/blob/main/docs/backers-sponsors.md#backers). Sponsoring directly impacts the longevity of this project.
-
-**🥇 Gold sponsors (\$3000+ total contribution):** <br/>
-<a href="https://mendix.com/"><img src="https://mobx.js.org/assets/mendix-logo.png" align="center" width="100" title="Mendix" alt="Mendix" /></a>
-<a href="https://frontendmasters.com/"><img src="https://mobx.js.org/assets/frontendmasters.jpg" align="center" width="100" title="Frontend Masters" alt="Frontend Masters"></a>
-<a href="https://opensource.facebook.com/"><img src="https://mobx.js.org/assets/fbos.jpeg" align="center" width="100" title="Facebook Open Source" alt="Facebook Open Source" /></a>
-<a href="http://auctionfrontier.com/"><img src="https://mobx.js.org/assets/auctionfrontier.jpeg" align="center" width="100" title="Auction Frontier" alt="Auction Frontier"></a>
-<a href="https://www.guilded.gg/"><img src="https://mobx.js.org/assets/guilded.jpg" align="center" width="100" title="Guilded" alt="Guilded" /></a>
-<a href="https://coinbase.com/"><img src="https://mobx.js.org/assets/coinbase.jpeg" align="center" width="100" title="Coinbase" alt="Coinbase" /></a>
-<a href="https://www.canva.com/"><img src="https://mobx.js.org/assets/canva.png" align="center" width="100" title="Canva" alt="Canva" /></a>
-
-**🥈 Silver sponsors (\$100+ per month):**<br/>
-<a href="https://www.codefirst.co.uk/"><img src="https://mobx.js.org/assets/codefirst.png" align="center" width="100" title="CodeFirst" alt="CodeFirst"/></a>
-<a href="https://www.dcsl.com/"><img src="https://mobx.js.org/assets/dcsl.png" align="center" width="100" title="DCSL Guidesmiths" alt="DCSL Guidesmiths"/></a>
-<a href="https://www.bugsnag.com/platforms/react-error-reporting?utm_source=MobX&utm_medium=Website&utm_content=open-source&utm_campaign=2019-community&utm_term=20190913"><img src="https://mobx.js.org/assets/bugsnag.jpg" align="center" width="100" title="Bugsnag" alt="Bugsnag"/></a>
-<a href="https://curology.com/blog/tech"><img src="https://mobx.js.org/assets/curology.png" align="center" width="100" title="Curology" alt="Curology"/></a>
-<a href="https://modulz.app/"><img src="https://mobx.js.org/assets/modulz.png" align="center" width="100" title="Modulz" alt="Modulz"/></a>
-<a href="https://space307.com/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/space307.png" align="center" width="100" title="Space307" alt="Space307"/></a>
-<a href="https://casinosites.ltd.uk/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/casino2.png" align="center" width="100" title="Casino Sites" alt="Casino Sites"/></a>
-
-**🥉 Bronze sponsors (\$500+ total contributions):**<br/>
-<a href="https://mantro.net/jobs/warlock"><img src="https://mobx.js.org/assets/mantro.png" align="center" width="100" title="mantro GmbH" alt="mantro GmbH"></a>
-<a href="https://www.algolia.com/"><img src="https://mobx.js.org/assets/algolia.jpg" align="center" width="100" title="Algolia" alt="Algolia" /></a>
-<a href="https://talentplot.com/"><img src="https://mobx.js.org/assets/talentplot.png" align="center" width="100" title="talentplot" alt="talentplot"></a>
-<a href="https://careers.dazn.com/"><img src="https://mobx.js.org/assets/dazn.png" align="center" width="100" title="DAZN" alt="DAZN"></a>
-<a href="https://blokt.com/"><img src="https://mobx.js.org/assets/blokt.jpg" align="center" width="100" title="Blokt" alt="Blokt"/></a>
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,63 +14,38 @@ _Simple, scalable state management._
 [![npm version](https://badge.fury.io/js/mobx.svg)](https://badge.fury.io/js/mobx)
 [![OpenCollective](https://opencollective.com/mobx/backers/badge.svg)](backers-sponsors.md#backers)
 [![OpenCollective](https://opencollective.com/mobx/sponsors/badge.svg)](backers-sponsors.md#sponsors)
+[![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/mobx)
 
 ---
 
-MobX is made possible by the generosity of the sponsors below, and many other [individual backers](backers-sponsors.md#backers). Sponsoring directly impacts the longevity of this project.
-
-**🥇 Gold sponsors (\$3000+ total contribution):** <br/>
-<a href="https://mendix.com/"><img src="https://mobx.js.org/assets/mendix-logo.png" align="center" width="100" title="Mendix" alt="Mendix" /></a>
-<a href="https://frontendmasters.com/"><img src="https://mobx.js.org/assets/frontendmasters.jpg" align="center" width="100" title="Frontend Masters" alt="Frontend Masters"></a>
-<a href="https://opensource.facebook.com/"><img src="https://mobx.js.org/assets/fbos.jpeg" align="center" width="100" title="Facebook Open Source" alt="Facebook Open Source" /></a>
-<a href="http://auctionfrontier.com/"><img src="https://mobx.js.org/assets/auctionfrontier.jpeg" align="center" width="100" title="Auction Frontier" alt="Auction Frontier"></a>
-<a href="https://www.guilded.gg/"><img src="https://mobx.js.org/assets/guilded.jpg" align="center" width="100" title="Guilded" alt="Guilded" /></a>
-<a href="https://coinbase.com/"><img src="https://mobx.js.org/assets/coinbase.jpeg" align="center" width="100" title="Coinbase" alt="Coinbase" /></a>
-<a href="https://www.canva.com/"><img src="https://mobx.js.org/assets/canva.png" align="center" width="100" title="Canva" alt="Canva" /></a>
-
-**🥈 Silver sponsors (\$100+ per month):**<br/>
-<a href="https://www.codefirst.co.uk/"><img src="https://mobx.js.org/assets/codefirst.png" align="center" width="100" title="CodeFirst" alt="CodeFirst"/></a>
-<a href="https://www.dcsl.com/"><img src="https://mobx.js.org/assets/dcsl.png" align="center" width="100" title="DCSL Guidesmiths" alt="DCSL Guidesmiths"/></a>
-<a href="https://www.bugsnag.com/platforms/react-error-reporting?utm_source=MobX&utm_medium=Website&utm_content=open-source&utm_campaign=2019-community&utm_term=20190913"><img src="https://mobx.js.org/assets/bugsnag.jpg" align="center" width="100" title="Bugsnag" alt="Bugsnag"/></a>
-<a href="https://curology.com/blog/tech"><img src="https://mobx.js.org/assets/curology.png" align="center" width="100" title="Curology" alt="Curology"/></a>
-<a href="https://modulz.app/"><img src="https://mobx.js.org/assets/modulz.png" align="center" width="100" title="Modulz" alt="Modulz"/></a>
-<a href="https://space307.com/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/space307.png" align="center" width="100" title="Space307" alt="Space307"/></a>
-<a href="https://casinosites.ltd.uk/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/casino2.png" align="center" width="100" title="Casino Sites" alt="Casino Sites"/></a>
-
-**🥉 Bronze sponsors (\$500+ total contributions):**<br/>
-<a href="https://mantro.net/jobs/warlock"><img src="https://mobx.js.org/assets/mantro.png" align="center" width="100" title="mantro GmbH" alt="mantro GmbH"></a>
-<a href="https://www.algolia.com/"><img src="https://mobx.js.org/assets/algolia.jpg" align="center" width="100" title="Algolia" alt="Algolia" /></a>
-<a href="https://talentplot.com/"><img src="https://mobx.js.org/assets/talentplot.png" align="center" width="100" title="talentplot" alt="talentplot"></a>
-<a href="https://careers.dazn.com/"><img src="https://mobx.js.org/assets/dazn.png" align="center" width="100" title="DAZN" alt="DAZN"></a>
-<a href="https://blokt.com/"><img src="https://mobx.js.org/assets/blokt.jpg" align="center" width="100" title="Blokt" alt="Blokt"/></a>
-
----
+> Documentation for older **unsupported** V4/V5 can be [found here](https://github.com/mobxjs/mobx/blob/mobx4and5/docs/README.md), but be sure to read about the [current documentation first](https://mobx.js.org/about-this-documentation.html).
 
 ## Introduction
 
 _Anything that can be derived from the application state, should be. Automatically._
 
-MobX is a battle tested library that makes state management simple and scalable by transparently applying functional reactive programming (TFRP).
+MobX is a battle-tested library that makes state management simple and scalable by transparently applying the principles of functional reactive programming.
 The philosophy behind MobX is simple:
 
 <div class="benefits">
     <div>
         <div class="pic">😙</div>
         <div>
-            <h5>Straightforward</h5>
-            <p>Write minimalistic, boilerplate free code that captures your intent.
-            Trying to update a record field? Use the good old JavaScript assignment.
-            Updating data in an asynchronous process? No special tools are required, the reactivity system will detect all your changes and propagate them out to where they are being used.
+            <h4>Straightforward</h4>
+            <p>Write minimalistic, boilerplate-free code that captures your intent.
+            Trying to update a record field? Simply use a normal JavaScript assignment —
+            the reactivity system will detect all your changes and propagate them out to where they are being used.
+            No special tools are required when updating data in an asynchronous process.
             </p>
         </div>
     </div>
     <div>
         <div class="pic">🚅</div>
         <div>
-            <h5>Effortless optimal rendering</h5>
+            <h4>Effortless optimal rendering</h4>
             <p>
                 All changes to and uses of your data are tracked at runtime, building a dependency tree that captures all relations between state and output.
-                This guarantees that computations depending on your state, like React components, run only when strictly needed.
+                This guarantees that computations that depend on your state, like React components, run only when strictly needed.
                 There is no need to manually optimize components with error-prone and sub-optimal techniques like memoization and selectors.
             </p>
         </div>
@@ -78,7 +53,7 @@ The philosophy behind MobX is simple:
     <div>
         <div class="pic">🤹🏻‍♂️</div>
         <div>
-            <h5>Architectural freedom</h5>
+            <h4>Architectural freedom</h4>
             <p>
                 MobX is unopinionated and allows you to manage your application state outside of any UI framework.
                 This makes your code decoupled, portable, and above all, easily testable.
@@ -86,6 +61,39 @@ The philosophy behind MobX is simple:
         </div>
     </div>
 </div>
+
+---
+
+## Sponsors
+
+MobX is made possible by the generosity of the sponsors below, and many other [individual backers](backers-sponsors.md#backers). Sponsoring directly impacts the longevity of this project.
+
+**🥇 Gold sponsors (\$3000+ total contribution):** <br/>
+<a href="https://mendix.com/"><img src="https://mobx.js.org/assets/mendix-logo.png" align="center" width="80" title="Mendix" alt="Mendix" /></a>
+<a href="https://frontendmasters.com/"><img src="https://mobx.js.org/assets/frontendmasters.jpg" align="center" width="80" title="Frontend Masters" alt="Frontend Masters"></a>
+<a href="https://opensource.facebook.com/"><img src="https://mobx.js.org/assets/fbos.jpeg" align="center" width="80" title="Facebook Open Source" alt="Facebook Open Source" /></a>
+<a href="http://auctionfrontier.com/"><img src="https://mobx.js.org/assets/auctionfrontier.jpeg" align="center" width="80" title="Auction Frontier" alt="Auction Frontier"></a>
+<a href="https://www.guilded.gg/"><img src="https://mobx.js.org/assets/guilded.jpg" align="center" width="80" title="Guilded" alt="Guilded" /></a>
+<a href="https://coinbase.com/"><img src="https://mobx.js.org/assets/coinbase.jpeg" align="center" width="80" title="Coinbase" alt="Coinbase" /></a>
+<a href="https://www.canva.com/"><img src="https://mobx.js.org/assets/canva.png" align="center" width="80" title="Canva" alt="Canva" /></a>
+
+**🥈 Silver sponsors (\$100+ per month):**<br/>
+<a href="https://www.codefirst.co.uk/"><img src="https://mobx.js.org/assets/codefirst.png" align="center" width="80" title="CodeFirst" alt="CodeFirst"/></a>
+<a href="https://www.dcsl.com/"><img src="https://mobx.js.org/assets/dcsl.png" align="center" width="80" title="DCSL Guidesmiths" alt="DCSL Guidesmiths"/></a>
+<a href="https://www.bugsnag.com/platforms/react-error-reporting?utm_source=MobX&utm_medium=Website&utm_content=open-source&utm_campaign=2019-community&utm_term=20190913"><img src="https://mobx.js.org/assets/bugsnag.jpg" align="center" width="80" title="Bugsnag" alt="Bugsnag"/></a>
+<a href="https://curology.com/blog/tech"><img src="https://mobx.js.org/assets/curology.png" align="center" width="80" title="Curology" alt="Curology"/></a>
+<a href="https://modulz.app/"><img src="https://mobx.js.org/assets/modulz.png" align="center" width="80" title="Modulz" alt="Modulz"/></a>
+<a href="https://space307.com/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/space307.png" align="center" width="80" title="Space307" alt="Space307"/></a>
+<a href="https://casinosites.ltd.uk/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/casino2.png" align="center" width="80" title="Casino Sites" alt="Casino Sites"/></a>
+
+**🥉 Bronze sponsors (\$500+ total contributions):**<br/>
+<a href="https://mantro.net/jobs/warlock"><img src="https://mobx.js.org/assets/mantro.png" align="center" width="80" title="mantro GmbH" alt="mantro GmbH"></a>
+<a href="https://www.algolia.com/"><img src="https://mobx.js.org/assets/algolia.jpg" align="center" width="80" title="Algolia" alt="Algolia" /></a>
+<a href="https://talentplot.com/"><img src="https://mobx.js.org/assets/talentplot.png" align="center" width="80" title="talentplot" alt="talentplot"></a>
+<a href="https://careers.dazn.com/"><img src="https://mobx.js.org/assets/dazn.png" align="center" width="80" title="DAZN" alt="DAZN"></a>
+<a href="https://blokt.com/"><img src="https://mobx.js.org/assets/blokt.jpg" align="center" width="80" title="Blokt" alt="Blokt"/></a>
+
+---
 
 ## A quick example
 
@@ -129,7 +137,7 @@ setInterval(() => {
 }, 1000)
 ```
 
-The `observer` wrapper around the `TimerView` React component, will automatically detect that rendering
+The `observer` wrapper around the `TimerView` React component will automatically detect that rendering
 depends on the `timer.secondsPassed` observable, even though this relationship is not explicitly defined. The reactivity system will take care of re-rendering the component when _precisely that_ field is updated in the future.
 
 Every event (`onClick` / `setInterval`) invokes an _action_ (`myTimer.increase` / `myTimer.reset`) that updates _observable state_ (`myTimer.secondsPassed`).
@@ -139,49 +147,37 @@ Changes in the observable state are propagated precisely to all _computations_ a
 
 This conceptual picture can be applied to the above example, or any other application using MobX.
 
-To learn about the core concepts of MobX using a larger example, check out [The gist of MobX](https://mobx.js.org/the-gist-of-mobx.html) section, or take the [10 minute interactive introduction to MobX and React](https://mobx.js.org/getting-started).
+## Getting started
+
+To learn about the core concepts of MobX using a larger example, check out **[The gist of MobX](https://mobx.js.org/the-gist-of-mobx.html)** page, or take the **[10 minute interactive introduction to MobX and React](https://mobx.js.org/getting-started)**.
+
 The philosophy and benefits of the mental model provided by MobX are also described in great detail in the blog posts [UI as an afterthought](https://michel.codes/blogs/ui-as-an-afterthought) and [How to decouple state and UI (a.k.a. you don’t need componentWillMount)](https://hackernoon.com/how-to-decouple-state-and-ui-a-k-a-you-dont-need-componentwillmount-cc90b787aa37).
 
-<div class="cheat"><a href="https://gum.co/fSocU"><button title="Download the MobX 6 cheat sheet and sponsor the project">Download the MobX 6 cheat sheet</button></a></div>
+## Further resources
 
-## What others are saying...
-
-> Guise, #mobx isn't pubsub, or your grandpa's observer pattern. Nay, it is a carefully orchestrated observable dimensional portal fueled by the power cosmic. It doesn't do change detection, it's actually a level 20 psionic with soul knife, slashing your viewmodel into submission.
-
-> After using #mobx for lone projects for a few weeks, it feels awesome to introduce it to the team. Time: 1/2, Fun: 2X
-
-> Working with #mobx is basically a continuous loop of me going “this is way too simple, it definitely won’t work” only to be proven wrong
-
-> I have built big apps with MobX already and comparing to the one before that which was using Redux, it is simpler to read and much easier to reason about.
-
-> The #mobx is the way I always want things to be! It's really surprising simple and fast! Totally awesome! Don't miss it!
-
-## Further resources and documentation
-
--   [MobX cheat sheet (also sponsors the project)](https://gum.co/fSocU)
+-   The [MobX cheat sheet](https://gum.co/fSocU) (£5) is both useful and sponsors the project
 -   [10 minute interactive introduction to MobX and React](https://mobx.js.org/getting-started)
 -   [Egghead.io course, based on MobX 3](https://egghead.io/courses/manage-complex-state-in-react-apps-with-mobx)
+-   The [MobX awesome list](https://github.com/mobxjs/awesome-mobx#awesome-mobx) – a long list of MobX resources and example projects
 
 ### The MobX book
 
-[<img src="https://mobx.js.org/assets/book.jpg" height="80px"/> ](https://books.google.nl/books?id=ALFmDwAAQBAJ&pg=PP1&lpg=PP1&dq=michel+weststrate+mobx+quick+start+guide:+supercharge+the+client+state+in+your+react+apps+with+mobx&source=bl&ots=D460fxti0F&sig=ivDGTxsPNwlOjLHrpKF1nweZFl8&hl=nl&sa=X&ved=2ahUKEwiwl8XO--ncAhWPmbQKHWOYBqIQ6AEwAnoECAkQAQ#v=onepage&q=michel%20weststrate%20mobx%20quick%20start%20guide%3A%20supercharge%20the%20client%20state%20in%20your%20react%20apps%20with%20mobx&f=false)
+<a href="https://www.packtpub.com/product/mobx-quick-start-guide/9781789344837"><img src="https://mobx.js.org/assets/book.jpg" height="120px" /></a>
 
-Created by [Pavan Podila](https://twitter.com/pavanpodila) and [Michel Weststrate](https://twitter.com/mweststrate).
+The **[MobX Quick Start Guide](https://www.packtpub.com/product/mobx-quick-start-guide/9781789344837)** ($24.99) by [Pavan Podila](https://twitter.com/pavanpodila) and [Michel Weststrate](https://twitter.com/mweststrate) is available as an [ebook](https://www.packtpub.com/product/mobx-quick-start-guide/9781789344837), [paperback](https://www.amazon.com/MobX-Quick-Start-Guide-Supercharge/dp/1789344832), and on the [O'Reilly platform](https://www.oreilly.com/library/view/mobx-quick-start/9781789344837/) (see [preview](https://books.google.com/books?id=ALFmDwAAQBAJ&printsec=frontcover#v=onepage&q&f=false)).
 
 ### Videos
 
--   [Introduction to MobX & React in 2020](https://www.youtube.com/watch?v=pnhIJA64ByY) by Leigh Halliday, _17min_.
--   [ReactNext 2016: Real World MobX](https://www.youtube.com/watch?v=Aws40KOx90U) by Michel Weststrate, _40min_, [slides](https://docs.google.com/presentation/d/1DrI6Hc2xIPTLBkfNH8YczOcPXQTOaCIcDESdyVfG_bE/edit?usp=sharing).
--   [CityJS 2020: MobX, from mutable to immutable, to observable data](https://youtu.be/sP7dtZm_Wx0?t=27050) by Michel Weststrate, _30min_.
--   [OpenSourceNorth: Practical React with MobX (ES5)](https://www.youtube.com/watch?v=XGwuM_u7UeQ) by Matt Ruby, _42min_.
--   [HolyJS 2019: MobX and the unique symbiosis of predictability and speed](https://www.youtube.com/watch?v=NBYbBbjZeX4&list=PL8sJahqnzh8JJD7xahG5zXkjfM5GOgcPA&index=21&t=0s) by Michel Weststrate, _59min_.
--   [React Amsterdam 2016: State Management Is Easy](https://www.youtube.com/watch?v=ApmSsu3qnf0&feature=youtu.be) by Michel Weststrate, _20min_, [slides](https://speakerdeck.com/mweststrate/state-management-is-easy-introduction-to-mobx).
--   {🚀} [React Live 2019: Reinventing MobX](https://www.youtube.com/watch?v=P_WqKZxpX8g) by Max Gallo, _27min_.
-
-And an all around [MobX awesome list](https://github.com/mobxjs/awesome-mobx#awesome-mobx).
+-   [Introduction to MobX & React in 2020](https://www.youtube.com/watch?v=pnhIJA64ByY) by Leigh Halliday, _17 min_.
+-   [ReactNext 2016: Real World MobX](https://www.youtube.com/watch?v=Aws40KOx90U) by Michel Weststrate, _40 min_, [slides](https://docs.google.com/presentation/d/1DrI6Hc2xIPTLBkfNH8YczOcPXQTOaCIcDESdyVfG_bE/edit?usp=sharing).
+-   [CityJS 2020: MobX, from mutable to immutable, to observable data](https://youtu.be/sP7dtZm_Wx0?t=27050) by Michel Weststrate, _30 min_.
+-   [OpenSourceNorth: Practical React with MobX (ES5)](https://www.youtube.com/watch?v=XGwuM_u7UeQ) by Matt Ruby, _42 min_.
+-   [HolyJS 2019: MobX and the unique symbiosis of predictability and speed](https://www.youtube.com/watch?v=NBYbBbjZeX4&list=PL8sJahqnzh8JJD7xahG5zXkjfM5GOgcPA&index=21&t=0s) by Michel Weststrate, _59 min_.
+-   [React Amsterdam 2016: State Management Is Easy](https://www.youtube.com/watch?v=ApmSsu3qnf0&feature=youtu.be) by Michel Weststrate, _20 min_, [slides](https://speakerdeck.com/mweststrate/state-management-is-easy-introduction-to-mobx).
+-   {🚀} [React Live 2019: Reinventing MobX](https://www.youtube.com/watch?v=P_WqKZxpX8g) by Max Gallo, _27 min_.
 
 ## Credits
 
-MobX is inspired by reactive programming principles as found in the spreadsheets. It is inspired by MVVM frameworks like MeteorJS tracker, knockout and Vue.js, but MobX brings _Transparent Functional Reactive Programming_ to the next level and provides a standalone implementation. It implements TFRP in a glitch-free, synchronous, predictable and efficient manner.
+MobX is inspired by reactive programming principles, which are for example used in spreadsheets. It is inspired by model–view–viewmodel frameworks like [MeteorJS's Tracker](https://docs.meteor.com/api/tracker.html), [Knockout](https://knockoutjs.com/) and [Vue.js](https://vuejs.org/), but MobX brings functional reactive programming (FRP) to the next level and provides a standalone implementation. It implements FRP in a glitch-free, synchronous, predictable and efficient manner.
 
-A ton of credits goes to [Mendix](https://github.com/mendix), for providing the flexibility and support to maintain MobX and the chance to proof the philosophy of MobX in a real, complex, performance critical applications.
+A ton of credit goes to [Mendix](https://github.com/mendix), for providing the flexibility and support to maintain MobX and the chance to prove the philosophy of MobX in a real, complex, performance critical applications.

--- a/docs/README.md
+++ b/docs/README.md
@@ -178,6 +178,6 @@ The **[MobX Quick Start Guide](https://www.packtpub.com/product/mobx-quick-start
 
 ## Credits
 
-MobX is inspired by reactive programming principles, which are for example used in spreadsheets. It is inspired by model–view–viewmodel frameworks like [MeteorJS's Tracker](https://docs.meteor.com/api/tracker.html), [Knockout](https://knockoutjs.com/) and [Vue.js](https://vuejs.org/), but MobX brings _Transparent Functional Reactive Programming_ (TFRP) to the next level and provides a standalone implementation. It implements TFRP in a glitch-free, synchronous, predictable and efficient manner.
+MobX is inspired by reactive programming principles, which are for example used in spreadsheets. It is inspired by model–view–viewmodel frameworks like [MeteorJS's Tracker](https://docs.meteor.com/api/tracker.html), [Knockout](https://knockoutjs.com/) and [Vue.js](https://vuejs.org/), but MobX brings _transparent functional reactive programming_ (TFRP, a concept which is further explained in the [MobX book](https://www.packtpub.com/product/mobx-quick-start-guide/9781789344837)) to the next level and provides a standalone implementation. It implements TFRP in a glitch-free, synchronous, predictable and efficient manner.
 
 A ton of credit goes to [Mendix](https://github.com/mendix) for providing the flexibility and support to maintain MobX and the chance to prove the philosophy of MobX in a real, complex, performance critical applications.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,38 @@ _Simple, scalable state management._
 
 ---
 
-> Documentation for older **unsupported** V4/V5 can be [found here](https://github.com/mobxjs/mobx/blob/mobx4and5/docs/README.md), but be sure to read about the [current documentation first](https://mobx.js.org/about-this-documentation.html).
+> Documentation for the older **unsupported** V4/V5 can be [found here](https://github.com/mobxjs/mobx/blob/mobx4and5/docs/README.md), but be sure to read about the [current documentation first](https://mobx.js.org/about-this-documentation.html).
+
+---
+
+MobX is made possible by the generosity of the sponsors below, and many other [individual backers](backers-sponsors.md#backers). Sponsoring directly impacts the longevity of this project.
+
+**🥇 Gold sponsors (\$3000+ total contribution):** <br/>
+<a href="https://mendix.com/"><img src="https://mobx.js.org/assets/mendix-logo.png" align="center" width="80" title="Mendix" alt="Mendix" /></a>
+<a href="https://frontendmasters.com/"><img src="https://mobx.js.org/assets/frontendmasters.jpg" align="center" width="80" title="Frontend Masters" alt="Frontend Masters"></a>
+<a href="https://opensource.facebook.com/"><img src="https://mobx.js.org/assets/fbos.jpeg" align="center" width="80" title="Facebook Open Source" alt="Facebook Open Source" /></a>
+<a href="http://auctionfrontier.com/"><img src="https://mobx.js.org/assets/auctionfrontier.jpeg" align="center" width="80" title="Auction Frontier" alt="Auction Frontier"></a>
+<a href="https://www.guilded.gg/"><img src="https://mobx.js.org/assets/guilded.jpg" align="center" width="80" title="Guilded" alt="Guilded" /></a>
+<a href="https://coinbase.com/"><img src="https://mobx.js.org/assets/coinbase.jpeg" align="center" width="80" title="Coinbase" alt="Coinbase" /></a>
+<a href="https://www.canva.com/"><img src="https://mobx.js.org/assets/canva.png" align="center" width="80" title="Canva" alt="Canva" /></a>
+
+**🥈 Silver sponsors (\$100+ per month):**<br/>
+<a href="https://www.codefirst.co.uk/"><img src="https://mobx.js.org/assets/codefirst.png" align="center" width="80" title="CodeFirst" alt="CodeFirst"/></a>
+<a href="https://www.dcsl.com/"><img src="https://mobx.js.org/assets/dcsl.png" align="center" width="80" title="DCSL Guidesmiths" alt="DCSL Guidesmiths"/></a>
+<a href="https://www.bugsnag.com/platforms/react-error-reporting?utm_source=MobX&utm_medium=Website&utm_content=open-source&utm_campaign=2019-community&utm_term=20190913"><img src="https://mobx.js.org/assets/bugsnag.jpg" align="center" width="80" title="Bugsnag" alt="Bugsnag"/></a>
+<a href="https://curology.com/blog/tech"><img src="https://mobx.js.org/assets/curology.png" align="center" width="80" title="Curology" alt="Curology"/></a>
+<a href="https://modulz.app/"><img src="https://mobx.js.org/assets/modulz.png" align="center" width="80" title="Modulz" alt="Modulz"/></a>
+<a href="https://space307.com/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/space307.png" align="center" width="80" title="Space307" alt="Space307"/></a>
+<a href="https://casinosites.ltd.uk/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/casino2.png" align="center" width="80" title="Casino Sites" alt="Casino Sites"/></a>
+
+**🥉 Bronze sponsors (\$500+ total contributions):**<br/>
+<a href="https://mantro.net/jobs/warlock"><img src="https://mobx.js.org/assets/mantro.png" align="center" width="80" title="mantro GmbH" alt="mantro GmbH"></a>
+<a href="https://www.algolia.com/"><img src="https://mobx.js.org/assets/algolia.jpg" align="center" width="80" title="Algolia" alt="Algolia" /></a>
+<a href="https://talentplot.com/"><img src="https://mobx.js.org/assets/talentplot.png" align="center" width="80" title="talentplot" alt="talentplot"></a>
+<a href="https://careers.dazn.com/"><img src="https://mobx.js.org/assets/dazn.png" align="center" width="80" title="DAZN" alt="DAZN"></a>
+<a href="https://blokt.com/"><img src="https://mobx.js.org/assets/blokt.jpg" align="center" width="80" title="Blokt" alt="Blokt"/></a>
+
+---
 
 ## Introduction
 
@@ -61,37 +92,6 @@ The philosophy behind MobX is simple:
         </div>
     </div>
 </div>
-
----
-
-## Sponsors
-
-MobX is made possible by the generosity of the sponsors below, and many other [individual backers](backers-sponsors.md#backers). Sponsoring directly impacts the longevity of this project.
-
-**🥇 Gold sponsors (\$3000+ total contribution):** <br/>
-<a href="https://mendix.com/"><img src="https://mobx.js.org/assets/mendix-logo.png" align="center" width="80" title="Mendix" alt="Mendix" /></a>
-<a href="https://frontendmasters.com/"><img src="https://mobx.js.org/assets/frontendmasters.jpg" align="center" width="80" title="Frontend Masters" alt="Frontend Masters"></a>
-<a href="https://opensource.facebook.com/"><img src="https://mobx.js.org/assets/fbos.jpeg" align="center" width="80" title="Facebook Open Source" alt="Facebook Open Source" /></a>
-<a href="http://auctionfrontier.com/"><img src="https://mobx.js.org/assets/auctionfrontier.jpeg" align="center" width="80" title="Auction Frontier" alt="Auction Frontier"></a>
-<a href="https://www.guilded.gg/"><img src="https://mobx.js.org/assets/guilded.jpg" align="center" width="80" title="Guilded" alt="Guilded" /></a>
-<a href="https://coinbase.com/"><img src="https://mobx.js.org/assets/coinbase.jpeg" align="center" width="80" title="Coinbase" alt="Coinbase" /></a>
-<a href="https://www.canva.com/"><img src="https://mobx.js.org/assets/canva.png" align="center" width="80" title="Canva" alt="Canva" /></a>
-
-**🥈 Silver sponsors (\$100+ per month):**<br/>
-<a href="https://www.codefirst.co.uk/"><img src="https://mobx.js.org/assets/codefirst.png" align="center" width="80" title="CodeFirst" alt="CodeFirst"/></a>
-<a href="https://www.dcsl.com/"><img src="https://mobx.js.org/assets/dcsl.png" align="center" width="80" title="DCSL Guidesmiths" alt="DCSL Guidesmiths"/></a>
-<a href="https://www.bugsnag.com/platforms/react-error-reporting?utm_source=MobX&utm_medium=Website&utm_content=open-source&utm_campaign=2019-community&utm_term=20190913"><img src="https://mobx.js.org/assets/bugsnag.jpg" align="center" width="80" title="Bugsnag" alt="Bugsnag"/></a>
-<a href="https://curology.com/blog/tech"><img src="https://mobx.js.org/assets/curology.png" align="center" width="80" title="Curology" alt="Curology"/></a>
-<a href="https://modulz.app/"><img src="https://mobx.js.org/assets/modulz.png" align="center" width="80" title="Modulz" alt="Modulz"/></a>
-<a href="https://space307.com/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/space307.png" align="center" width="80" title="Space307" alt="Space307"/></a>
-<a href="https://casinosites.ltd.uk/?utm_source=sponsorship&utm_medium=mobx&utm_campaign=readme"><img src="https://mobx.js.org/assets/casino2.png" align="center" width="80" title="Casino Sites" alt="Casino Sites"/></a>
-
-**🥉 Bronze sponsors (\$500+ total contributions):**<br/>
-<a href="https://mantro.net/jobs/warlock"><img src="https://mobx.js.org/assets/mantro.png" align="center" width="80" title="mantro GmbH" alt="mantro GmbH"></a>
-<a href="https://www.algolia.com/"><img src="https://mobx.js.org/assets/algolia.jpg" align="center" width="80" title="Algolia" alt="Algolia" /></a>
-<a href="https://talentplot.com/"><img src="https://mobx.js.org/assets/talentplot.png" align="center" width="80" title="talentplot" alt="talentplot"></a>
-<a href="https://careers.dazn.com/"><img src="https://mobx.js.org/assets/dazn.png" align="center" width="80" title="DAZN" alt="DAZN"></a>
-<a href="https://blokt.com/"><img src="https://mobx.js.org/assets/blokt.jpg" align="center" width="80" title="Blokt" alt="Blokt"/></a>
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ MobX is made possible by the generosity of the sponsors below, and many other [i
 
 _Anything that can be derived from the application state, should be. Automatically._
 
-MobX is a battle-tested library that makes state management simple and scalable by transparently applying the principles of functional reactive programming.
+MobX is a battle-tested library that makes state management simple and scalable by transparently applying functional reactive programming.
 The philosophy behind MobX is simple:
 
 <div class="benefits">
@@ -178,6 +178,6 @@ The **[MobX Quick Start Guide](https://www.packtpub.com/product/mobx-quick-start
 
 ## Credits
 
-MobX is inspired by reactive programming principles, which are for example used in spreadsheets. It is inspired by model–view–viewmodel frameworks like [MeteorJS's Tracker](https://docs.meteor.com/api/tracker.html), [Knockout](https://knockoutjs.com/) and [Vue.js](https://vuejs.org/), but MobX brings functional reactive programming (FRP) to the next level and provides a standalone implementation. It implements FRP in a glitch-free, synchronous, predictable and efficient manner.
+MobX is inspired by reactive programming principles, which are for example used in spreadsheets. It is inspired by model–view–viewmodel frameworks like [MeteorJS's Tracker](https://docs.meteor.com/api/tracker.html), [Knockout](https://knockoutjs.com/) and [Vue.js](https://vuejs.org/), but MobX brings _Transparent Functional Reactive Programming_ (TFRP) to the next level and provides a standalone implementation. It implements TFRP in a glitch-free, synchronous, predictable and efficient manner.
 
-A ton of credit goes to [Mendix](https://github.com/mendix), for providing the flexibility and support to maintain MobX and the chance to prove the philosophy of MobX in a real, complex, performance critical applications.
+A ton of credit goes to [Mendix](https://github.com/mendix) for providing the flexibility and support to maintain MobX and the chance to prove the philosophy of MobX in a real, complex, performance critical applications.

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -204,7 +204,7 @@ Check out the [above code block](#examples) for an example.
 
 ## Actions and inheritance
 
-Only actions defined **on prototype** can be **overriden** by subclass:
+Only actions defined **on prototype** can be **overridden** by subclass:
 
 ```javascript
 class Parent {

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -154,7 +154,7 @@ For debugging purposes, we recommend to either name the wrapped function, or pas
 
 Another feature of actions is that they are [untracked](api.md#untracked). When an action is called from inside a side effect or a computed value (very rare!), observables read by the action won't be counted towards the dependencies of the derivation
 
-`makeAutoObservable`, `extendObservable` and `observable` use a special flavour of `action` called `autoAction`,
+`makeAutoObservable`, `extendObservable` and `observable` use a special flavour of `action` called [`autoAction`](observable-state.md#autoAction),
 that will determine at runtime if the function is a derivation or action.
 
 </details>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 ---
 title: MobX API Reference
-sidebar_label: MobX API Reference
+sidebar_label: API
 hide_title: true
 ---
 
@@ -11,7 +11,7 @@ hide_title: true
 Functions marked with {🚀} are considered advanced, and should typically not be needed.
 Consider downloading our handy cheat sheet that explains all important APIs on a single page:
 
-<div class="cheat"><a href="https://gum.co/fSocU"><button title="Download the MobX 6 cheat sheet and sponsor the project">Download the MobX 6 cheat sheet</button></a></div>
+<div class="cheat"><a href="https://gum.co/fSocU"><button title="Download the MobX 6 cheat sheet and sponsor the project">Get the MobX 6 cheat sheet (£5)</button></a></div>
 
 ## Core APIs
 
@@ -25,13 +25,15 @@ _Making things observable._
 
 ### `makeObservable`
 
-[**Usage**](observable-state.md#makeobservable): `makeObservable(target, annotations?, options?)`
+Usage: `makeObservable(target, annotations?, options?)`
+<small>(<b>[further information](observable-state.md#makeobservable)</b>)</small>
 
 Properties, entire objects, arrays, Maps and Sets can all be made observable.
 
 ### `makeAutoObservable`
 
-[**Usage**](observable-state.md#makeautoobservable): `makeAutoObservable(target, overrides?, options?)`
+Usage: `makeAutoObservable(target, overrides?, options?)`
+<small>(<b>[further information](observable-state.md#makeautoobservable)</b>)</small>
 
 Automatically make properties, objects, arrays, Maps and Sets observable.
 
@@ -55,13 +57,15 @@ It is possible to use `extendObservable` to add observable fields to an existing
 
 ### `observable`
 
-[**Usage**](observable-state.md#observable): `observable(source, overrides?, options?)` or `observable` _(annotation)_
+Usage: `observable(source, overrides?, options?)` or `observable` _(annotation)_
+<small>(<b>[further information](observable-state.md#observable)</b>)</small>
 
 Clones an object and makes it observable. Source can be a plain object, array, Map or Set. By default, `observable` is applied recursively. If one of the encountered values is an object or array, that value will be passed through `observable` as well.
 
 ### `observable.object`
 
-{🚀} [**Usage**](observable-state.md#observable): `observable.object(source, overrides?, options?)`
+{🚀} Usage: `observable.object(source, overrides?, options?)`
+<small>(<b>[further information](observable-state.md#observable)</b>)</small>
 
 Alias for `observable(source, overrides?, options?)`. Creates a clone of the provided object and makes all of its properties observable.
 
@@ -105,25 +109,29 @@ If the values in the Set should not be turned into observables automatically, us
 
 ### `observable.ref`
 
-[**Usage**](observable-state.md#available-annotations): `observable.ref` _(annotation)_
+Usage: `observable.ref` _(annotation)_
+<small>(<b>[further information](observable-state.md#available-annotations)</b>)</small>
 
 Like the `observable` annotation, but only reassignments will be tracked. The assigned values themselves won't be made observable automatically. For example, use this if you intend to store immutable data in an observable field.
 
 ### `observable.shallow`
 
-[**Usage**](observable-state.md#available-annotations): `observable.shallow` _(annotation)_
+Usage: `observable.shallow` _(annotation)_
+<small>(<b>[further information](observable-state.md#available-annotations)</b>)</small>
 
 Like the `observable.ref` annotation, but for collections. Any collection assigned will be made observable, but the contents of the collection itself won't become observable.
 
 ### `observable.struct`
 
-{🚀} [**Usage**](observable-state.md#available-annotations): `observable.struct` _(annotation)_
+{🚀} Usage: `observable.struct` _(annotation)_
+<small>(<b>[further information](observable-state.md#available-annotations)</b>)</small>
 
 Like the `observable` annotation, except that any assigned value that is structurally equal to the current value will be ignored.
 
 ### `observable.deep`
 
-{🚀} [**Usage**](observable-state.md#available-annotations): `observable.deep` _(annotation)_
+{🚀} Usage: `observable.deep` _(annotation)_
+<small>(<b>[further information](observable-state.md#available-annotations)</b>)</small>
 
 Alias for the [`observable`](#observable) annotation.
 
@@ -162,25 +170,29 @@ _An action is any piece of code that modifies the state._
 
 ### `action`
 
-[**Usage**](actions.md): `action(fn)` or `action` _(annotation)_
+Usage: `action(fn)` or `action` _(annotation)_
+<small>(<b>[further information](actions.md)</b>)</small>
 
 Use on functions that intend to modify the state.
 
 ### `runInAction`
 
-{🚀} [**Usage**](actions.md#runinaction): `runInAction(fn)`
+{🚀} Usage: `runInAction(fn)`
+<small>(<b>[further information](actions.md#runinaction)</b>)</small>
 
 Create a one-time action that is immediately invoked.
 
 ### `flow`
 
-[**Usage**](actions.md#using-flow-instead-of-async--await-): `flow(fn)` or `flow` _(annotation)_
+Usage: `flow(fn)` or `flow` _(annotation)_
+<small>(<b>[further information](actions.md#using-flow-instead-of-async--await-)</b>)</small>
 
 MobX friendly replacement for `async` / `await` that supports cancellation.
 
 ### `flowResult`
 
-[**Usage**](actions.md#using-flow-instead-of-async--await-): `flowResult(flowFunctionResult)`
+Usage: `flowResult(flowFunctionResult)`
+<small>(<b>[further information](actions.md#using-flow-instead-of-async--await-)</b>)</small>
 
 For TypeScript users only. Utility that casts the output of the generator to a promise.
 This is just a type-wise correction for the promise wrapping done by `flow`. At runtime it directly returns the inputted value.
@@ -193,7 +205,8 @@ _Computed values can be used to derive information from other observables._
 
 ### `computed`
 
-[**Usage**](computeds.md): `computed(fn, options?)` or `computed(options?)` _(annotation)_
+Usage: `computed(fn, options?)` or `computed(options?)` _(annotation)_
+<small>(<b>[further information](computeds.md)</b>)</small>
 
 Creates an observable value that is derived from other observables, but won't be recomputed unless one of the underlying observables changes.
 
@@ -205,19 +218,22 @@ _From the `mobx-react` / `mobx-react-lite` packages._
 
 ### `observer`
 
-[**Usage**](react-integration.md): `observer(component)`
+Usage: `observer(component)`
+<small>(<b>[further information](react-integration.md)</b>)</small>
 
 A higher order component you can use to make a functional or class based React component re-render when observables change.
 
 ### `Observer`
 
-[**Usage**](react-integration.md#callback-components-might-require-observer): `<Observer>{() => rendering}</Observer>`
+Usage: `<Observer>{() => rendering}</Observer>`
+<small>(<b>[further information](react-integration.md#callback-components-might-require-observer)</b>)</small>
 
 Renders the given render function, and automatically re-renders it once one of the observables used in the render function changes.
 
 ### `useLocalObservable`
 
-[**Usage**](react-integration.md#using-local-observable-state-in-observer-components): `useLocalObservable(() => source, annotations?)`
+Usage: `useLocalObservable(() => source, annotations?)`
+<small>(<b>[further information](react-integration.md#using-local-observable-state-in-observer-components)</b>)</small>
 
 Creates a new observable object using `makeObservable`, and keeps it around in the component for the entire life-cycle of the component.
 
@@ -229,19 +245,22 @@ _The goal of reactions is to model side effects that happen automatically._
 
 ### `autorun`
 
-[**Usage**](reactions.md#autorun): `autorun(() => effect, options?)`
+Usage: `autorun(() => effect, options?)`
+<small>(<b>[further information](reactions.md#autorun)</b>)</small>
 
 Reruns a function every time anything it observes changes.
 
 ### `reaction`
 
-[**Usage**](reactions.md#reaction): `reaction(() => data, data => effect, options?)`
+Usage: `reaction(() => data, data => effect, options?)`
+<small>(<b>[further information](reactions.md#reaction)</b>)</small>
 
 Reruns a side effect when any selected data changes.
 
 ### `when`
 
-[**Usage**](reactions.md#when): `when(() => condition, () => effect, options?)` or `await when(() => condition, options?)`
+Usage: `when(() => condition, () => effect, options?)` or `await when(() => condition, options?)`
+<small>(<b>[further information](reactions.md#when)</b>)</small>
 
 Executes a side effect once when a observable condition becomes true.
 
@@ -259,32 +278,37 @@ Attaches a global error listener, which is invoked for every error that is throw
 
 ### `intercept`
 
-{🚀} [**Usage**](intercept-and-observe.md#intercept): `intercept(propertyName|array|object|Set|Map, listener)`
+{🚀} Usage: `intercept(propertyName|array|object|Set|Map, listener)`
+<small>(<b>[further information](intercept-and-observe.md#intercept)</b>)</small>
 
 Intercepts changes before they are applied to an observable API. Returns a disposer function that stops the interception.
 
 ### `observe`
 
-{🚀} [**Usage**](intercept-and-observe.md#observe): `observe(propertyName|array|object|Set|Map, listener)`
+{🚀} Usage: `observe(propertyName|array|object|Set|Map, listener)`
+<small>(<b>[further information](intercept-and-observe.md#observe)</b>)</small>
 
 Low-level API that can be used to observe a single observable value. Returns a disposer function that stops the interception.
 
 ### `onBecomeObserved`
 
-{🚀} [**Usage**](lazy-observables.md): `onBecomeObserved(observable, property?, listener: () => void)`
+{🚀} Usage: `onBecomeObserved(observable, property?, listener: () => void)`
+<small>(<b>[further information](lazy-observables.md)</b>)</small>
 
 Hook for when something becomes observed.
 
 ### `onBecomeUnobserved`
 
-{🚀} [**Usage**](lazy-observables.md): `onBecomeUnobserved(observable, property?, listener: () => void)`
+{🚀} Usage: `onBecomeUnobserved(observable, property?, listener: () => void)`
+<small>(<b>[further information](lazy-observables.md)</b>)</small>
 
 Hook for when something stops being observed.
 
 ### `toJS`
 
-[**Usage**](observable-state.md#converting-observables-back-to-vanilla-javascript-collections): `toJS(value)`
- 
+Usage: `toJS(value)`
+<small>(<b>[further information](observable-state.md#converting-observables-back-to-vanilla-javascript-collections)</b>)</small>
+
 Recursively converts an observable object to a JavaScript _object_. Supports observable arrays, objects, Maps and primitives.
 
 It does NOT recurse into non-observables, these are left as they are, even if they contain observables.
@@ -311,7 +335,8 @@ _Fine-tuning your MobX instance._
 
 ### `configure`
 
-[**Usage**](configuration.md): sets global behavior settings on the active MobX instance.
+Usage: sets global behavior settings on the active MobX instance.
+<small>(<b>[further information](configuration.md)</b>)</small>
 Use it to change how MobX behaves as a whole.
 
 ---
@@ -322,43 +347,50 @@ _They enable manipulating observable arrays, objects and Maps with the same gene
 
 ### `values`
 
-{🚀} [**Usage**](collection-utilities.md): `values(array|object|Set|Map)`
+{🚀} Usage: `values(array|object|Set|Map)`
+<small>(<b>[further information](collection-utilities.md)</b>)</small>
 
 Returns all values in the collection as an array.
 
 ### `keys`
 
-{🚀} [**Usage**](collection-utilities.md): `keys(array|object|Set|Map)`
+{🚀} Usage: `keys(array|object|Set|Map)`
+<small>(<b>[further information](collection-utilities.md)</b>)</small>
 
 Returns all keys / indices in the collection as an array.
 
 ### `entries`
 
-{🚀} [**Usage**](collection-utilities.md): `entries(array|object|Set|Map)`
+{🚀} Usage: `entries(array|object|Set|Map)`
+<small>(<b>[further information](collection-utilities.md)</b>)</small>
 
 Returns a `[key, value]` pair of every entry in the collection as an array.
 
 ### `set`
 
-{🚀} [**Usage**](collection-utilities.md): `set(array|object|Map, key, value)`
+{🚀} Usage: `set(array|object|Map, key, value)`
+<small>(<b>[further information](collection-utilities.md)</b>)</small>
 
 Updates the collection.
 
 ### `remove`
 
-{🚀} [**Usage**](collection-utilities.md): `remove(array|object|Map, key)`
+{🚀} Usage: `remove(array|object|Map, key)`
+<small>(<b>[further information](collection-utilities.md)</b>)</small>
 
 Removes item from the collection.
 
 ### `has`
 
-{🚀} [**Usage**](collection-utilities.md): `has(array|object|Map, key)`
+{🚀} Usage: `has(array|object|Map, key)`
+<small>(<b>[further information](collection-utilities.md)</b>)</small>
 
 Checks for membership in the collection.
 
 ### `get`
 
-{🚀} [**Usage**](collection-utilities.md): `get(array|object|Map, key)`
+{🚀} Usage: `get(array|object|Map, key)`
+<small>(<b>[further information](collection-utilities.md)</b>)</small>
 
 Gets value from the collection with key.
 
@@ -430,31 +462,36 @@ Is this a computed property?
 
 ### `trace`
 
-{🚀} [**Usage**](analyzing-reactivity.md): `trace()`, `trace(true)` _(enter debugger)_ or `trace(object, propertyName, enterDebugger?)`
+{🚀} Usage: `trace()`, `trace(true)` _(enter debugger)_ or `trace(object, propertyName, enterDebugger?)`
+<small>(<b>[further information](analyzing-reactivity.md)</b>)</small>
 
 Should be used inside an observer, reaction or computed value. Logs when the value is invalidated, or sets the debugger breakpoint if called with _true_.
 
 ### `spy`
 
-{🚀} [**Usage**](analyzing-reactivity.md#spy): `spy(eventListener)`
+{🚀} Usage: `spy(eventListener)`
+<small>(<b>[further information](analyzing-reactivity.md#spy)</b>)</small>
 
 Registers a global spy listener that listens to all events that happen in MobX.
 
 ### `getDebugName`
 
-{🚀} [**Usage**](analyzing-reactivity.md#getdebugname): `getDebugName(reaction|array|Set|Map)` or `getDebugName(object|Map, propertyName)`
+{🚀} Usage: `getDebugName(reaction|array|Set|Map)` or `getDebugName(object|Map, propertyName)`
+<small>(<b>[further information](analyzing-reactivity.md#getdebugname)</b>)</small>
 
 Returns the (generated) friendly debug name for an observable or reaction.
 
 ### `getDependencyTree`
 
-{🚀} [**Usage**](analyzing-reactivity.md#getdependencytree): `getDependencyTree(object, computedPropertyName)`
+{🚀} Usage: `getDependencyTree(object, computedPropertyName)`
+<small>(<b>[further information](analyzing-reactivity.md#getdependencytree)</b>)</small>
 
 Returns a tree structure with all observables the given reaction / computation currently depends upon.
 
 ### `getObserverTree`
 
-{🚀} [**Usage**](analyzing-reactivity.md#getobservertree): `getObserverTree(array|Set|Map)` or `getObserverTree(object|Map, propertyName)`
+{🚀} Usage: `getObserverTree(array|Set|Map)` or `getObserverTree(object|Map, propertyName)`
+<small>(<b>[further information](analyzing-reactivity.md#getobservertree)</b>)</small>
 
 Returns a tree structure with all reactions / computations that are observing the given observable.
 
@@ -466,7 +503,8 @@ _In the rare case you want to extend MobX itself._
 
 ### `createAtom`
 
-{🚀} [**Usage**](custom-observables.md): `createAtom(name, onBecomeObserved?, onBecomeUnobserved?)`
+{🚀} Usage: `createAtom(name, onBecomeObserved?, onBecomeUnobserved?)`
+<small>(<b>[further information](custom-observables.md)</b>)</small>
 
 Creates your own observable data structure and hooks it up to MobX. Used internally by all observable data types. Atom exposes two _report_ methods to notify MobX with when:
 
@@ -475,7 +513,8 @@ Creates your own observable data structure and hooks it up to MobX. Used interna
 
 ### `getAtom`
 
-{🚀} [**Usage**](analyzing-reactivity.md#getatom): `getAtom(thing, property?)`
+{🚀} Usage: `getAtom(thing, property?)`
+<small>(<b>[further information](analyzing-reactivity.md#getatom)</b>)</small>
 
 Returns the backing atom.
 

--- a/docs/custom-observables.md
+++ b/docs/custom-observables.md
@@ -8,19 +8,17 @@ hide_title: true
 
 # Creating custom observables {🚀}
 
-## Atoms
-
 At some point you might want to have more data structures or other things (like streams) that can be used in reactive computations.
-Achieving this is pretty simple by using the concept of atoms.
-Atoms can be used to signal MobX that some observable data source has been observed or changed, and MobX will signal the atom whenever it is used or no longer in use.
+Achieving this is pretty simple by using **atoms**, which is the class that MobX uses internally for all observable data types.
+Atoms can be used to signal to MobX that some observable data source has been observed or changed, and MobX will let the atom know when it's being used and when it's not.
 
-_**Tip**: in many cases you can avoid the need to create your own atoms just by creating a normal observable, and using
+> _**Tip**: In many cases you can avoid the need to create your own atoms just by creating a normal observable, and using
 the [`onBecomeObserved`](lazy-observables.md) utility to be notified when MobX starts tracking it._
 
 The following example demonstrates how you can create an observable `Clock` that returns the current date-time, which can then be used in reactive functions.
 This clock will only actually tick if it is being observed by someone.
 
-The complete API of the `Atom` class is demonstrated by this example.
+The complete API of the `Atom` class is demonstrated by this example. For further information, see [`createAtom`](api.md#createAtom).
 
 ```javascript
 import { createAtom, autorun } from "mobx"

--- a/docs/enabling-decorators.md
+++ b/docs/enabling-decorators.md
@@ -44,7 +44,7 @@ class TodoList {
 }
 ```
 
-MobX before version 6 did not require the `makeObservable(this)` call in the constructor, but because it makes the implementation of decorator simpler and more compatible, it now does. This instructs MobX to make the instances observable following the information in the decorators -- the decorators take the place of the second argument to `makeObservable`.
+MobX before version 6 did not require the `makeObservable(this)` call in the constructor, but because it makes the implementation of decorator simpler and more compatible, it now does. This instructs MobX to make the instances observable following the information in the decorators – the decorators take the place of the second argument to `makeObservable`.
 
 We intend to continue to support decorators in this form.
 Any existing MobX 4/5 codebase can be migrated to use `makeObservable` calls by our [code-mod](https://www.npmjs.com/package/mobx-undecorate).
@@ -52,7 +52,7 @@ When migrating from MobX 4/5 to 6, we recommend to always run the code-mod, to m
 
 Check out the [Migrating from MobX 4/5 {🚀}](migrating-from-4-or-5.md) section.
 
-## Using `observer` as decorator
+## Using `observer` as a decorator
 
 The `observer` function from `mobx-react` is both a function and a decorator that can be used on class components:
 
@@ -89,12 +89,12 @@ Install support for decorators: `npm i --save-dev @babel/plugin-proposal-class-p
 
 Decorators are only supported out of the box when using TypeScript in `create-react-app@^2.1.1` and newer. In older versions or when using vanilla JavaScript use eject, or the [customize-cra](https://github.com/arackaf/customize-cra) package.
 
-## Disclaimer: Limitations of decorator syntax:
+## Disclaimer: Limitations of the decorator syntax
 
-_The current transpiler implementations of decorator syntax are quite limited and don't behave exactly the same.
+The current transpiler implementations of the decorator syntax are quite limited and don't behave exactly the same.
 Also, many compositional patterns are currently not possible with decorators, until the stage-2 proposal has been implemented by all transpilers.
 For this reason the scope of decorator syntax support in MobX is currently scoped to make sure that the supported features
-behave consistently across all environments._
+behave consistently across all environments.
 
 The following patterns are not officially supported by the MobX community:
 

--- a/docs/migrating-from-4-or-5.md
+++ b/docs/migrating-from-4-or-5.md
@@ -40,7 +40,7 @@ Check out [makeObservable / makeAutoObservable](observable-state.md) for more de
 Some specifics to note:
 
 1. Using `makeObservable` / `makeAutoObservable` needs to be done in every class definition that declares MobX based members. So if a sub-class and super-class both introduce observable members, they will both have to call `makeObservable`.
-2. `makeAutoObservable` will mark methods using a new decorator `autoAction`, that will apply `action` only if it is not in a derivation context. This makes it safe to call automatically decorated methods also from computed properties.
+2. `makeAutoObservable` will mark methods using a new decorator [`autoAction`](observable-state.md#autoAction), that will apply `action` only if it is not in a derivation context. This makes it safe to call automatically decorated methods also from computed properties.
 
 Migrating a large code base with lots of classes might be daunting. But no worries, there is a code-mod available that will automate the above process!!
 

--- a/docs/observable-state.md
+++ b/docs/observable-state.md
@@ -12,11 +12,9 @@ Properties, entire objects, arrays, Maps and Sets can all be made observable.
 The basics of making objects observable is specifying an annotation per property using `makeObservable`.
 The most important annotations are:
 
--   `observable` defines a trackable field that stores the state.
--   `action` marks a method as action that will modify the state.
--   `computed` marks a getter that will derive new facts from the state and cache its output.
-
-Collections such as arrays, Maps and Sets are made observable automatically.
+-   [`observable`](#observable) defines a trackable field that stores the state.
+-   [`action`](actions.md) marks a method as an action that will modify the state.
+-   [`computed`](computeds.md) marks a getter that will derive new facts from the state and cache its output.
 
 ## `makeObservable`
 
@@ -24,14 +22,13 @@ Usage:
 
 -   `makeObservable(target, annotations?, options?)`
 
-It can be used to trap _existing_ object properties and make them observable. Any JavaScript object (including class instances) can be passed into `target`.
+This function can be used to make _existing_ object properties observable. Any JavaScript object (including class instances) can be passed into `target`.
 Typically `makeObservable` is used in the constructor of a class, and its first argument is `this`.
 The `annotations` argument maps [annotations](#available-annotations) to each member. Note that when using [decorators](enabling-decorators.md), the `annotations` argument can be omitted.
 
-Methods that derive information and take arguments (for example `findUsersOlderThan(age: number): User[]`) don't need any annotation.
-Their read operations will still be tracked when they are called from a reaction, but their output won't be memoized to avoid memory leaks. Check out [MobX-utils computedFn {🚀}](https://github.com/mobxjs/mobx-utils#computedfn) as well.
+Methods that derive information and take arguments (for example `findUsersOlderThan(age: number): User[]`) can not be annotated as `computed` – their read operations will still be tracked when they are called from a reaction, but their output won't be memoized to avoid memory leaks. To memoize such methods you can use [MobX-utils computedFn {🚀}](https://github.com/mobxjs/mobx-utils#computedfn) instead.
 
-[Subclassing is supported with some limitations](subclassing.md) via `override` annotation.
+[Subclassing is supported with some limitations](subclassing.md) via the [`override`](api.md#observable) argument to [`observable`](api.md#observable).
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--class + makeObservable-->
@@ -123,9 +120,10 @@ Usage:
 
 -   `makeAutoObservable(target, overrides?, options?)`
 
-`makeAutoObservable` is like `makeObservable` on steroids, as it infers all the properties by default. You can still use `overrides` to override the default behavior with specific annotations.
-In particular `false` can be used to exclude a property or method from being processed entirely.
-Check out the code tabs above for an example.
+`makeAutoObservable` is like `makeObservable` on steroids, as it infers all the properties by default. You can however use the `overrides` parameter to override the default behavior with specific annotations —
+in particular `false` can be used to exclude a property or method from being processed entirely.
+Check out the code above for an example.
+
 The `makeAutoObservable` function can be more compact and easier to maintain than using `makeObservable`, since new members don't have to be mentioned explicitly.
 However, `makeAutoObservable` cannot be used on classes that have super or are [subclassed](subclassing.md).
 
@@ -134,7 +132,7 @@ Inference rules:
 -   All _own_ properties become `observable`.
 -   All `get`ters become `computed`.
 -   All `set`ters become `action`.
--   All _functions on prototype_ become `autoAction`.
+-   All _functions on prototype_ become [`autoAction`](#autoAction).
 -   All _generator functions on prototype_ become `flow`. (Note that generator functions are not detectable in some transpiler configurations, if flow doesn't work as expected, make sure to specify `flow` explicitly.)
 -   Members marked with `false` in the `overrides` argument will not be annotated. For example, using it for read only fields such as identifiers.
 
@@ -221,8 +219,8 @@ Note that it is possible to pass `{ proxy: false }` as an option to `observable`
 
 | Annotation                         | Description                                                                                                                                                                                                                                                                                                                        |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `observable`<br/>`observable.deep` | Defines a trackable field that stores state. If possible, any value assigned to `observable` is automatically converted to (deep) `observable`, `autoAction` or `flow` based on it's type. Only `plain object`, `array`, `Map`, `Set`, `function`, `generator function` are convertible. Class instances and others are untouched. |
-| `observable.ref`                   | Like `observable`, but only reassignments will be tracked. The assigned values are completely ignored and will NOT be automatically converted to `observable`/`autoAction`/`flow`. For example, use this if you intend to store immutable data in an observable field.                                                             |
+| `observable`<br/>`observable.deep` | Defines a trackable field that stores state. If possible, any value assigned to `observable` is automatically converted to (deep) `observable`, [`autoAction`](#autoAction) or `flow` based on it's type. Only `plain object`, `array`, `Map`, `Set`, `function`, `generator function` are convertible. Class instances and others are untouched. |
+| `observable.ref`                   | Like `observable`, but only reassignments will be tracked. The assigned values are completely ignored and will NOT be automatically converted to `observable`/[`autoAction`](#autoAction)/`flow`. For example, use this if you intend to store immutable data in an observable field.                                                             |
 | `observable.shallow`               | Like `observable.ref` but for collections. Any collection assigned will be made observable, but the contents of the collection itself won't become observable.                                                                                                                                                                     |
 | `observable.struct`                | Like `observable`, except that any assigned value that is structurally equal to the current value will be ignored.                                                                                                                                                                                                                 |
 | `action`                           | Mark a method as an action that will modify the state. Check out [actions](actions.md) for more details. Non-writable.                                                                                                                                                                                                             |
@@ -234,7 +232,7 @@ Note that it is possible to pass `{ proxy: false }` as an option to `observable`
 | `flow`                             | Creates a `flow` to manage asynchronous processes. Check out [flow](actions.md#using-flow-instead-of-async--await-) for more details. Note that the inferred return type in TypeScript might be off. Non-writable.                                                                                                                 |
 | `flow.bound`                       | Like flow, but will also bind the flow to the instance so that `this` will always be set. Non-writable.                                                                                                                                                                                                                            |
 | `override`                         | [Applicable to inherited `action`, `flow`, `computed`, `action.bound` overriden by subclass](subclassing.md).                                                                                                                                                                                                                      |
-| `autoAction`                       | Should not be used explicitly, but is used under the hood by `makeAutoObservable` to mark methods that can act as action or derivation, based on their calling context.                                                                                                                                                            |
+| <span id="autoAction"></span> `autoAction`                       | Should not be used explicitly, but is used under the hood by `makeAutoObservable` to mark methods that can act as action or derivation, based on their calling context. It will be determined at runtime if the function is a derivation or action. |
 
 ## Limitations
 

--- a/docs/observable-state.md
+++ b/docs/observable-state.md
@@ -28,7 +28,7 @@ The `annotations` argument maps [annotations](#available-annotations) to each me
 
 Methods that derive information and take arguments (for example `findUsersOlderThan(age: number): User[]`) can not be annotated as `computed` – their read operations will still be tracked when they are called from a reaction, but their output won't be memoized to avoid memory leaks. To memoize such methods you can use [MobX-utils computedFn {🚀}](https://github.com/mobxjs/mobx-utils#computedfn) instead.
 
-[Subclassing is supported with some limitations](subclassing.md) via the [`override`](api.md#observable) argument to [`observable`](api.md#observable).
+[Subclassing is supported with some limitations](subclassing.md) by using the `override` annotation (see the example [here](subclassing.md)).
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--class + makeObservable-->
@@ -231,7 +231,7 @@ Note that it is possible to pass `{ proxy: false }` as an option to `observable`
 | `false`                            | Explicitly do not annotate this property.                                                                                                                                                                                                                                                                                          |
 | `flow`                             | Creates a `flow` to manage asynchronous processes. Check out [flow](actions.md#using-flow-instead-of-async--await-) for more details. Note that the inferred return type in TypeScript might be off. Non-writable.                                                                                                                 |
 | `flow.bound`                       | Like flow, but will also bind the flow to the instance so that `this` will always be set. Non-writable.                                                                                                                                                                                                                            |
-| `override`                         | [Applicable to inherited `action`, `flow`, `computed`, `action.bound` overriden by subclass](subclassing.md).                                                                                                                                                                                                                      |
+| `override`                         | [Applicable to inherited `action`, `flow`, `computed`, `action.bound` overridden by subclass](subclassing.md).                                                                                                                                                                                                                      |
 | <span id="autoAction"></span> `autoAction`                       | Should not be used explicitly, but is used under the hood by `makeAutoObservable` to mark methods that can act as action or derivation, based on their calling context. It will be determined at runtime if the function is a derivation or action. |
 
 ## Limitations
@@ -244,7 +244,7 @@ Note that it is possible to pass `{ proxy: false }` as an option to `observable`
    [Can be disabled with `configure({ safeDescriptors: false })` {🚀☣️} ](configuration.md#safedescriptors-boolean).
 1. **All non-observable** (stateless) fields (`action`, `flow`) are **non-writable**.<br>
    [Can be disabled with `configure({ safeDescriptors: false })` {🚀☣️} ](configuration.md#safedescriptors-boolean).
-1. [Only **`action`, `computed`, `flow`, `action.bound`** defined **on prototype** can be **overriden** by subclass](subclassing.md).
+1. [Only **`action`, `computed`, `flow`, `action.bound`** defined **on prototype** can be **overridden** by subclass](subclassing.md).
 1. By default _TypeScript_ will not allow you to annotate **private** fields. This can be overcome by explicitly passing the relevant private fields as generic argument, like this: `makeObservable<MyStore, "privateField" | "privateField2">(this, { privateField: observable, privateField2: observable })`
 1. **Calling `make(Auto)Observable`** and providing annotations must be done **unconditionally**, as this makes it possible to cache the inference results.
 1. **Modifying prototypes** after **`make(Auto)Observable`** has been called is **not supported**.

--- a/docs/subclassing.md
+++ b/docs/subclassing.md
@@ -8,7 +8,7 @@ hide_title: true
 
 # Subclassing
 
-Subclassing is supported with [limitations](#limitations). Most notably you can only **override actions/flows/computeds on prototype** - you cannot override _[field declarations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#field_declarations)_. Use `override` annotation for methods/getters overriden in subclass - see example below. Try to keep things simple and prefer composition over inheritance.
+Subclassing is supported with [limitations](#limitations). Most notably you can only **override actions/flows/computeds on prototype** - you cannot override _[field declarations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#field_declarations)_. Use the `override` annotation for methods/getters overridden in a subclass - see example below. Try to keep things simple and prefer composition over inheritance.
 
 ```javascript
 import { makeObservable, observable, computed, action, override } from "mobx"
@@ -78,7 +78,7 @@ class Child extends Parent {
 
 ## Limitations
 
-1. Only `action`, `computed`, `flow`, `action.bound` defined **on prototype** can be **overriden** by subclass.
+1. Only `action`, `computed`, `flow`, `action.bound` defined **on prototype** can be **overridden** by subclass.
 1. Field can't be re-annotated in subclass, except with `override`.
 1. `makeAutoObservable` does not support subclassing.
 1. Extending builtins (`ObservableMap`, `ObservableArray`, etc) is not supported.

--- a/packages/mobx-react/__tests__/Provider.test.tsx
+++ b/packages/mobx-react/__tests__/Provider.test.tsx
@@ -50,7 +50,7 @@ describe("Provider", () => {
             return (
                 <Provider overridable="original" nonOverridable="original">
                     <B />
-                    <Provider overridable="overriden">
+                    <Provider overridable="overridden">
                         <B />
                     </Provider>
                 </Provider>
@@ -60,7 +60,7 @@ describe("Provider", () => {
         expect(container).toMatchInlineSnapshot(`
 <div>
   original original
-  overriden original
+  overridden original
 </div>
 `)
     })

--- a/packages/mobx-react/__tests__/__snapshots__/observer.test.tsx.snap
+++ b/packages/mobx-react/__tests__/__snapshots__/observer.test.tsx.snap
@@ -5,8 +5,8 @@ exports[`#797 - replacing this.render should trigger a warning 1`] = `
   "calls": Array [
     Array [
       "The reactive render of an observer class component (Component)
-                was overriden after MobX attached. This may result in a memory leak if the
-                overriden reactive render was not properly disposed.",
+                was overridden after MobX attached. This may result in a memory leak if the
+                overridden reactive render was not properly disposed.",
     ],
   ],
   "results": Array [
@@ -24,6 +24,24 @@ exports[`Redeclaring an existing observer component as an observer should log a 
     Array [
       "The provided component class (AlreadyObserver)
                 has already been declared as an observer component.",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`SSR works #3448 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "The reactive render of an observer class component (TestCmp)
+                was overridden after MobX attached. This may result in a memory leak if the
+                overridden reactive render was not properly disposed.",
     ],
   ],
   "results": Array [

--- a/packages/mobx-react/__tests__/disposeOnUnmount.test.tsx
+++ b/packages/mobx-react/__tests__/disposeOnUnmount.test.tsx
@@ -353,7 +353,7 @@ it("componentDidMount should be different between components", () => {
     doTest(false)
 })
 
-test("base cWU should not be called if overriden", () => {
+test("base cWU should not be called if overridden", () => {
     let baseCalled = 0
     let dCalled = 0
     let oCalled = 0

--- a/packages/mobx-react/__tests__/observer.test.tsx
+++ b/packages/mobx-react/__tests__/observer.test.tsx
@@ -1018,6 +1018,8 @@ test("class observer supports re-mounting #3395", () => {
 })
 
 test("SSR works #3448", () => {
+    consoleWarnMock = jest.spyOn(console, "warn").mockImplementation(() => {})
+
     @observer
     class TestCmp extends React.Component<any> {
         render() {
@@ -1032,4 +1034,6 @@ test("SSR works #3448", () => {
     expect(container).toHaveTextContent(":)")
     enableStaticRendering(false)
     unmount()
+
+    expect(consoleWarnMock).toMatchSnapshot()
 })

--- a/packages/mobx-react/src/observerClass.ts
+++ b/packages/mobx-react/src/observerClass.ts
@@ -90,12 +90,12 @@ export function makeClassComponentObserver(
             // Forces reaction to be re-created on next render
             this.render[mobxAdminProperty] = null
         } else {
-            // Render may have been hot-swapped and/or overriden by a subclass.
+            // Render may have been hot-swapped and/or overridden by a subclass.
             const displayName = getDisplayName(this)
             console.warn(
                 `The reactive render of an observer class component (${displayName})
-                was overriden after MobX attached. This may result in a memory leak if the
-                overriden reactive render was not properly disposed.`
+                was overridden after MobX attached. This may result in a memory leak if the
+                overridden reactive render was not properly disposed.`
             )
         }
 

--- a/packages/mobx/CHANGELOG.md
+++ b/packages/mobx/CHANGELOG.md
@@ -256,7 +256,7 @@ Support the ongoing maintenance at: https://opencollective.com/mobx
 
 [`28f8a11d`](https://github.com/mobxjs/mobx/commit/28f8a11d8b94f1aca2eec4ae9c5f45c5ea2f4362) [#2641](https://github.com/mobxjs/mobx/pull/2641) Thanks [@urugator](https://github.com/urugator)!
 
--   `action`, `computed`, `flow` defined on prototype can be overriden by subclass via `override` annotation/decorator. Previously broken.
+-   `action`, `computed`, `flow` defined on prototype can be overridden by subclass via `override` annotation/decorator. Previously broken.
 -   Overriding anything defined on instance itself (`this`) is not supported and should throw. Previously partially possible or broken.
 -   Attempt to re-annotate property always throws. Previously mostly undefined outcome.
 -   All annotated and non-observable props (action/flow) are non-writable. Previously writable.
@@ -1517,7 +1517,7 @@ function Square() {
 
 -   Fixed #360: Removed expensive cycle detection (cycles are still detected, but a bit later)
 -   Fixed #377: `toJS` serialization of Dates and Regexes preserves the original values
--   Fixed #379: `@action` decorated methods can now be inherited / overriden
+-   Fixed #379: `@action` decorated methods can now be inherited / overridden
 
 ## 2.3.3
 

--- a/packages/mobx/src/api/decorators.ts
+++ b/packages/mobx/src/api/decorators.ts
@@ -51,7 +51,7 @@ function assertNotDecorated(prototype: object, annotation: Annotation, key: Prop
             `Cannot apply '@${requestedAnnotationType}' to '${fieldName}':` +
                 `\nThe field is already decorated with '@${currentAnnotationType}'.` +
                 `\nRe-decorating fields is not allowed.` +
-                `\nUse '@override' decorator for methods overriden by subclass.`
+                `\nUse '@override' decorator for methods overridden by subclass.`
         )
     }
 }

--- a/packages/mobx/src/types/observableobject.ts
+++ b/packages/mobx/src/types/observableobject.ts
@@ -776,7 +776,7 @@ function assertAnnotable(
             `Cannot apply '${requestedAnnotationType}' to '${fieldName}':` +
                 `\nThe field is already annotated with '${currentAnnotationType}'.` +
                 `\nRe-annotating fields is not allowed.` +
-                `\nUse 'override' annotation for methods overriden by subclass.`
+                `\nUse 'override' annotation for methods overridden by subclass.`
         )
     }
 }

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -19,7 +19,7 @@
       },
       "api": {
         "title": "MobX API Reference",
-        "sidebar_label": "MobX API Reference"
+        "sidebar_label": "API"
       },
       "backers-sponsors": {
         "title": "MobX Backers and Sponsors"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -10,7 +10,8 @@
       "observable-state",
       "actions",
       "computeds",
-      "reactions"
+      "reactions",
+      "api"
     ],
     "MobX and React": [
       "react-integration",

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -233,3 +233,15 @@ details[open] > summary {
 .tip-anchor::after {
     content: "∞"
 }
+
+blockquote {
+    color: #444a50;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+small {
+    font-size: smaller;
+}


### PR DESCRIPTION
Hi. This pull request changes a handful of things which I found to be confusing when reading this otherwise excellent documentation. I apologize if this PR is too bold — do of course feel free to close this PR should you disagree with these changes.

The changes are:

* I found the lack of a link to the API in the sidebar to be extremely confusing. It turns out that it was in the header, but it still always takes me a while to remember where to look for it.
* The API docs include links to more detailed articles on some topics, but that link is "hidden" behind the "Usage:" label. I did not figure that out at first, and so I've changed the link to a "(further information)" label.
* In "Creating custom observables", it was not clear that "the concept of atoms" refers to a class used interally by MobX.
* README:
  * The main README in GitHub did not include a link to the main documentation at mobx.js.org which I occasionally found confusing.
  * <s>I believe it is better to let readers know *what* the project is about before showing a long list of sponsors, so I've moved the introduction above the list of sponsors.</s>
  * I removed the "What others are saying" section. The quotes were not convincing and fairly childish, which I associate mainly with brand new, non-stable projects.
  * Changed the link to the MobX book from an incomplete Google Books preview to PacktPub/Amazon.
  * Changed the term "Transparent Functional Reactive Programming" to simply "functional reactive programming". The README read as if TFRP is some general term one could be expected to know, but no, it is practically non-existent, not being used by anyone apart from MobX and two (low-impact) papers. "Transparent Reactive Programming" was used internally by someone at Meteor but that term did not catch on either. In my view it is therefore not helpful to readers to include it.
* Removed the sentence "Collections such as arrays, Maps and Sets are made observable automatically" from the page "Creating observable state". It appears that this claim is missing some additional context.
* Added "(£5)" to "Download the Mobx cheat sheet".
* Also some minor wording fixes.