### PR TITLE
Add missing webfont weight and style for getting started page

### DIFF
--- a/website/static/getting-started.html
+++ b/website/static/getting-started.html
@@ -7,7 +7,9 @@
     <meta name="description" content="Ten minute introduction to MobX + React">
 
     <link rel="stylesheet" href="assets/getting-started-assets/style.css" />
-    <link href='https://fonts.googleapis.com/css?family=PT+Serif' rel='stylesheet' type='text/css'>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 
     <link rel="shortcut icon" type="image/png" href="assets/getting-started-assets/images/favicon.png" />
 


### PR DESCRIPTION
Documentation change only.

When including the webfont from Google Fonts, only regular roman was added, and italics/bolds are fallbacking to unexpected styles. This change updates the webfont url to include roman, italics, roman bold and italics bold.

Before:
![mobx js org_getting-started](https://user-images.githubusercontent.com/3235854/198280115-bbe758b6-3ed5-4d9c-980d-29621943e800.png)

After:
![mobx js org_getting-started (1)](https://user-images.githubusercontent.com/3235854/198280148-4d7c4784-1f3f-435a-96ca-cc3f8b67ff87.png)

