### PR TITLE
Derive computed states only when required for delayed Reactions

### DIFF
--- a/.changeset/smart-items-juggle.md
+++ b/.changeset/smart-items-juggle.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Delay derivation of computed values for reactions until they're required. This means that unnescessary derivations will be avoided and that derivations will be properly delayed until they're read.

--- a/packages/mobx/__tests__/v5/base/autorunAsync.js
+++ b/packages/mobx/__tests__/v5/base/autorunAsync.js
@@ -100,7 +100,7 @@ test("autorun re-calculates computed states only when required", function (done)
             c.get()
             autoruns++
         },
-        { delay: 1000 }
+        { delay: 300 }
     )
     expect(computedCalcs).toBe(0)
 
@@ -108,7 +108,7 @@ test("autorun re-calculates computed states only when required", function (done)
         // We expect the first run to run the computed
         expect(autoruns).toBe(1)
         expect(computedCalcs).toBe(1)
-    }, 1100)
+    }, 400)
 
     // We shouldn't eagerly calculate the state before the autorun runs because
     // the state can be mutated again before `delay` expires - if that happens, a
@@ -116,20 +116,20 @@ test("autorun re-calculates computed states only when required", function (done)
     setTimeout(() => {
         o.set(1)
         expect(computedCalcs).toBe(1)
-    }, 1500)
+    }, 800)
 
     // This will re-invalidate the state so we'll need to recalculate
     // again when autorun runs (when `delay` expires).
     setTimeout(() => {
         o.set(3)
         expect(computedCalcs).toBe(1)
-    }, 1600)
+    }, 900)
 
     setTimeout(() => {
         expect(autoruns).toBe(2)
         expect(computedCalcs).toBe(2)
         done()
-    }, 3000)
+    }, 1600)
 })
 
 test("autorun should not result in loop", function (done) {

--- a/packages/mobx/__tests__/v5/base/autorunAsync.js
+++ b/packages/mobx/__tests__/v5/base/autorunAsync.js
@@ -110,9 +110,9 @@ test("autorun re-calculates computed states only when required", function (done)
         expect(computedCalcs).toBe(1)
     }, 1100)
 
-    // We shouldn't eagerly calculate the state before the autorun runs.
-    // because the state can be mutated again before `delay` expires - if that
-    // happens, a re-calculation here would be wasted.
+    // We shouldn't eagerly calculate the state before the autorun runs because
+    // the state can be mutated again before `delay` expires - if that happens, a
+    // re-calculation here would be wasted.
     setTimeout(() => {
         o.set(1)
         expect(computedCalcs).toBe(1)

--- a/packages/mobx/__tests__/v5/base/autorunAsync.js
+++ b/packages/mobx/__tests__/v5/base/autorunAsync.js
@@ -85,6 +85,39 @@ test("autorun 1", function (done) {
     }, 30)
 })
 
+test("autorun re-calculates computed states only when required", function (done) {
+    let _result = null
+    let _cCalcs = 0
+
+    const o = mobx.observable.box(0)
+    const c = mobx.computed(() => {
+        _cCalcs++
+        return o.get()
+    })
+
+    mobx.autorun(
+        () => {
+            _result = c.get()
+        },
+        { delay: 100 }
+    )
+
+    setTimeout(
+        mobx.action(() => o.set(1)),
+        30
+    )
+
+    expect(_cCalcs).toEqual(0)
+
+    setTimeout(() => mobx.action(() => o.set(2)), 30)
+
+    setTimeout(() => {
+        expect(_cCalcs).toEqual(1)
+        expect(_result).toEqual(1)
+        done()
+    }, 200)
+})
+
 test("autorun should not result in loop", function (done) {
     let i = 0
     const a = mobx.observable({

--- a/packages/mobx/src/api/autorun.ts
+++ b/packages/mobx/src/api/autorun.ts
@@ -50,6 +50,7 @@ export function autorun(
 
     const name: string =
         opts?.name ?? (__DEV__ ? (view as any).name || "Autorun@" + getNextId() : "Autorun")
+    const scheduler = createSchedulerFromOptions(opts)
     const reaction = new Reaction(
         name,
         function (this: Reaction) {
@@ -57,7 +58,7 @@ export function autorun(
         },
         opts.onError,
         opts.requiresObservable,
-        createSchedulerFromOptions(opts)
+        f => scheduler(f)
     )
 
     function reactionRunner() {

--- a/packages/mobx/src/api/autorun.ts
+++ b/packages/mobx/src/api/autorun.ts
@@ -130,7 +130,6 @@ export function reaction<T, FireImmediately extends boolean = false>(
         name,
         opts.onError ? wrapErrorHandler(opts.onError, effect) : effect
     )
-
     const runSync = !opts.scheduler && !opts.delay
     const scheduler = createSchedulerFromOptions(opts)
 
@@ -154,7 +153,8 @@ export function reaction<T, FireImmediately extends boolean = false>(
         },
         opts.onError,
         opts.requiresObservable,
-        opts.delay
+        opts.delay,
+        true
     )
 
     function reactionRunner() {

--- a/packages/mobx/src/api/autorun.ts
+++ b/packages/mobx/src/api/autorun.ts
@@ -114,13 +114,22 @@ export function reaction<T, FireImmediately extends boolean = false>(
         ? comparer.structural
         : opts.equals || comparer.default
 
+    let firstRun = true
+    const scheduler = createSchedulerFromOptions(opts)
+
     const r = new Reaction(
         name,
         () => reactionRunner(),
         opts.onError,
         opts.requiresObservable,
-        createSchedulerFromOptions(opts),
-        true
+        (f: Lambda) => {
+            if (firstRun) {
+                firstRun = false
+                f()
+                return
+            }
+            scheduler(f)
+        }
     )
 
     function reactionRunner() {

--- a/packages/mobx/src/api/autorun.ts
+++ b/packages/mobx/src/api/autorun.ts
@@ -119,7 +119,8 @@ export function reaction<T, FireImmediately extends boolean = false>(
         () => reactionRunner(),
         opts.onError,
         opts.requiresObservable,
-        createSchedulerFromOptions(opts)
+        createSchedulerFromOptions(opts),
+        true
     )
 
     function reactionRunner() {

--- a/packages/mobx/src/core/reaction.ts
+++ b/packages/mobx/src/core/reaction.ts
@@ -71,8 +71,7 @@ export class Reaction implements IDerivation, IReactionPublic {
         private onInvalidate_: () => void,
         private errorHandler_?: (error: any, derivation: IDerivation) => void,
         public requiresObservable_?,
-        private scheduler: (callback: () => void) => any = f => f(),
-        private runFirstReactionImmediately = false
+        private scheduler: (callback: () => void) => any = f => f()
     ) {}
 
     onBecomeStale_() {
@@ -95,11 +94,6 @@ export class Reaction implements IDerivation, IReactionPublic {
      * internal, use schedule() if you intend to kick off a reaction
      */
     runReaction_() {
-        if (this.runFirstReactionImmediately && this.firstRun_) {
-            this.firstRun_ = false
-            this.runReactionImpl()
-            return
-        }
         if (!this.scheduledRunReaction_) {
             this.scheduledRunReaction_ = true
             this.scheduler(() => {

--- a/packages/mobx/src/core/reaction.ts
+++ b/packages/mobx/src/core/reaction.ts
@@ -63,7 +63,6 @@ export class Reaction implements IDerivation, IReactionPublic {
     isTrackPending_ = false
     isRunning_ = false
     isTracing_: TraceMode = TraceMode.NONE
-    scheduledTrack_ = false
     scheduledRunReaction_ = false
 
     constructor(
@@ -131,16 +130,6 @@ export class Reaction implements IDerivation, IReactionPublic {
     }
 
     track(fn: () => void) {
-        if (!this.scheduledTrack_) {
-            this.scheduledTrack_ = true
-            this.scheduler(() => {
-                this.scheduledTrack_ = false
-                this.trackImpl(fn)
-            })
-        }
-    }
-
-    private trackImpl(fn: () => void) {
         if (this.isDisposed_) {
             return
             // console.warn("Reaction already disposed") // Note: Not a warning / error in mobx 4 either

--- a/packages/mobx/src/core/reaction.ts
+++ b/packages/mobx/src/core/reaction.ts
@@ -64,7 +64,6 @@ export class Reaction implements IDerivation, IReactionPublic {
     isRunning_ = false
     isTracing_: TraceMode = TraceMode.NONE
     scheduledRunReaction_ = false
-    firstRun_ = true
 
     constructor(
         public name_: string = __DEV__ ? "Reaction@" + getNextId() : "Reaction",


### PR DESCRIPTION
## Derive computed states only when required for delayed Reactions

Fixes https://github.com/mobxjs/mobx/issues/3724

## Context

We use MobX with React. Due to the above issue, we are triggering unnecessary derivations for computed values (and contexts) for `autorun`s with `delay` or custom schedulers. This means that, at times, the user presses a button on screen and a render is scheduled, but, before the browser paints, it has to compute some derivation that is not required for the render.

Sometimes our derivations are expensive, so we really rely on deferring the (re)calculation of computed values until a delayed `autorun` needs to read them. Moreover, without these changes, we trigger unnescessary (re)calculations prior to when a delayed `autorun` runs.

![image](https://github.com/mobxjs/mobx/assets/13295571/60a6817b-11c3-4864-b742-c5981bfa2153)


## Changes 

The core change of this PR is to lift the "scheduler" from the `autorun` and `reaction` into `Reaction`. The rationale for this change is (I haven't contributed to this library before, so please scrutinise these reasons closely 🙏 ):

It is within [`Reaction`](https://github.com/mobxjs/mobx/blob/df7e1ebd3404d4d44cd06b7d0a3b27f4c3a6aad1/packages/mobx/src/core/reaction.ts#L53) that `shouldCompute` runs. I.e., the `Reaction` itself determines whether its been invalidated and needs to run its `onInvalidate`, so, I reasoned that it should also be responsible for scheduling that invalidation.

https://github.com/mobxjs/mobx/blob/df7e1ebd3404d4d44cd06b7d0a3b27f4c3a6aad1/packages/mobx/src/core/reaction.ts#L98

## Benefits

Again, I am a MobX noob, so these are the perceived benefits from a novice's POV:

1. We only derive computed values when they're read when they're needed, both reducing the number of times some state is derived (during `delay`) and only deriving them when needed.
2. The `autorun` and `reaction` APIs appear a bit simpler since we've consolidated the scheduling logic to `Reaction`.

## Disadvantages

Are we moving logic to Reaction that shouldn't be moved there? I think it makes sense for a Reaction to schedule its own `onInvalidation`, but I don't have the full context of the library.


### Code change checklist

-   [x] Added/updated unit tests
-   ~[ ] Updated `/docs`. For new functionality, at least `API.md` should be updated~
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

cc @urugator 

