### PR TITLE
Make mobx-react compatible with TS 4.8+

### DIFF
--- a/.changeset/polite-meals-drop.md
+++ b/.changeset/polite-meals-drop.md
@@ -1,0 +1,5 @@
+---
+"mobx-react": minor
+---
+
+Make mobx-react compatible with TS 4.8+

--- a/packages/mobx-react/__tests__/context.test.tsx
+++ b/packages/mobx-react/__tests__/context.test.tsx
@@ -71,7 +71,7 @@ test("getDerivedStateFromProps works #447", () => {
         }
     }
 
-    const MainInjected = inject(({ store }) => ({ thing: store.thing }))(Main)
+    const MainInjected = inject(({ store }: { store: { thing: number } }) => ({ thing: store.thing }))(Main)
 
     const store = { thing: 3 }
 

--- a/packages/mobx-react/__tests__/observer.test.tsx
+++ b/packages/mobx-react/__tests__/observer.test.tsx
@@ -326,7 +326,7 @@ test("observer component can be injected", () => {
     )
 
     // N.B, the injected component will be observer since mobx-react 4.0!
-    inject(() => {})(
+    inject(() => ({}))(
         observer(
             class T extends React.Component {
                 render() {

--- a/packages/mobx-react/src/inject.ts
+++ b/packages/mobx-react/src/inject.ts
@@ -6,7 +6,6 @@ import { IReactComponent } from "./types/IReactComponent"
 import { IValueMap } from "./types/IValueMap"
 import { IWrappedComponent } from "./types/IWrappedComponent"
 import { IStoresToProps } from "./types/IStoresToProps"
-import { IKeyValueMap } from "mobx"
 
 /**
  * Store Injection
@@ -81,7 +80,7 @@ export function inject(
 ): <T extends IReactComponent<any>>(
     target: T
 ) => T & (T extends IReactComponent<infer P> ? IWrappedComponent<P> : never)
-export function inject<S extends IKeyValueMap = {}, P extends IKeyValueMap = {}, I extends IKeyValueMap = {}, C extends IKeyValueMap = {}>(
+export function inject<S extends IValueMap = {}, P extends IValueMap = {}, I extends IValueMap = {}, C extends IValueMap = {}>(
     fn: IStoresToProps<S, P, I, C>
 ): <T extends IReactComponent>(target: T) => T & IWrappedComponent<P>
 

--- a/packages/mobx-react/src/inject.ts
+++ b/packages/mobx-react/src/inject.ts
@@ -6,6 +6,7 @@ import { IReactComponent } from "./types/IReactComponent"
 import { IValueMap } from "./types/IValueMap"
 import { IWrappedComponent } from "./types/IWrappedComponent"
 import { IStoresToProps } from "./types/IStoresToProps"
+import { IKeyValueMap } from "mobx"
 
 /**
  * Store Injection
@@ -80,7 +81,7 @@ export function inject(
 ): <T extends IReactComponent<any>>(
     target: T
 ) => T & (T extends IReactComponent<infer P> ? IWrappedComponent<P> : never)
-export function inject<S, P, I, C>(
+export function inject<S extends IKeyValueMap, P extends IKeyValueMap, I extends IKeyValueMap, C extends IKeyValueMap>(
     fn: IStoresToProps<S, P, I, C>
 ): <T extends IReactComponent>(target: T) => T & IWrappedComponent<P>
 

--- a/packages/mobx-react/src/inject.ts
+++ b/packages/mobx-react/src/inject.ts
@@ -81,7 +81,7 @@ export function inject(
 ): <T extends IReactComponent<any>>(
     target: T
 ) => T & (T extends IReactComponent<infer P> ? IWrappedComponent<P> : never)
-export function inject<S extends IKeyValueMap, P extends IKeyValueMap, I extends IKeyValueMap, C extends IKeyValueMap>(
+export function inject<S extends IKeyValueMap = {}, P extends IKeyValueMap = {}, I extends IKeyValueMap = {}, C extends IKeyValueMap = {}>(
     fn: IStoresToProps<S, P, I, C>
 ): <T extends IReactComponent>(target: T) => T & IWrappedComponent<P>
 


### PR DESCRIPTION
Resolves: https://github.com/mobxjs/mobx/issues/3532

As @DanielSWolf wrote (thanks for that!): "This error occurs because TypeScript 4.8 is stricter than previous versions regarding unconstrained type parameters (see the [blog entry announcing TypeScript 4.8](https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#unconstrained-generics-no-longer-assignable-to))." 

I confirm that adding constraint to the generic fixes the issue. Now the generic constraints are identical to `IStoresToProps`: https://github.com/mobxjs/mobx/blob/a39ce7fbe19f92348470ef71ad60555c37a5d5e9/packages/mobx-react/src/types/IStoresToProps.ts#L2+L6

I've chosen `minor` instead of `patch` because it's kinda BC break but at the same time it's a bugfix.