### PR TITLE
Fix #3728: observables initialization should not update state version

### DIFF
--- a/.changeset/seven-poems-sneeze.md
+++ b/.changeset/seven-poems-sneeze.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+fix: #3734: `isolateGlobalState: true` makes observer stop to react to store changes

--- a/.changeset/spotty-emus-hear.md
+++ b/.changeset/spotty-emus-hear.md
@@ -5,4 +5,3 @@
 -   fix: #3728: Observable initialization updates state version.
 -   fix: Observable set initialization violates `enforceActions: "always"`.
 -   fix: Changing keys of observable object does not respect `enforceActions`.
--   fix: #3734: `isolateGlobalState: true` makes observer stop to react to store changes

--- a/.changeset/spotty-emus-hear.md
+++ b/.changeset/spotty-emus-hear.md
@@ -5,3 +5,4 @@
 -   fix: #3728: Observable initialization updates state version.
 -   fix: Observable set initialization violates `enforceActions: "always"`.
 -   fix: Changing keys of observable object does not respect `enforceActions`.
+-   fix: #3734: `isolateGlobalState: true` makes observer stop to react to store changes

--- a/.changeset/spotty-emus-hear.md
+++ b/.changeset/spotty-emus-hear.md
@@ -1,0 +1,7 @@
+---
+"mobx": patch
+---
+
+-   fix: #3728: Observable initialization updates state version.
+-   fix: Observable set initialization violates `enforceActions: "always"`.
+-   fix: Changing keys of observable object does not respect `enforceActions`.

--- a/packages/mobx-react-lite/__tests__/observer.test.tsx
+++ b/packages/mobx-react-lite/__tests__/observer.test.tsx
@@ -1107,3 +1107,24 @@ test("StrictMode #3671", async () => {
     )
     expect(container).toHaveTextContent("1")
 })
+
+test("`isolateGlobalState` shouldn't break reactivity #3734", async () => {
+    mobx.configure({ isolateGlobalState: true })
+
+    const o = mobx.observable({ x: 0 })
+
+    const Cmp = observer(() => o.x as any)
+
+    const { container, unmount } = render(<Cmp />)
+
+    expect(container).toHaveTextContent("0")
+    act(
+        mobx.action(() => {
+            o.x++
+        })
+    )
+    expect(container).toHaveTextContent("1")
+    unmount()
+
+    mobx._resetGlobalState()
+})

--- a/packages/mobx-react-lite/__tests__/strictAndConcurrentModeUsingFinalizationRegistry.test.tsx
+++ b/packages/mobx-react-lite/__tests__/strictAndConcurrentModeUsingFinalizationRegistry.test.tsx
@@ -42,9 +42,8 @@ test("uncommitted components should not leak observations", async () => {
     )
 
     // Allow gc to kick in in case to let finalization registry cleanup
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await Promise.resolve()
     gc()
-    await new Promise(resolve => setTimeout(resolve, 0))
     // Can take a while (especially on CI) before gc actually calls the registry
     await waitFor(
         () => {
@@ -55,7 +54,7 @@ test("uncommitted components should not leak observations", async () => {
         },
         {
             timeout: 10_000,
-            interval: 200
+            interval: 150
         }
     )
 })

--- a/packages/mobx-react-lite/__tests__/strictAndConcurrentModeUsingFinalizationRegistry.test.tsx
+++ b/packages/mobx-react-lite/__tests__/strictAndConcurrentModeUsingFinalizationRegistry.test.tsx
@@ -42,7 +42,7 @@ test("uncommitted components should not leak observations", async () => {
     )
 
     // Allow gc to kick in in case to let finalization registry cleanup
-    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 100))
     gc()
     // Can take a while (especially on CI) before gc actually calls the registry
     await waitFor(
@@ -53,8 +53,8 @@ test("uncommitted components should not leak observations", async () => {
             expect(count2IsObserved).toBeFalsy()
         },
         {
-            timeout: 10_000,
-            interval: 150
+            timeout: 15_000,
+            interval: 200
         }
     )
 })

