### PR TITLE
Reduce memory overhead of tracking

### DIFF
--- a/.changeset/swift-numbers-prove.md
+++ b/.changeset/swift-numbers-prove.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Reduce memory overhead of tracking dependencies

--- a/packages/mobx/src/core/derivation.ts
+++ b/packages/mobx/src/core/derivation.ts
@@ -167,9 +167,12 @@ export function checkIfStateReadsAreAllowed(observable: IObservable) {
 export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T, context: any) {
     const prevAllowStateReads = allowStateReadsStart(true)
     changeDependenciesStateTo0(derivation)
-    // pre allocate array allocation + 20% extra room for variation in deps
-    // array will be trimmed by bindDependencies
-    derivation.newObserving_ = new Array(Math.ceil(derivation.observing_.length * 1.2))
+    // Preallocate array; will be trimmed by bindDependencies.
+    derivation.newObserving_ = new Array(
+        derivation.observing_.length
+            ? Math.ceil(derivation.observing_.length * 1.2) // 20% extra room for variation in deps
+            : 100 // Establishing initial dependencies, preallocate constant space.
+    )
     derivation.unboundDepsCount_ = 0
     derivation.runId_ = ++globalState.runId
     const prevTracking = globalState.trackingDerivation

--- a/packages/mobx/src/core/derivation.ts
+++ b/packages/mobx/src/core/derivation.ts
@@ -170,7 +170,7 @@ export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T, con
     // Preallocate array; will be trimmed by bindDependencies.
     derivation.newObserving_ = new Array(
         // Reserve constant space for initial dependencies, dynamic space otherwise.
-        derivation.runId_ === 0 ? 100 : Math.ceil(derivation.observing_.length)
+        derivation.runId_ === 0 ? 100 : derivation.observing_.length
     )
     derivation.unboundDepsCount_ = 0
     derivation.runId_ = ++globalState.runId

--- a/packages/mobx/src/core/derivation.ts
+++ b/packages/mobx/src/core/derivation.ts
@@ -170,6 +170,7 @@ export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T, con
     // Preallocate array; will be trimmed by bindDependencies.
     derivation.newObserving_ = new Array(
         // Reserve constant space for initial dependencies, dynamic space otherwise.
+        // See https://github.com/mobxjs/mobx/pull/3833
         derivation.runId_ === 0 ? 100 : derivation.observing_.length
     )
     derivation.unboundDepsCount_ = 0

--- a/packages/mobx/src/core/derivation.ts
+++ b/packages/mobx/src/core/derivation.ts
@@ -169,9 +169,8 @@ export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T, con
     changeDependenciesStateTo0(derivation)
     // Preallocate array; will be trimmed by bindDependencies.
     derivation.newObserving_ = new Array(
-        derivation.observing_.length
-            ? Math.ceil(derivation.observing_.length * 1.2) // 20% extra room for variation in deps
-            : 100 // Establishing initial dependencies, preallocate constant space.
+        // Reserve constant space for initial dependencies (dynamic space otherwise).
+        derivation.runId_ === 0 ? 100 : Math.ceil(derivation.observing_.length)
     )
     derivation.unboundDepsCount_ = 0
     derivation.runId_ = ++globalState.runId

--- a/packages/mobx/src/core/derivation.ts
+++ b/packages/mobx/src/core/derivation.ts
@@ -169,7 +169,7 @@ export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T, con
     changeDependenciesStateTo0(derivation)
     // Preallocate array; will be trimmed by bindDependencies.
     derivation.newObserving_ = new Array(
-        // Reserve constant space for initial dependencies (dynamic space otherwise).
+        // Reserve constant space for initial dependencies, dynamic space otherwise.
         derivation.runId_ === 0 ? 100 : Math.ceil(derivation.observing_.length)
     )
     derivation.unboundDepsCount_ = 0

--- a/packages/mobx/src/core/derivation.ts
+++ b/packages/mobx/src/core/derivation.ts
@@ -166,10 +166,10 @@ export function checkIfStateReadsAreAllowed(observable: IObservable) {
  */
 export function trackDerivedFunction<T>(derivation: IDerivation, f: () => T, context: any) {
     const prevAllowStateReads = allowStateReadsStart(true)
-    // pre allocate array allocation + room for variation in deps
-    // array will be trimmed by bindDependencies
     changeDependenciesStateTo0(derivation)
-    derivation.newObserving_ = new Array(derivation.observing_.length + 100)
+    // pre allocate array allocation + 20% extra room for variation in deps
+    // array will be trimmed by bindDependencies
+    derivation.newObserving_ = new Array(Math.ceil(derivation.observing_.length * 1.2))
     derivation.unboundDepsCount_ = 0
     derivation.runId_ = ++globalState.runId
     const prevTracking = globalState.trackingDerivation


### PR DESCRIPTION
TL;DR Preallocating a `size + 100` item array when tracking dependencies seems overly generous and can lead to more frequent garbage collections, causing jank. This PR replaces that with relative legroom (we preallocate 120% of space used by dependencies in the last run).

### Example
Let's consider this scenario where we read 1M computed values in an `autorun`.
```javascript
const obs = mobx.observable.box(1);
const arr = Array.from({length: 1_000_000}, () => mobx.computed(() => obs.get()));

mobx.autorun(() => {
  arr.forEach((val) => val.get());
});

function main() {
  // Recompute computeds in autorun.
  mobx.runInAction(() => obs.set(obs.get() + 1));
}

window.__main = () => main();
```
A million may seem like a lot but if we read e.g. 2000 computed values in every frame of an interaction and the interaction takes 5 seconds, we get 60fps * 5s * 2000 reads per frame and we're at 600K already. So: not super unrealistic, actually.

I've done some testing on our Canva codebase and the overhead of preallocations during some interactions (e.g. panning) is ~98% (i.e., we only use 2% of the preallocated space, rest gets GC'd).

### Impact
Memory profiling with mobx production build from CDN, I get ~430MB allocated when running. `__main()` (i.e., we have huge swathes of memory that'll need to be GC'd). With this change, this drops to ~36MB.

<img width="600" alt="Screenshot 2024-02-19 at 11 54 35 am" src="https://github.com/mobxjs/mobx/assets/596749/9c16b5f6-943c-4732-8c79-bc623ef13208">
<img width="600" alt="Screenshot 2024-02-19 at 11 53 05 am" src="https://github.com/mobxjs/mobx/assets/596749/31c242b0-fb95-43d4-a394-c3de0d8386f7">

Devtools profiler also (unsurprisingly) reports shorter time spend in GC for the build with this change (37ms vs 57ms); overall the `__main()` function runs ~30% faster with this change (compared to current main).

Of course, this is a lab scenario so the difference in real-world cases would presumably be different. However, I think it's quite reasonable to expect that in P99 case the number of dependencies between derivation runs doesn't increase dramatically so a 20% legroom instead of a large constant one seems reasonable.

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->
