### PR TITLE
Fix: disable global state version usage in observer. Fixes #3728

### DIFF
--- a/.changeset/light-birds-grow.md
+++ b/.changeset/light-birds-grow.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+Switched observer implementation from using global to local state version. Fixes #3728

--- a/packages/mobx-react-lite/src/useObserver.ts
+++ b/packages/mobx-react-lite/src/useObserver.ts
@@ -25,7 +25,7 @@ type ObserverAdministration = {
 }
 
 // BC
-const globalStateVersionIsAvailable = typeof _getGlobalState().stateVersion !== "undefined"
+const globalStateVersionIsAvailable = false // See #3728; TODO: typeof _getGlobalState().stateVersion !== "undefined"
 
 function createReaction(adm: ObserverAdministration) {
     adm.reaction = new Reaction(`observer${adm.name}`, () => {

--- a/packages/mobx-react-lite/src/useObserver.ts
+++ b/packages/mobx-react-lite/src/useObserver.ts
@@ -1,4 +1,4 @@
-import { Reaction, _getGlobalState } from "mobx"
+import { Reaction } from "mobx"
 import React from "react"
 import { printDebugValue } from "./utils/printDebugValue"
 import { isUsingStaticRendering } from "./staticRendering"
@@ -24,15 +24,9 @@ type ObserverAdministration = {
     getSnapshot: Parameters<typeof React.useSyncExternalStore>[1]
 }
 
-// BC
-const globalStateVersionIsAvailable = false // See #3728; TODO: typeof _getGlobalState().stateVersion !== "undefined"
-
 function createReaction(adm: ObserverAdministration) {
     adm.reaction = new Reaction(`observer${adm.name}`, () => {
-        if (!globalStateVersionIsAvailable) {
-            // BC
-            adm.stateVersion = Symbol()
-        }
+        adm.stateVersion = Symbol()
         // onStoreChange won't be available until the component "mounts".
         // If state changes in between initial render and mount,
         // `useSyncExternalStore` should handle that by checking the state version and issuing update.
@@ -46,9 +40,6 @@ export function useObserver<T>(render: () => T, baseComponentName: string = "obs
     }
 
     const admRef = React.useRef<ObserverAdministration | null>(null)
-
-    // Provides ability to force component update without changing state version
-    const [, forceUpdate] = React.useState<Symbol>()
 
     if (!admRef.current) {
         // First render
@@ -69,7 +60,8 @@ export function useObserver<T>(render: () => T, baseComponentName: string = "obs
                     // even if state did not change.
                     createReaction(adm)
                     // `onStoreChange` won't force update if subsequent `getSnapshot` returns same value.
-                    forceUpdate(Symbol())
+                    // So we make sure that is not the case
+                    adm.stateVersion = Symbol()
                 }
 
                 return () => {
@@ -81,9 +73,7 @@ export function useObserver<T>(render: () => T, baseComponentName: string = "obs
             },
             getSnapshot() {
                 // Do NOT access admRef here!
-                return globalStateVersionIsAvailable
-                    ? _getGlobalState().stateVersion
-                    : adm.stateVersion
+                return adm.stateVersion
             }
         }
 


### PR DESCRIPTION
This diff disables the usage of global state versioning. The reasoning here is:

* global state versioning is principle more correct
* effectively it doesn't make the implementation more compatible with concurrent mode, both implementations fail layer 3 compatibility
* in neither cases, the snapshot represents what actually will be read during render; as the latest version of all data is read, instead of the state described by the snapshot version. 
* since the local versioning approach doesn't break #3728 (for which could be argued it is unidiomatic), there seems at this moment little upside to the global version approach.

This PR deliberately doesn't clean up the underlying infra; the tracking of a global state version in the first place. I will probably put up a separate PR for that, but I also want to pursue more implementation solutions that might work better, that build on that infra. 
