### PR TITLE
Remove { rootStore: false } from docs since it's not needed

### DIFF
--- a/docs/defining-data-stores.md
+++ b/docs/defining-data-stores.md
@@ -289,7 +289,7 @@ class TodoStore {
     rootStore
 
     constructor(rootStore) {
-        makeAutoObservable(this, { rootStore: false })
+        makeAutoObservable(this)
         this.rootStore = rootStore
     }
 }


### PR DESCRIPTION
`makeAutoObservable` ignores instances of classes from autoconversion, so it's not necessary to exclude it. Helps to avoid confusion: https://github.com/mobxjs/mobx/discussions/2847#discussioncomment-7314913