### PR TITLE
return action initializer instead of using addInitializer

### DIFF
--- a/packages/mobx/src/types/actionannotation.ts
+++ b/packages/mobx/src/types/actionannotation.ts
@@ -75,10 +75,7 @@ function decorate_20223_(this: Annotation, mthd, context: DecoratorContext) {
 
     // Backwards/Legacy behavior, expects makeObservable(this)
     if (kind == "field") {
-        addInitializer(function () {
-            storeAnnotation(this, name, ann)
-        })
-        return
+        return _createAction
     }
 
     if (kind == "method") {


### PR DESCRIPTION
Fixes #3817 . 

Mobx currently fails to work with spec-compliant decorators (in swc) when using `@action x = () => {}`.

The reason this issue is hard to see is that apparently both tsc and babel do not follow the decorator spec, while swc does. I've opened an issue with typescript as well https://github.com/microsoft/TypeScript/issues/57096 because both their code as well as the types seem to conflict with the spec. 

In any case, this change works both with tsc and with swc (and I assume babel as well).

