### PR TITLE
doc: Correct legacy version support for react #3828

### DIFF
--- a/packages/mobx-react/README.md
+++ b/packages/mobx-react/README.md
@@ -19,8 +19,8 @@ Only the latest version is actively maintained. If you're missing a fix or a fea
 | ----------- | -------------------- | ------------------------ | -------------------------------------------------------------------------------- |
 | v9          | 6.\*                 | >16.8                    | Hooks, React 18.2 in strict mode                                                 |
 | v7          | 6.\*                 | >16.8 < 18.2             | Hooks                                                                            |
-| v6          | 4.\* / 5.\*          | >16.8 <18                | Hooks                                                                            |
-| v5          | 4.\* / 5.\*          | >0.13 <18                | No, but it is possible to use `<Observer>` sections inside hook based components |
+| v6          | 4.\* / 5.\*          | >16.8 <17                | Hooks                                                                            |
+| v5          | 4.\* / 5.\*          | >0.13 <17                | No, but it is possible to use `<Observer>` sections inside hook based components |
 
 mobx-react 6 / 7 is a repackage of the smaller [mobx-react-lite](https://github.com/mobxjs/mobx/tree/main/packages/mobx-react-lite) package + following features from the `mobx-react@5` package added:
 


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

I pulled down the old mobx-react repo for version 6, and updated the react dependencies to v17, but the tests fail. I don't think mobx-react v5 or v6 can support react v17. 