### PR TITLE
Make trace() noop in production build

### DIFF
--- a/.changeset/fifty-rivers-doubt.md
+++ b/.changeset/fifty-rivers-doubt.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Make trace() noop in production build

--- a/packages/mobx/src/api/trace.ts
+++ b/packages/mobx/src/api/trace.ts
@@ -5,7 +5,7 @@ export function trace(thing?: any, enterBreakPoint?: boolean): void
 export function trace(enterBreakPoint?: boolean): void
 export function trace(...args: any[]): void {
     if (!__DEV__) {
-        die(`trace() is not available in production builds`)
+        return
     }
     let enterBreakPoint = false
     if (typeof args[args.length - 1] === "boolean") {


### PR DESCRIPTION
This PR disables the `trace` functionality in the production build instead of throwing an error. Related discussion: https://github.com/mobxjs/mobx/discussions/3708