### PR TITLE
fix!: Prevent calling set on the return value of 'computed()'

### DIFF
--- a/.changeset/fluffy-shoes-return.md
+++ b/.changeset/fluffy-shoes-return.md
@@ -1,0 +1,13 @@
+---
+"mobx": major
+---
+
+Only expose IComputedValue.set as a typescript type when it won't throw an error
+
+The breaking change is that it is now a typescript compile error to call the `set(value: T)` method on an `IComputedValue` that is not writable.
+This is a breaking change because it is possible to create an `IComputedValue` that is not writable, and then call `set` on it.
+This will now throw a runtime error.
+
+This change was made to help with refactoring code, especially between `IObservableValue<T>` and `IComputedValue<T>` which both have a similar interface but one of them throws more errors.
+
+To fix your code, you will need to change the type annotations for any updatable computed value to `IComputedValue<T, true>`.

--- a/docs/computeds.md
+++ b/docs/computeds.md
@@ -236,3 +236,8 @@ It is recommended to set this one to `true` on very expensive computed values. I
 ### `keepAlive`
 
 This avoids suspending computed values when they are not being observed by anything (see the above explanation). Can potentially create memory leaks, similar to the ones discussed for [reactions](reactions.md#always-dispose-of-reactions).
+
+### `set`
+
+This optional function allows the returned `IComputedValue<T>` to also act as something that knows how to update its backing data. When not provided, however, this function that is provided will throw an error.
+To help prevent runtime errors like this, especially when refactoring code from `IObservableValue<T>` to `IComputedValue<T>` the typescript types will are set up so that trying to call a function will result in a compile time error when this option is not set.

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -2474,3 +2474,20 @@ test("observable.box should keep track of undefined and null in type", () => {
     const a = observable.box<string | undefined>()
     assert<IsExact<typeof a, IObservableValue<string | undefined>>>(true)
 })
+
+test("computed without a set function should not allow the consumer to set the value", () => {
+    const a = observable.box<string>("hello")
+    const b = computed(() => a.get())
+    assert<IsExact<typeof b, mobx.IComputedValue<string>>>(true)
+    // @ts-expect-error
+    b.set("world")
+})
+
+test("computed with a set function should allow the consumer to set the value", () => {
+    const a = observable.box<string>("hello")
+    const b = computed(() => a.get(), {
+        set: value => a.set(value)
+    })
+    assert<IsExact<typeof b, mobx.IComputedValue<string, true>>>(true)
+    b.set("world")
+})

--- a/packages/mobx/src/api/computed.ts
+++ b/packages/mobx/src/api/computed.ts
@@ -18,9 +18,11 @@ export const COMPUTED_STRUCT = "computed.struct"
 
 export interface IComputedFactory extends Annotation, PropertyDecorator {
     // @computed(opts)
-    <T>(options: IComputedValueOptions<T>): Annotation & PropertyDecorator
+    <T>(options: IComputedValueOptions<T, boolean>): Annotation & PropertyDecorator
     // computed(fn, opts)
-    <T>(func: () => T, options?: IComputedValueOptions<T>): IComputedValue<T>
+    <T>(func: () => T, options?: IComputedValueOptions<T, false>): IComputedValue<T, false>
+    <T>(func: () => T, options?: IComputedValueOptions<T, true>): IComputedValue<T, true>
+    <T>(func: () => T, options?: IComputedValueOptions<T, boolean>): IComputedValue<T, boolean>
 
     struct: Annotation & PropertyDecorator
 }

--- a/packages/mobx/src/mobx.ts
+++ b/packages/mobx/src/mobx.ts
@@ -129,7 +129,6 @@ export {
     onReactionError,
     interceptReads as _interceptReads,
     IComputedValueOptions,
-    IActionRunInfo,
     _startAction,
     _endAction,
     allowStateReadsStart as _allowStateReadsStart,


### PR DESCRIPTION
BREAKING CHANGE: 'set()' method now only exists if a 'set()' is provided

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->
resolves https://github.com/mobxjs/mobx/issues/3767