### PR TITLE
fix: ensure observer component name is only set when configurable

### DIFF
--- a/.changeset/wicked-cheetahs-build.md
+++ b/.changeset/wicked-cheetahs-build.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+fix: ensure observer component name is only set when configurable


### PR DESCRIPTION
this patch addresses issue with environments where function name property is not configurable, notably pre-ES2015.

the same condition exists in MobX: [core/action.ts](https://github.com/mobxjs/mobx/blob/main/packages/mobx/src/core/action.ts#L54).

regarding tests, I couldn't find a feasible way to seal a function, which was also discussed in #2262.

<details>

```shell
$ podman run --rm node:0.12 node -p 'Object.getOwnPropertyDescriptor(function() {}, "name")'
{ value: '',
  writable: false,
  enumerable: false,
  configurable: false }

$ podman run --rm node:0.12 node -e 'Object.defineProperty(function() {}, "name", { value: "foobar" })'
[eval]:1
Object.defineProperty(function() {}, "name", { value: "foobar" })
       ^
TypeError: Cannot redefine property: name
    at Function.defineProperty (native)
    at [eval]:1:8
    at Object.exports.runInThisContext (vm.js:74:17)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:460:26)
    at evalScript (node.js:431:25)
    at startup (node.js:90:7)
    at node.js:814:3
```

</details>

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->
