### PR TITLE
fix: action transparently forwards toString of underlying function

### DIFF
--- a/.changeset/sweet-experts-allow.md
+++ b/.changeset/sweet-experts-allow.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+fix: action transparently forwards toString of underlying function

--- a/packages/mobx/__tests__/v5/base/action.js
+++ b/packages/mobx/__tests__/v5/base/action.js
@@ -646,3 +646,18 @@ test("auto action should not update state from inside a derivation", async () =>
     })
     d()
 })
+
+test("action forwards toString of underlying function", async () => {
+    const fn = () => {
+        /* not actually doing anything */
+    }
+    fn.a = 42
+    fn.toString = function () {
+        return `toString referencing this, a=${this.a}`
+    }
+
+    const act = mobx.action(fn)
+
+    expect(fn.toString()).toBe("toString referencing this, a=42")
+    expect(act.toString()).toBe("toString referencing this, a=42")
+})

--- a/packages/mobx/src/core/action.ts
+++ b/packages/mobx/src/core/action.ts
@@ -50,6 +50,7 @@ export function createAction(
         return executeAction(actionName, autoAction, fn, ref || this, arguments)
     }
     res.isMobxAction = true
+    res.toString = () => fn.toString()
     if (isFunctionNameConfigurable) {
         tmpNameDescriptor.value = actionName
         defineProperty(res, "name", tmpNameDescriptor)


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [x] ~~Updated `/docs`. For new functionality, at least `API.md` should be updated~~
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->

Fixes #3653 in that it transparently forwards the output of `toString` for functions wrapped in an action
