### PR TITLE
Fix: observer class components going stale after 10 seconds

### DIFF
--- a/.changeset/hip-bulldogs-act.md
+++ b/.changeset/hip-bulldogs-act.md
@@ -1,0 +1,5 @@
+---
+"mobx-react": patch
+---
+
+Fixed premature disposal of class component observers.

--- a/packages/mobx-react/src/observerClass.ts
+++ b/packages/mobx-react/src/observerClass.ts
@@ -133,7 +133,7 @@ export function makeClassComponentObserver(
         admin.mounted = true
 
         // Component instance committed, prevent reaction disposal.
-        observerFinalizationRegistry.unregister(admin)
+        observerFinalizationRegistry.unregister(this)
 
         // We don't set forceUpdate before mount because it requires a reference to `this`,
         // therefore `this` could NOT be garbage collected before mount,


### PR DESCRIPTION
After upgrading from MobX 4 to MobX 6 in a React Native project (React 18.2, no StrictMode), I noticed almost all of my screens went stale shortly after rendering.

An observer class component is registered with `observerFinalizationRegistry` like so:
```ts
_observerFinalizationRegistry.register(this, admin, this);
```
The third argument is the `token`, which is used to store the registration in a Map. In `componentDidMount` the finalization is then unregistered so it is allowed to stay alive, but using `admin` as the token, not `this`:
```ts
_observerFinalizationRegistry.unregister(admin);
```
`admin` is not registered to begin with, so the finalization does not get cleaned up, resulting in every class component going stale after about 10 seconds of being rendered.

### Code change checklist

-   [ ] Added/updated unit tests
-   [X] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [X] Verified that there is no significant performance drop (`yarn mobx test:performance`)

Happy to write tests for this - but I will need some pointers. I saw the `finalizationRegistry` test, but it is not immediately obvious to me how I should approach testing registration and deregistration.