### PR TITLE
Fix IReactionDisposer and IIsObservableObject  Typing

### DIFF
--- a/.changeset/seven-rules-add.md
+++ b/.changeset/seven-rules-add.md
@@ -2,4 +2,4 @@
 "mobx": patch
 ---
 
-Fix IReactionDisposer interface definition so that Typescript knows the property key `$mobx` is a symbol and not a string
+Fix `IReactionDisposer` and `IIsObservableObject` interface definition so that Typescript knows the property key `$mobx` is a symbol and not a string

--- a/.changeset/seven-rules-add.md
+++ b/.changeset/seven-rules-add.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix IReactionDisposer interface definition so that Typescript knows the property key `$mobx` is a symbol and not a string

--- a/packages/mobx/src/core/reaction.ts
+++ b/packages/mobx/src/core/reaction.ts
@@ -18,7 +18,8 @@ import {
     spyReportStart,
     startBatch,
     trace,
-    trackDerivedFunction, GenericAbortSignal
+    trackDerivedFunction,
+    GenericAbortSignal
 } from "../internal"
 
 /**
@@ -47,7 +48,7 @@ export interface IReactionPublic {
 
 export interface IReactionDisposer {
     (): void
-    $mobx: Reaction
+    [$mobx]: Reaction
 }
 
 export class Reaction implements IDerivation, IReactionPublic {

--- a/packages/mobx/src/types/observableobject.ts
+++ b/packages/mobx/src/types/observableobject.ts
@@ -629,7 +629,7 @@ export class ObservableObjectAdministration
         this.keysAtom_.reportChanged()
     }
 
-    ownKeys_(): ArrayLike<string | symbol> {
+    ownKeys_(): Array<string | symbol> {
         this.keysAtom_.reportObserved()
         return ownKeys(this.target_)
     }

--- a/packages/mobx/src/types/observableobject.ts
+++ b/packages/mobx/src/types/observableobject.ts
@@ -647,7 +647,7 @@ export class ObservableObjectAdministration
 }
 
 export interface IIsObservableObject {
-    $mobx: ObservableObjectAdministration
+    [$mobx]: ObservableObjectAdministration
 }
 
 export function asObservableObject(


### PR DESCRIPTION
This is typing only PR.


Current interface definition for `IReactionDisposer` is
```
export interface IReactionDisposer {
    (): void
    $mobx: Reaction
}
```

but that's wrong because because like so typescript considers the property key `$mobx` to be a string, whereas it is a symbol. The correct indexing type is given by 
```
export interface IReactionDisposer {
    (): void
    [$mobx]: Reaction
}
```

[Edit] : same thing for `IIsObservableObject`