### PR TITLE
State version cleanup

### DIFF
--- a/.changeset/light-birds-grow.md
+++ b/.changeset/light-birds-grow.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+Switched observer implementation from using global to local state version. Fixes #3728

--- a/packages/mobx-react-lite/src/useObserver.ts
+++ b/packages/mobx-react-lite/src/useObserver.ts
@@ -25,7 +25,7 @@ type ObserverAdministration = {
 }
 
 // BC
-const globalStateVersionIsAvailable = typeof _getGlobalState().stateVersion !== "undefined"
+const globalStateVersionIsAvailable = false // See #3728; TODO: typeof _getGlobalState().stateVersion !== "undefined"
 
 function createReaction(adm: ObserverAdministration) {
     adm.reaction = new Reaction(`observer${adm.name}`, () => {

--- a/packages/mobx-react-lite/src/useObserver.ts
+++ b/packages/mobx-react-lite/src/useObserver.ts
@@ -24,18 +24,9 @@ type ObserverAdministration = {
     getSnapshot: Parameters<typeof React.useSyncExternalStore>[1]
 }
 
-// BC
-const globalStateVersionIsAvailable = false // See #3728; TODO: typeof _getGlobalState().stateVersion !== "undefined"
-
 function createReaction(adm: ObserverAdministration) {
     adm.reaction = new Reaction(`observer${adm.name}`, () => {
-        if (!globalStateVersionIsAvailable) {
-            // BC
-            adm.stateVersion = Symbol()
-        }
-        // onStoreChange won't be available until the component "mounts".
-        // If state changes in between initial render and mount,
-        // `useSyncExternalStore` should handle that by checking the state version and issuing update.
+        adm.stateVersion = Symbol()
         adm.onStoreChange?.()
     })
 }
@@ -81,9 +72,7 @@ export function useObserver<T>(render: () => T, baseComponentName: string = "obs
             },
             getSnapshot() {
                 // Do NOT access admRef here!
-                return globalStateVersionIsAvailable
-                    ? _getGlobalState().stateVersion
-                    : adm.stateVersion
+                return adm.stateVersion
             }
         }
 

--- a/packages/mobx/__tests__/v5/base/observables.js
+++ b/packages/mobx/__tests__/v5/base/observables.js
@@ -2361,43 +2361,6 @@ describe("`requiresObservable` takes precedence over global `reactionRequiresObs
     })
 })
 
-test("state version updates correctly", () => {
-    // This test was designed around the idea of updating version only at the end of batch,
-    // which is NOT an implementation we've settled on, but the test is still valid.
-
-    // This test demonstrates that the version is correctly updated with each state mutations:
-    // 1. Even without wrapping mutation in batch explicitely.
-    // 2. Even in self-invoking recursive derivation.
-    const o = mobx.observable({ x: 0 })
-    let prevStateVersion
-
-    const disposeAutorun = mobx.autorun(() => {
-        if (o.x === 5) {
-            disposeAutorun()
-            return
-        }
-        const currentStateVersion = getGlobalState().stateVersion
-        expect(prevStateVersion).not.toBe(currentStateVersion)
-        prevStateVersion = currentStateVersion
-        o.x++
-    })
-
-    // expect(o.x).toBe(4) is 1?
-    prevStateVersion = getGlobalState().stateVersion
-    o.x++
-    expect(o.x).toBe(5)
-    expect(prevStateVersion).not.toBe(getGlobalState().stateVersion)
-})
-
-test("Atom.reportChanged does not change state version when called from the batch the atom was created in", () => {
-    mobx.transaction(() => {
-        const prevStateVersion = getGlobalState().stateVersion
-        const atom = mobx.createAtom()
-        atom.reportChanged()
-        expect(prevStateVersion).toBe(getGlobalState().stateVersion)
-    })
-})
-
 test('Observables initialization does not violate `enforceActions: "always"`', () => {
     const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
 

--- a/packages/mobx/src/core/globalstate.ts
+++ b/packages/mobx/src/core/globalstate.ts
@@ -64,12 +64,6 @@ export class MobXGlobals {
     inBatch: number = 0
 
     /**
-     * ID of the latest batch. Used to suppress reportChanged of newly created atoms.
-     * Note the value persists even after batch ended.
-     */
-    batchId: number = Number.MIN_SAFE_INTEGER
-
-    /**
      * Observables that don't have observers anymore, and are about to be
      * suspended, unless somebody else accesses it in the same batch
      *
@@ -156,11 +150,6 @@ export class MobXGlobals {
      * configurable: true
      */
     safeDescriptors = true
-
-    /**
-     * Changes with each state update, used by useSyncExternalStore
-     */
-    stateVersion = Number.MIN_SAFE_INTEGER
 }
 
 let canMergeGlobalState = true

--- a/packages/mobx/src/core/observable.ts
+++ b/packages/mobx/src/core/observable.ts
@@ -104,12 +104,6 @@ export function queueForUnobservation(observable: IObservable) {
  * Avoids unnecessary recalculations.
  */
 export function startBatch() {
-    if (globalState.inBatch === 0) {
-        globalState.batchId =
-            globalState.batchId < Number.MAX_SAFE_INTEGER
-                ? globalState.batchId + 1
-                : Number.MIN_SAFE_INTEGER
-    }
     globalState.inBatch++
 }
 


### PR DESCRIPTION
Follow up of #3763, cleanup global stateVersion. Kept initObservable as is, as it handles several flags around warnings etc better.
