### PR TITLE
fix: fix mobx-react-lite release issue, fixes #3662

### DIFF
--- a/.changeset/thin-bugs-boil.md
+++ b/.changeset/thin-bugs-boil.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+(Hopefully) fixed release process for mobx-react-lite

--- a/packages/mobx-react-lite/package.json
+++ b/packages/mobx-react-lite/package.json
@@ -75,6 +75,6 @@
         "test:size": "yarn import-size --report . observer useLocalObservable",
         "test:types": "tsc --noEmit",
         "test:check": "yarn test:types",
-        "prepublish": "yarn build --target publish && yarn build:cjs && yarn build:es"
+        "prepublish": "cd ../mobx && yarn build --target publish && cd ../mobx-react-lite && yarn build --target publish && yarn build:cjs && yarn build:es"
     }
 }


### PR DESCRIPTION
Running prepublish locally on an empty check-out fails the mobx-react-lite build, as the types are nog generated when mobx itself hasn't been build:

```
(typescript) Error: /Users/mweststrate/Desktop/mobx/packages/mobx-react-lite/src/useLocalStore.ts(1,28): semantic error TS2307: Cannot find module 'mobx' or its corresponding type declarations.
Error: /Users/mweststrate/Desktop/mobx/packages/mobx-react-lite/src/useLocalStore.ts(1,28): semantic error TS2307: Cannot find module 'mobx' or its corresponding type declarations.
```

Fixed it by forcing a MobX build in the prepublish script