### PR TITLE
Suggest mobx-log instead of mobx-logger

### DIFF
--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -525,4 +525,4 @@ Help! My component isn't re-rendering...
 1. Make sure you grok how tracking works in general. Check out the [Understanding reactivity](understanding-reactivity.md) section.
 1. Read the common pitfalls as described above.
 1. [Configure](configuration.md#linting-options) MobX to warn you of unsound usage of mechanisms and check the console logs.
-1. Use [trace](analyzing-reactivity.md) to verify that you are subscribing to the right things or check what MobX is doing in general using [spy](analyzing-reactivity.md#spy) / the [mobx-logger](https://github.com/winterbe/mobx-logger) package.
+1. Use [trace](analyzing-reactivity.md) to verify that you are subscribing to the right things or check what MobX is doing in general using [spy](analyzing-reactivity.md#spy) / or [mobx-log](https://github.com/kubk/mobx-log) package.

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -525,4 +525,4 @@ Help! My component isn't re-rendering...
 1. Make sure you grok how tracking works in general. Check out the [Understanding reactivity](understanding-reactivity.md) section.
 1. Read the common pitfalls as described above.
 1. [Configure](configuration.md#linting-options) MobX to warn you of unsound usage of mechanisms and check the console logs.
-1. Use [trace](analyzing-reactivity.md) to verify that you are subscribing to the right things or check what MobX is doing in general using [spy](analyzing-reactivity.md#spy) / the [mobx-log](https://github.com/kubk/mobx-log) package.
+1. Use [trace](analyzing-reactivity.md) to verify that you are subscribing to the right things or check what MobX is doing in general using [spy](analyzing-reactivity.md#spy) / [mobx-log](https://github.com/kubk/mobx-log) package.

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -525,4 +525,4 @@ Help! My component isn't re-rendering...
 1. Make sure you grok how tracking works in general. Check out the [Understanding reactivity](understanding-reactivity.md) section.
 1. Read the common pitfalls as described above.
 1. [Configure](configuration.md#linting-options) MobX to warn you of unsound usage of mechanisms and check the console logs.
-1. Use [trace](analyzing-reactivity.md) to verify that you are subscribing to the right things or check what MobX is doing in general using [spy](analyzing-reactivity.md#spy) / or [mobx-log](https://github.com/kubk/mobx-log) package.
+1. Use [trace](analyzing-reactivity.md) to verify that you are subscribing to the right things or check what MobX is doing in general using [spy](analyzing-reactivity.md#spy) / the [mobx-log](https://github.com/kubk/mobx-log) package.

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -525,4 +525,4 @@ Help! My component isn't re-rendering...
 1. Make sure you grok how tracking works in general. Check out the [Understanding reactivity](understanding-reactivity.md) section.
 1. Read the common pitfalls as described above.
 1. [Configure](configuration.md#linting-options) MobX to warn you of unsound usage of mechanisms and check the console logs.
-1. Use [trace](analyzing-reactivity.md) to verify that you are subscribing to the right things or check what MobX is doing in general using [spy](analyzing-reactivity.md#spy) / [mobx-log](https://github.com/kubk/mobx-log) package.
+1. Use [trace](analyzing-reactivity.md) to verify that you are subscribing to the right things or check what MobX is doing in general using [spy](analyzing-reactivity.md#spy) / the [mobx-log](https://github.com/kubk/mobx-log) package.


### PR DESCRIPTION
Almost 1 year ago I had to find a logger for Mobx. I stumbled upon `mobx-logger`, tried it, but unfortunately its output was limited with Mobx 6. I created an issue: https://github.com/winterbe/mobx-logger/issues/34

The issue has no response since then. Last publish of the package was 4 years ago: https://www.npmjs.com/package/mobx-logger

It looks like the package isn't maintained anymore. I've created `mobx-log` to have a Mobx 6 compatible logger. This packages is new and less popular (25 stars VS 230 stars, [503](https://www.npmjs.com/package/mobx-log) weekly downloads vs [3997](https://www.npmjs.com/package/mobx-logger)), but it includes more:
- Chrome formatters for ES6 Proxy
- Access to stores via browser console 
- The issues are being addressed (so far 😅) [Example 1](https://github.com/kubk/mobx-log/issues/9), [Example 2](https://github.com/kubk/mobx-log/issues/23)

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated

<!--
    Feel free to ask help with any of these boxes!
-->