--- a/packages/mobx-react-lite/__tests__/useAsObservableSource.deprecated.test.tsx
+++ b/packages/mobx-react-lite/__tests__/useAsObservableSource.deprecated.test.tsx
@@ -126,19 +126,19 @@ describe("base useAsObservableSource should work", () => {
         const { container } = render(<Parent />)
 
         expect(container.querySelector("span")!.innerHTML).toBe("10")
-        expect(counterRender).toBe(2)
+        expect(counterRender).toBe(1)
 
         act(() => {
             ;(container.querySelector("#inc")! as any).click()
         })
         expect(container.querySelector("span")!.innerHTML).toBe("11")
-        expect(counterRender).toBe(3)
+        expect(counterRender).toBe(2)
 
         act(() => {
             ;(container.querySelector("#incmultiplier")! as any).click()
         })
         expect(container.querySelector("span")!.innerHTML).toBe("22")
-        expect(counterRender).toBe(5) // TODO: should be 3
+        expect(counterRender).toBe(4) // One from props, second from updating local observable (setState during render)
     })
 })
 
@@ -271,7 +271,12 @@ describe("combining observer with props and stores", () => {
             store.x = 10
         })
 
-        expect(renderedValues).toEqual([10, 10, 15, 15, 20]) // TODO: should have one 15 less
+        expect(renderedValues).toEqual([
+            10,
+            15, // props change
+            15, // local observable change (setState during render)
+            20
+        ])
 
         // TODO: re-enable this line. When debugging, the correct value is returned from render,
         // which is also visible with renderedValues, however, querying the dom doesn't show the correct result

--- a/packages/mobx-react-lite/__tests__/useAsObservableSource.test.tsx
+++ b/packages/mobx-react-lite/__tests__/useAsObservableSource.test.tsx
@@ -192,19 +192,19 @@ describe("base useAsObservableSource should work", () => {
         const { container } = render(<Parent />)
 
         expect(container.querySelector("span")!.innerHTML).toBe("10")
-        expect(counterRender).toBe(2)
+        expect(counterRender).toBe(1)
 
         act(() => {
             ;(container.querySelector("#inc")! as any).click()
         })
         expect(container.querySelector("span")!.innerHTML).toBe("11")
-        expect(counterRender).toBe(3)
+        expect(counterRender).toBe(2)
 
         act(() => {
             ;(container.querySelector("#incmultiplier")! as any).click()
         })
         expect(container.querySelector("span")!.innerHTML).toBe("22")
-        expect(counterRender).toBe(5) // TODO: should be 3
+        expect(counterRender).toBe(4) // One from props, second from updating local observable with effect
     })
 })
 
@@ -337,7 +337,12 @@ describe("combining observer with props and stores", () => {
             store.x = 10
         })
 
-        expect(renderedValues).toEqual([10, 10, 15, 15, 20]) // TODO: should have one 15 less
+        expect(renderedValues).toEqual([
+            10,
+            15, // props change
+            15, // local observable change during render (localStore.y = props.y)
+            20
+        ])
 
         expect(container.querySelector("div")!.textContent).toBe("20")
     })

--- a/packages/mobx-react-lite/__tests__/useLocalObservable.test.tsx
+++ b/packages/mobx-react-lite/__tests__/useLocalObservable.test.tsx
@@ -116,7 +116,7 @@ describe("is used to keep observable within component body", () => {
         fireEvent.click(div)
         expect(div.textContent).toBe("3-2")
 
-        expect(renderCount).toBe(4)
+        expect(renderCount).toBe(3)
     })
 
     it("actions can be used", () => {
@@ -418,19 +418,19 @@ describe("is used to keep observable within component body", () => {
             const { container } = render(<Parent />)
 
             expect(container.querySelector("span")!.innerHTML).toBe("10")
-            expect(counterRender).toBe(2)
+            expect(counterRender).toBe(1)
 
             act(() => {
                 ;(container.querySelector("#inc")! as any).click()
             })
             expect(container.querySelector("span")!.innerHTML).toBe("11")
-            expect(counterRender).toBe(3)
+            expect(counterRender).toBe(2)
 
             act(() => {
                 ;(container.querySelector("#incmultiplier")! as any).click()
             })
             expect(container.querySelector("span")!.innerHTML).toBe("22")
-            expect(counterRender).toBe(5) // TODO: should be 3
+            expect(counterRender).toBe(4) // One from props, second from updating local observable with effect
         })
     })
 })

