### PR TITLE
Fix 3514: legacy array compat with Safari 9

### DIFF
--- a/.changeset/fresh-suns-listen.md
+++ b/.changeset/fresh-suns-listen.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+fix regression #3514: LegacyObservableArray compat with Safari 9.\*


### PR DESCRIPTION
Reintroduced workaround from mobx < 6.

Did not test as I don't have a means to do so. 

Fixes #3514