### PR TITLE
Prevent Reaction From Keeping a Reference to The OldValue

### DIFF
--- a/.changeset/six-pugs-impress.md
+++ b/.changeset/six-pugs-impress.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Prevent `reaction` from heeping a Reference to the OldValue that would prevent GC.

--- a/packages/mobx/src/api/autorun.ts
+++ b/packages/mobx/src/api/autorun.ts
@@ -139,7 +139,6 @@ export function reaction<T, FireImmediately extends boolean = false>(
     let firstTime = true
     let isScheduled = false
     let value: T
-    let oldValue: T | undefined
 
     const equals: IEqualsComparer<T> = (opts as any).compareStructural
         ? comparer.structural
@@ -165,10 +164,10 @@ export function reaction<T, FireImmediately extends boolean = false>(
             return
         }
         let changed: boolean = false
+        const oldValue = value
         r.track(() => {
             const nextValue = allowStateChanges(false, () => expression(r))
             changed = firstTime || !equals(value, nextValue)
-            oldValue = value
             value = nextValue
         })
 


### PR DESCRIPTION
HI Folks

This PR is about `reaction` and memory retainment preventing object beeing garbage collected

For some reason, the `reactionRunner` of a reaction creates a closure around an `oldValue` and so the reference to the `oldValue` is kept untill a newValue is computed.

I can see no reason for keeping such a reference "alive", `oldValue` could just be declared in the scope of the `reactionRunner` as it is the only place where it is used. Doing so, the `oldValue` can be garbage collected if needed.


No additional Unit test is needed for such a change, and there is no backward compatibility issue as it only touches internal/private stuff within a `reaction`.