### PR TITLE
Add name to WHEN_TIMEOUT error if available

### DIFF
--- a/packages/mobx/src/api/when.ts
+++ b/packages/mobx/src/api/when.ts
@@ -35,7 +35,7 @@ export function when(predicate: any, arg1?: any, arg2?: any): any {
 function _when(predicate: () => boolean, effect: Lambda, opts: IWhenOptions): IReactionDisposer {
     let timeoutHandle: any
     if (typeof opts.timeout === "number") {
-        const error = new Error("WHEN_TIMEOUT")
+        const error = new Error(`WHEN_TIMEOUT${opts.name ? `: ${opts.name}` : ``}`)
         timeoutHandle = setTimeout(() => {
             if (!disposer[$mobx].isDisposed_) {
                 disposer()


### PR DESCRIPTION
It's useful to have a name attached to the WHEN_TIMEOUT error for debugging/tracing. Since `when` already takes a name as an option this PR just adds the name to the WHEN_TIMEOUT error if it is available.

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [X ] Added/updated unit tests
-   [X ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [X ] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->