--- a/packages/mobx-react-lite/__tests__/useLocalStore.deprecated.test.tsx
+++ b/packages/mobx-react-lite/__tests__/useLocalStore.deprecated.test.tsx
@@ -119,8 +119,7 @@ describe("is used to keep observable within component body", () => {
         fireEvent.click(div)
         expect(div.textContent).toBe("3-2")
 
-        // though render 4 times, mobx.observable only called once
-        expect(renderCount).toBe(4)
+        expect(renderCount).toBe(3)
     })
 
     it("actions can be used", () => {
@@ -424,19 +423,19 @@ describe("is used to keep observable within component body", () => {
             const { container } = render(<Parent />)
 
             expect(container.querySelector("span")!.innerHTML).toBe("10")
-            expect(counterRender).toBe(2)
+            expect(counterRender).toBe(1)
 
             act(() => {
                 ;(container.querySelector("#inc")! as any).click()
             })
             expect(container.querySelector("span")!.innerHTML).toBe("11")
-            expect(counterRender).toBe(3)
+            expect(counterRender).toBe(2)
 
             act(() => {
                 ;(container.querySelector("#incmultiplier")! as any).click()
             })
             expect(container.querySelector("span")!.innerHTML).toBe("22")
-            expect(counterRender).toBe(5) // TODO: should be 3
+            expect(counterRender).toBe(4) // One from props, second from updating source (setState during render)
         })
     })
 })

--- a/packages/mobx-react-lite/src/useObserver.ts
+++ b/packages/mobx-react-lite/src/useObserver.ts
@@ -24,10 +24,8 @@ type ObserverAdministration = {
     getSnapshot: Parameters<typeof React.useSyncExternalStore>[1]
 }
 
-const mobxGlobalState = _getGlobalState()
-
 // BC
