### PR TITLE
fix(mobx-react-lite): fix double component rendering due to empty getServerSnapshot

### DIFF
--- a/.changeset/thirty-beans-dress.md
+++ b/.changeset/thirty-beans-dress.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+fix #3826: components make two renders because of the different state of the snapshots

--- a/packages/mobx-react-lite/src/useObserver.ts
+++ b/packages/mobx-react-lite/src/useObserver.ts
@@ -5,9 +5,6 @@ import { isUsingStaticRendering } from "./staticRendering"
 import { observerFinalizationRegistry } from "./utils/observerFinalizationRegistry"
 import { useSyncExternalStore } from "use-sync-external-store/shim"
 
-// Required by SSR when hydrating #3669
-const getServerSnapshot = () => {}
-
 // Do not store `admRef` (even as part of a closure!) on this object,
 // otherwise it will prevent GC and therefore reaction disposal via FinalizationRegistry.
 type ObserverAdministration = {
@@ -98,7 +95,7 @@ export function useObserver<T>(render: () => T, baseComponentName: string = "obs
         // Both of these must be stable, otherwise it would keep resubscribing every render.
         adm.subscribe,
         adm.getSnapshot,
-        getServerSnapshot
+        adm.getSnapshot
     )
 
     // render the original component, but have the


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

Fixes #3826
Fixes double rendering of component due to difference of snapshot values in `getSnapshot()` and `getServerSnapshot()` on initial rendering.