-const globalStateVersionIsAvailable = typeof mobxGlobalState.stateVersion !== "undefined"
+const globalStateVersionIsAvailable = typeof _getGlobalState().stateVersion !== "undefined"
 
 function createReaction(adm: ObserverAdministration) {
     adm.reaction = new Reaction(`observer${adm.name}`, () => {
@@ -84,7 +82,7 @@ export function useObserver<T>(render: () => T, baseComponentName: string = "obs
             getSnapshot() {
                 // Do NOT access admRef here!
                 return globalStateVersionIsAvailable
-                    ? mobxGlobalState.stateVersion
+                    ? _getGlobalState().stateVersion
                     : adm.stateVersion
             }
         }

--- a/packages/mobx-react/__tests__/finalizationRegistry.tsx
+++ b/packages/mobx-react/__tests__/finalizationRegistry.tsx
@@ -8,12 +8,6 @@ import { observer } from "../src"
 
 afterEach(cleanup)
 
-function sleep(time: number) {
-    return new Promise<void>(res => {
-        setTimeout(res, time)
-    })
-}
-
 // TODO remove once https://github.com/mobxjs/mobx/pull/3620 is merged.
 declare class WeakRef<T> {
     constructor(object: T)
@@ -80,9 +74,12 @@ test("should not prevent GC of uncomitted components", async () => {
     expect(aConstructorCount).toBe(2)
     expect(aMountCount).toBe(1)
 
+    await Promise.resolve()
     gc()
-    await sleep(50)
-    expect(firstARef!.deref()).toBeUndefined()
+    await waitFor(() => expect(firstARef!.deref()).toBeUndefined(), {
+        timeout: 10_000,
+        interval: 150
+    })
 
     unmount()
 })

--- a/packages/mobx-react/__tests__/hooks.test.tsx
+++ b/packages/mobx-react/__tests__/hooks.test.tsx
@@ -93,10 +93,9 @@ test("computed properties result in double render when using observer instead of
     expect(seen).toEqual([
         "parent",
         0,
-        0,
         "parent",
-        2,
-        2 // should contain "2" only once! But with hooks, one update is scheduled based the fact that props change, the other because the observable source changed.
+        2, // props changed
+        2 // observable source changed (setState during render)
     ])
     expect(container).toHaveTextContent("2")
 })

--- a/packages/mobx/__tests__/v5/base/extendObservable.js
+++ b/packages/mobx/__tests__/v5/base/extendObservable.js
@@ -7,7 +7,9 @@ import {
     isObservableProp,
     isComputedProp,
     isAction,
-    extendObservable
+    extendObservable,
+    observable,
+    reaction
 } from "../../../src/mobx"
 
 test("extendObservable should work", function () {
@@ -159,4 +161,16 @@ test("extendObservable should apply specified decorators", function () {
 
     expect(isAction(box.someFunc)).toBe(true)
     expect(box.someFunc()).toEqual(2)
+})
+
+test("extendObservable notifies about added keys", () => {
+    let reactionCalled = false
+    const o = observable({})
+    const disposeReaction = reaction(
+        () => Object.keys(o),
+        () => (reactionCalled = true)
+    )
+    extendObservable(o, { x: 0 })
+    expect(reactionCalled).toBe(true)
+    disposeReaction()
 })

--- a/packages/mobx/__tests__/v5/base/observables.js
+++ b/packages/mobx/__tests__/v5/base/observables.js
@@ -2387,3 +2387,15 @@ test("state version updates correctly", () => {
     expect(o.x).toBe(5)
     expect(prevStateVersion).not.toBe(getGlobalState().stateVersion)
 })
+
+test.only("state version is not updated on observable creation", () => {
+    const globalState = getGlobalState()
+    let prevStateVersion = globalState.stateVersion
+    //mobx.observable({ x: 0 })
+    // mobx.observable.box(0)
+    //mobx.observable.map([["key", "val"]])
+    mobx.configure({ enforceActions: "always" })
+    mobx.makeAutoObservable({ x: "x" })
+
+    expect(prevStateVersion).toBe(globalState.stateVersion)
+})

--- a/packages/mobx/__tests__/v5/base/observables.js
+++ b/packages/mobx/__tests__/v5/base/observables.js
@@ -2388,7 +2388,7 @@ test("state version updates correctly", () => {
     expect(prevStateVersion).not.toBe(getGlobalState().stateVersion)
 })
 
-test("Atom.reportChanged does change state version when called from the batch the atom was created in", () => {
+test("Atom.reportChanged does not change state version when called from the batch the atom was created in", () => {
     mobx.transaction(() => {
         const prevStateVersion = getGlobalState().stateVersion
         const atom = mobx.createAtom()

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -287,6 +287,7 @@ test("computed setter should succeed", () => {
 })
 
 test("atom clock example", done => {
+    // TODO randomly fails, rework
     let ticks = 0
     const time_factor = process.env.CI === "true" ? 300 : 100 // speed up / slow down tests
 
@@ -1824,12 +1825,16 @@ test("sync when can be aborted", async () => {
     const x = mobx.observable.box(1)
 
     const ac = new AbortController()
-    mobx.when(() => x.get() === 3, () => {
-        fail("should abort")
-    }, { signal: ac.signal })
+    mobx.when(
+        () => x.get() === 3,
+        () => {
+            fail("should abort")
+        },
+        { signal: ac.signal }
+    )
     ac.abort()
 
-    x.set(3);
+    x.set(3)
 })
 
 test("it should support asyncAction as decorator (ts)", async () => {

--- a/packages/mobx/src/api/extendobservable.ts
+++ b/packages/mobx/src/api/extendobservable.ts
@@ -11,7 +11,10 @@ import {
     die,
     getOwnPropertyDescriptors,
     $mobx,
-    ownKeys
+    ownKeys,
+    globalState,
+    allowStateChangesStart,
+    allowStateChangesEnd
 } from "../internal"
 
 export function extendObservable<A extends Object, B extends Object>(
@@ -41,6 +44,8 @@ export function extendObservable<A extends Object, B extends Object>(
     const descriptors = getOwnPropertyDescriptors(properties)
 
     const adm: ObservableObjectAdministration = asObservableObject(target, options)[$mobx]
+    const allowStateChanges = allowStateChangesStart(true)
+    globalState.suppressReportChanged = true
     startBatch()
     try {
         ownKeys(descriptors).forEach(key => {
@@ -52,6 +57,8 @@ export function extendObservable<A extends Object, B extends Object>(
             )
         })
     } finally {
+        globalState.suppressReportChanged = false
+        allowStateChangesEnd(allowStateChanges)
         endBatch()
     }
     return target as any

--- a/packages/mobx/src/api/observable.ts
+++ b/packages/mobx/src/api/observable.ts
@@ -29,7 +29,8 @@ import {
     assign,
     isStringish,
     createObservableAnnotation,
-    createAutoAnnotation
+    createAutoAnnotation,
+    initObservable
 } from "../internal"
 
 export const OBSERVABLE = "observable"
@@ -211,12 +212,14 @@ const observableFactories: IObservableFactory = {
         decorators?: AnnotationsMap<T, never>,
         options?: CreateObservableOptions
     ): T {
-        return extendObservable(
-            globalState.useProxies === false || options?.proxy === false
-                ? asObservableObject({}, options)
-                : asDynamicObservableObject({}, options),
-            props,
-            decorators
+        return initObservable(() =>
+            extendObservable(
+                globalState.useProxies === false || options?.proxy === false
+                    ? asObservableObject({}, options)
+                    : asDynamicObservableObject({}, options),
+                props,
+                decorators
+            )
         )
     },
     ref: createDecoratorAnnotation(observableRefAnnotation),

--- a/packages/mobx/src/core/atom.ts
+++ b/packages/mobx/src/core/atom.ts
@@ -65,6 +65,9 @@ export class Atom implements IAtom {
      * Invoke this method _after_ this method has changed to signal mobx that all its observers should invalidate.
      */
     public reportChanged() {
+        if (globalState.suppressReportChanged) {
+            return
+        }
         startBatch()
         propagateChanged(this)
         // We could update state version only at the end of batch,

--- a/packages/mobx/src/core/atom.ts
+++ b/packages/mobx/src/core/atom.ts
@@ -27,6 +27,7 @@ export class Atom implements IAtom {
     isBeingObserved_ = false
     observers_ = new Set<IDerivation>()
 
+    batchId_: number
     diffValue_ = 0
     lastAccessedBy_ = 0
     lowestObserverState_ = IDerivationState_.NOT_TRACKING_
@@ -34,7 +35,9 @@ export class Atom implements IAtom {
      * Create a new atom. For debugging purposes it is recommended to give it a name.
      * The onBecomeObserved and onBecomeUnobserved callbacks can be used for resource management.
      */
-    constructor(public name_ = __DEV__ ? "Atom@" + getNextId() : "Atom") {}
+    constructor(public name_ = __DEV__ ? "Atom@" + getNextId() : "Atom") {
+        this.batchId_ = globalState.inBatch ? globalState.batchId : NaN
+    }
 
     // onBecomeObservedListeners
     public onBOL: Set<Lambda> | undefined
@@ -65,9 +68,13 @@ export class Atom implements IAtom {
      * Invoke this method _after_ this method has changed to signal mobx that all its observers should invalidate.
      */
     public reportChanged() {
-        if (globalState.suppressReportChanged) {
+        if (globalState.inBatch && this.batchId_ === globalState.batchId) {
+            // Called from the same batch this atom was created in.
             return
         }
+        // Avoids the possibility of hitting the same globalState.batchId when it cycled through all integers (necessary?)
+        this.batchId_ = NaN
+
         startBatch()
         propagateChanged(this)
         // We could update state version only at the end of batch,

--- a/packages/mobx/src/core/globalstate.ts
+++ b/packages/mobx/src/core/globalstate.ts
@@ -155,6 +155,11 @@ export class MobXGlobals {
      * Changes with each state update, used by useSyncExternalStore
      */
     stateVersion = Number.MIN_SAFE_INTEGER
+
+    /**
+     * TODO
+     */
+    suppressReportChanged = false
 }
 
 let canMergeGlobalState = true

--- a/packages/mobx/src/core/globalstate.ts
+++ b/packages/mobx/src/core/globalstate.ts
@@ -64,6 +64,12 @@ export class MobXGlobals {
     inBatch: number = 0
 
     /**
+     * ID of the latest batch. Used to suppress reportChanged of newly created atoms.
+     * Note the value persists even after batch ended.
+     */
+    batchId: number = Number.MIN_SAFE_INTEGER
+
+    /**
      * Observables that don't have observers anymore, and are about to be
      * suspended, unless somebody else accesses it in the same batch
      *
@@ -155,11 +161,6 @@ export class MobXGlobals {
      * Changes with each state update, used by useSyncExternalStore
      */
     stateVersion = Number.MIN_SAFE_INTEGER
-
-    /**
-     * TODO
-     */
-    suppressReportChanged = false
 }
 
 let canMergeGlobalState = true

--- a/packages/mobx/src/core/observable.ts
+++ b/packages/mobx/src/core/observable.ts
@@ -104,6 +104,12 @@ export function queueForUnobservation(observable: IObservable) {
  * Avoids unnecessary recalculations.
  */
 export function startBatch() {
+    if (globalState.inBatch === 0) {
+        globalState.batchId =
+            globalState.batchId < Number.MAX_SAFE_INTEGER
+                ? globalState.batchId + 1
+                : Number.MIN_SAFE_INTEGER
+    }
     globalState.inBatch++
 }
 

--- a/packages/mobx/src/types/legacyobservablearray.ts
+++ b/packages/mobx/src/types/legacyobservablearray.ts
@@ -11,7 +11,8 @@ import {
     IEnhancer,
     isObservableArray,
     IObservableArray,
-    defineProperty
+    defineProperty,
+    globalState
 } from "../internal"
 
 // Bug in safari 9.* (or iOS 9 safari mobile). See #364
@@ -67,10 +68,15 @@ class LegacyObservableArray<T> extends StubArray {
         addHiddenFinalProp(this, $mobx, adm)
 
         if (initialValues && initialValues.length) {
-            const prev = allowStateChangesStart(true)
-            // @ts-ignore
-            this.spliceWithArray(0, 0, initialValues)
-            allowStateChangesEnd(prev)
+            const allowStateChanges = allowStateChangesStart(true)
+            globalState.suppressReportChanged = true
+            try {
+                // @ts-ignore
+                this.spliceWithArray(0, 0, initialValues)
+            } finally {
+                globalState.suppressReportChanged = false
+                allowStateChangesEnd(allowStateChanges)
+            }
         }
 
         if (safariPrototypeSetterInheritanceBug) {

--- a/packages/mobx/src/types/observablearray.ts
+++ b/packages/mobx/src/types/observablearray.ts
@@ -411,9 +411,14 @@ export function createObservableArray<T>(
     const proxy = new Proxy(adm.values_, arrayTraps) as any
     adm.proxy_ = proxy
     if (initialValues && initialValues.length) {
-        const prev = allowStateChangesStart(true)
-        adm.spliceWithArray_(0, 0, initialValues)
-        allowStateChangesEnd(prev)
+        const allowStateChanges = allowStateChangesStart(true)
+        globalState.suppressReportChanged = true
+        try {
+            adm.spliceWithArray_(0, 0, initialValues)
+        } finally {
+            globalState.suppressReportChanged = false
+            allowStateChangesEnd(allowStateChanges)
+        }
     }
     return proxy
 }

--- a/packages/mobx/src/types/observablemap.ts
+++ b/packages/mobx/src/types/observablemap.ts
@@ -35,8 +35,7 @@ import {
     UPDATE,
     IAtom,
     PureSpyEvent,
-    allowStateChangesStart,
-    allowStateChangesEnd
+    initObservable
 } from "../internal"
 
 export interface IKeyValueMap<V = any> {
@@ -94,9 +93,9 @@ export class ObservableMap<K = any, V = any>
     implements Map<K, V>, IInterceptable<IMapWillChange<K, V>>, IListenable
 {
     [$mobx] = ObservableMapMarker
-    data_: Map<K, ObservableValue<V>>
-    hasMap_: Map<K, ObservableValue<boolean>> // hasMap, not hashMap >-).
-    keysAtom_: IAtom
+    data_!: Map<K, ObservableValue<V>>
+    hasMap_!: Map<K, ObservableValue<boolean>> // hasMap, not hashMap >-).
+    keysAtom_!: IAtom
     interceptors_
     changeListeners_
     dehancer: any
@@ -109,19 +108,14 @@ export class ObservableMap<K = any, V = any>
         if (!isFunction(Map)) {
             die(18)
         }
-        this.keysAtom_ = createAtom(__DEV__ ? `${this.name_}.keys()` : "ObservableMap.keys()")
-        this.data_ = new Map()
-        this.hasMap_ = new Map()
-        if (initialData) {
-            const allowStateChanges = allowStateChangesStart(true)
-            globalState.suppressReportChanged = true
-            try {
+        initObservable(() => {
+            this.keysAtom_ = createAtom(__DEV__ ? `${this.name_}.keys()` : "ObservableMap.keys()")
+            this.data_ = new Map()
+            this.hasMap_ = new Map()
+            if (initialData) {
                 this.merge(initialData)
-            } finally {
-                globalState.suppressReportChanged = false
-                allowStateChangesEnd(allowStateChanges)
             }
-        }
+        })
     }
 
     private has_(key: K): boolean {

--- a/packages/mobx/src/types/observableobject.ts
+++ b/packages/mobx/src/types/observableobject.ts
@@ -46,7 +46,8 @@ import {
     getAdministration,
     getDebugName,
     objectPrototype,
-    MakeResult
+    MakeResult,
+    checkIfStateModificationsAreAllowed
 } from "../internal"
 
 const descriptorCache = Object.create(null)
@@ -314,6 +315,7 @@ export class ObservableObjectAdministration
         descriptor: PropertyDescriptor,
         proxyTrap: boolean = false
     ): boolean | null {
+        checkIfStateModificationsAreAllowed(this.keysAtom_)
         try {
             startBatch()
 
@@ -368,6 +370,7 @@ export class ObservableObjectAdministration
         enhancer: IEnhancer<any>,
         proxyTrap: boolean = false
     ): boolean | null {
+        checkIfStateModificationsAreAllowed(this.keysAtom_)
         try {
             startBatch()
 
@@ -432,6 +435,7 @@ export class ObservableObjectAdministration
         options: IComputedValueOptions<any>,
         proxyTrap: boolean = false
     ): boolean | null {
+        checkIfStateModificationsAreAllowed(this.keysAtom_)
         try {
             startBatch()
 
@@ -490,6 +494,7 @@ export class ObservableObjectAdministration
      * @returns {boolean|null} true on success, false on failure (proxyTrap + non-configurable), null when cancelled by interceptor
      */
     delete_(key: PropertyKey, proxyTrap: boolean = false): boolean | null {
+        checkIfStateModificationsAreAllowed(this.keysAtom_)
         // No such prop
         if (!hasProp(this.target_, key)) {
             return true

--- a/packages/mobx/src/types/observableset.ts
+++ b/packages/mobx/src/types/observableset.ts
@@ -28,9 +28,7 @@ import {
     ADD,
     die,
     isFunction,
-    allowStateChangesStart,
-    globalState,
-    allowStateChangesEnd
+    initObservable
 } from "../internal"
 
 const ObservableSetMarker = {}
@@ -68,7 +66,7 @@ export type ISetWillChange<T = any> =
 export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillChange>, IListenable {
     [$mobx] = ObservableSetMarker
     private data_: Set<any> = new Set()
-    atom_: IAtom
+    atom_!: IAtom
     changeListeners_
     interceptors_
     dehancer: any
@@ -82,18 +80,13 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
         if (!isFunction(Set)) {
             die(22)
         }
-        this.atom_ = createAtom(this.name_)
         this.enhancer_ = (newV, oldV) => enhancer(newV, oldV, name_)
-        if (initialData) {
-            const allowStateChanges = allowStateChangesStart(true)
-            globalState.suppressReportChanged = true
-            try {
+        initObservable(() => {
+            this.atom_ = createAtom(this.name_)
+            if (initialData) {
                 this.replace(initialData)
-            } finally {
-                globalState.suppressReportChanged = false
-                allowStateChangesEnd(allowStateChanges)
             }
-        }
+        })
     }
 
     private dehanceValue_<X extends T | undefined>(value: X): X {

--- a/packages/mobx/src/types/observableset.ts
+++ b/packages/mobx/src/types/observableset.ts
@@ -27,7 +27,10 @@ import {
     DELETE,
     ADD,
     die,
-    isFunction
+    isFunction,
+    allowStateChangesStart,
+    globalState,
+    allowStateChangesEnd
 } from "../internal"
 
 const ObservableSetMarker = {}
@@ -82,7 +85,14 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
         this.atom_ = createAtom(this.name_)
         this.enhancer_ = (newV, oldV) => enhancer(newV, oldV, name_)
         if (initialData) {
-            this.replace(initialData)
+            const allowStateChanges = allowStateChangesStart(true)
+            globalState.suppressReportChanged = true
+            try {
+                this.replace(initialData)
+            } finally {
+                globalState.suppressReportChanged = false
+                allowStateChangesEnd(allowStateChanges)
+            }
         }
     }
 

--- a/packages/mobx/src/types/type-utils.ts
+++ b/packages/mobx/src/types/type-utils.ts
@@ -113,7 +113,7 @@ export function initObservable<T>(cb: () => T): T {
         return cb()
     } finally {
         endBatch()
-        untrackedEnd(derivation)
         allowStateChangesEnd(allowStateChanges)
+        untrackedEnd(derivation)
     }
 }


### PR DESCRIPTION
-   fix: #3728: Observable initialization updates state version.
-   fix: Observable set initialization violates `enforceActions: "always"`.
-   fix: Changing keys of observable object does not respect `enforceActions`.
-   fix: #3734: `isolateGlobalState: true` makes observer stop to react to store changes