### PR TITLE
Reintroduce observable state,props,context in mobx-react

### DIFF
--- a/.changeset/bright-hornets-listen.md
+++ b/.changeset/bright-hornets-listen.md
@@ -1,0 +1,5 @@
+---
+"mobx-react": patch
+---
+
+Reintroduce observable state,props,context in mobx-react

--- a/packages/mobx-react/__tests__/exp.test.tsx
+++ b/packages/mobx-react/__tests__/exp.test.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import { observer } from "../src"
+import { render, act } from "@testing-library/react"
+
+/**
+ *  some test suite is too tedious
+ */
+
+afterEach(() => {
+    jest.useRealTimers()
+})
+
+// let consoleWarnMock: jest.SpyInstance | undefined
+// afterEach(() => {
+//     consoleWarnMock?.mockRestore()
+// })
+
+test("TODO", async () => {
+    let renderCount = 0
+    const Child = observer(function Child({ children }) {
+        renderCount++
+        // Accesses Parent's this.props
+        return children()
+    })
+
+    @observer
+    class Parent extends React.Component<any> {
+        // intentionally stable, so test breaks when you disable observable props (comment line 239 in observerClass)
+        renderCallback = () => {
+            return this.props.x
+        }
+        render() {
+            // Access observable props as part of child
+            return <Child>{this.renderCallback}</Child>
+        }
+    }
+
+    function Root() {
+        const [x, setX] = React.useState(0)
+        // Send new props to Parent
+        return (
+            <div onClick={() => setX(x => x + 1)}>
+                <Parent x={x} />
+            </div>
+        )
+    }
+
+    const app = <Root />
+
+    const { unmount, container } = render(app)
+
+    expect(container).toHaveTextContent("0")
+    expect(renderCount).toBe(1)
+
+    await new Promise(resolve => setTimeout(() => resolve(null), 1000))
+    act(() => {
+        console.log("changing state")
+        container.querySelector("div")?.click()
+    })
+    expect(container).toHaveTextContent("1")
+    expect(renderCount).toBe(2)
+    unmount()
+})

--- a/packages/mobx-react/__tests__/observer.test.tsx
+++ b/packages/mobx-react/__tests__/observer.test.tsx
@@ -9,7 +9,8 @@ import {
     computed,
     observable,
     transaction,
-    makeObservable
+    makeObservable,
+    runInAction
 } from "mobx"
 import { withConsole } from "./utils/withConsole"
 import { shallowEqual } from "../src/utils/utils"
@@ -502,14 +503,14 @@ describe("should render component even if setState called with exactly the same 
         expect(renderCount).toBe(2)
     })
 
-    test("after click twice renderCount === 3", () => {
+    test("after click twice renderCount === 2", () => {
         const { container } = render(<Comp />)
         const clickableDiv = container.querySelector("#clickableDiv") as HTMLElement
 
         act(() => clickableDiv.click())
         act(() => clickableDiv.click())
 
-        expect(renderCount).toBe(3)
+        expect(renderCount).toBe(2)
     })
 })
 
@@ -1129,6 +1130,7 @@ test("Class observer can react to changes made before mount #3730", () => {
 
     @observer
     class Child extends React.Component {
+        @action
         componentDidMount(): void {
             o.set(1)
         }

--- a/packages/mobx-react/__tests__/observer.test.tsx
+++ b/packages/mobx-react/__tests__/observer.test.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode, Suspense } from "react"
+import React, { createContext, StrictMode, Suspense } from "react"
 import { inject, observer, Observer, enableStaticRendering } from "../src"
 import { render, act, waitFor } from "@testing-library/react"
 import {
@@ -9,11 +9,7 @@ import {
     computed,
     observable,
     transaction,
-    makeObservable,
-    autorun,
-    IReactionDisposer,
-    reaction,
-    configure
+    makeObservable
 } from "mobx"
 import { withConsole } from "./utils/withConsole"
 import { shallowEqual } from "../src/utils/utils"
@@ -897,6 +893,74 @@ test("Missing render should throw", () => {
     expect(() => observer(Component)).toThrow()
 })
 
+test("this.context is observable if ComponentName.contextType is set", () => {
+    const Context = createContext({})
+
+    let renderCounter = 0
+
+    @observer
+    class Parent extends React.Component<any> {
+        constructor(props: any) {
+            super(props)
+            makeObservable(this)
+        }
+
+        @observable
+        counter = 0
+
+        @computed
+        get contextValue() {
+            return { counter: this.counter }
+        }
+
+        render() {
+            return (
+                <Context.Provider value={this.contextValue}>{this.props.children}</Context.Provider>
+            )
+        }
+    }
+
+    @observer
+    class Child extends React.Component {
+        static contextType = Context
+
+        constructor(props: any) {
+            super(props)
+            makeObservable(this)
+        }
+
+        @computed
+        get counterValue() {
+            return (this.context as any).counter
+        }
+
+        render() {
+            renderCounter++
+            return <div>{this.counterValue}</div>
+        }
+    }
+
+    const parentRef = React.createRef<Parent>()
+
+    const app = (
+        <Parent ref={parentRef}>
+            <Child />
+        </Parent>
+    )
+
+    const { unmount, container } = render(app)
+
+    act(() => {
+        if (parentRef.current) {
+            parentRef.current!.counter = 1
+        }
+    })
+
+    expect(renderCounter).toBe(2)
+    expect(container).toHaveTextContent("1")
+    unmount()
+})
+
 test("class observer supports re-mounting #3395", () => {
     const state = observable.box(1)
     let mountCounter = 0
@@ -1010,315 +1074,4 @@ test("#3492 should not cause warning by calling forceUpdate on uncommited compon
     expect(aRenderCount).toBe(3)
     unmount()
     expect(consoleWarnMock).toMatchSnapshot()
-})
-;["props", "state", "context"].forEach(key => {
-    test(`using ${key} in computed throws`, () => {
-        // React prints errors even if we catch em
-        const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
-
-        const TestCmp = observer(
-            class TestCmp extends React.Component {
-                render() {
-                    computed(() => this[key]).get()
-                    return ""
-                }
-            }
-        )
-
-        expect(() => render(<TestCmp />)).toThrowError(
-            new RegExp(`^\\[mobx-react\\] Cannot read "TestCmp.${key}" in a reactive context`)
-        )
-
-        consoleErrorSpy.mockRestore()
-    })
-
-    test(`using ${key} in autorun throws`, () => {
-        // React prints errors even if we catch em
-        const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
-
-        let caughtError
-
-        const TestCmp = observer(
-            class TestCmp extends React.Component {
-                disposeAutorun: IReactionDisposer | undefined
-
-                componentDidMount(): void {
-                    this.disposeAutorun = autorun(() => this[key], {
-                        onError: error => (caughtError = error)
-                    })
-                }
-
-                componentWillUnmount(): void {
-                    this.disposeAutorun?.()
-                }
-
-                render() {
-                    return ""
-                }
-            }
-        )
-
-        render(<TestCmp />)
-        expect(caughtError?.message).toMatch(
-            new RegExp(`^\\[mobx-react\\] Cannot read "TestCmp.${key}" in a reactive context`)
-        )
-
-        consoleErrorSpy.mockRestore()
-    })
-})
-
-test(`Component react's to observable changes in componenDidMount #3691`, () => {
-    const o = observable.box(0)
-
-    const TestCmp = observer(
-        class TestCmp extends React.Component {
-            componentDidMount(): void {
-                o.set(o.get() + 1)
-            }
-
-            render() {
-                return o.get()
-            }
-        }
-    )
-
-    const { container, unmount } = render(<TestCmp />)
-    expect(container).toHaveTextContent("1")
-    unmount()
-})
-
-test(`Observable changes in componenWillUnmount don't cause any warnings or errors`, () => {
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
-    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
-    const o = observable.box(0)
-
-    const TestCmp = observer(
-        class TestCmp extends React.Component {
-            componentWillUnmount(): void {
-                o.set(o.get() + 1)
-            }
-
-            render() {
-                return o.get()
-            }
-        }
-    )
-
-    const { container, unmount } = render(<TestCmp />)
-    expect(container).toHaveTextContent("0")
-    unmount()
-
-    expect(consoleErrorSpy).not.toBeCalled()
-    expect(consoleWarnSpy).not.toBeCalled()
-
-    consoleErrorSpy.mockRestore()
-    consoleWarnSpy.mockRestore()
-})
-
-test(`Observable prop workaround`, () => {
-    configure({
-        enforceActions: "observed"
-    })
-
-    const propValues: Array<any> = []
-
-    const TestCmp = observer(
-        class TestCmp extends React.Component<{ prop: number }> {
-            disposeReaction: IReactionDisposer | undefined
-            observableProp: number
-
-            get computed() {
-                return this.observableProp + 100
-            }
-
-            constructor(props) {
-                super(props)
-                // Synchronize our observableProp with the actual prop on the first render.
-                this.observableProp = this.props.prop
-                makeObservable(this, {
-                    observableProp: observable,
-                    computed: computed,
-                    // Mutates observable therefore must be action
-                    componentDidUpdate: action
-                })
-            }
-
-            componentDidMount(): void {
-                // Reactions/autoruns must be created in componenDidMount (not in constructor).
-                this.disposeReaction = reaction(
-                    () => this.observableProp,
-                    prop => propValues.push(prop),
-                    {
-                        fireImmediately: true
-                    }
-                )
-            }
-
-            componentDidUpdate(): void {
-                // Synchronize our observableProp with the actual prop on every update.
-                this.observableProp = this.props.prop
-            }
-
-            componentWillUnmount(): void {
-                this.disposeReaction?.()
-            }
-
-            render() {
-                return this.computed
-            }
-        }
-    )
-
-    const { container, unmount, rerender } = render(<TestCmp prop={1} />)
-    expect(container).toHaveTextContent("101")
-    rerender(<TestCmp prop={2} />)
-    expect(container).toHaveTextContent("102")
-    rerender(<TestCmp prop={3} />)
-    expect(container).toHaveTextContent("103")
-    rerender(<TestCmp prop={4} />)
-    expect(container).toHaveTextContent("104")
-    expect(propValues).toEqual([1, 2, 3, 4])
-    unmount()
-})
-
-test(`Observable props/state/context workaround`, () => {
-    configure({
-        enforceActions: "observed"
-    })
-
-    const reactionResults: Array<string> = []
-
-    const ContextType = React.createContext(0)
-
-    const TestCmp = observer(
-        class TestCmp extends React.Component<any, any> {
-            static contextType = ContextType
-
-            disposeReaction: IReactionDisposer | undefined
-            observableProps: any
-            observableState: any
-            observableContext: any
-
-            constructor(props, context) {
-                super(props, context)
-                this.state = {
-                    x: 0
-                }
-                this.observableState = this.state
-                this.observableProps = this.props
-                this.observableContext = this.context
-                makeObservable(this, {
-                    observableProps: observable,
-                    observableState: observable,
-                    observableContext: observable,
-                    computed: computed,
-                    componentDidUpdate: action
-                })
-            }
-
-            get computed() {
-                return `${this.observableProps?.x}${this.observableState?.x}${this.observableContext}`
-            }
-
-            componentDidMount(): void {
-                this.disposeReaction = reaction(
-                    () => this.computed,
-                    prop => reactionResults.push(prop),
-                    {
-                        fireImmediately: true
-                    }
-                )
-            }
-
-            componentDidUpdate(): void {
-                // Props are different object with every update
-                if (!shallowEqual(this.observableProps, this.props)) {
-                    this.observableProps = this.props
-                }
-                if (!shallowEqual(this.observableState, this.state)) {
-                    this.observableState = this.state
-                }
-                if (!shallowEqual(this.observableContext, this.context)) {
-                    this.observableContext = this.context
-                }
-            }
-
-            componentWillUnmount(): void {
-                this.disposeReaction?.()
-            }
-
-            render() {
-                return (
-                    <span
-                        id="updateState"
-                        onClick={() => this.setState(state => ({ x: state.x + 1 }))}
-                    >
-                        {this.computed}
-                    </span>
-                )
-            }
-        }
-    )
-
-    const App = () => {
-        const [context, setContext] = React.useState(0)
-        const [prop, setProp] = React.useState(0)
-        return (
-            <ContextType.Provider value={context}>
-                <span id="updateContext" onClick={() => setContext(val => val + 1)}></span>
-                <span id="updateProp" onClick={() => setProp(val => val + 1)}></span>
-                <TestCmp x={prop}></TestCmp>
-            </ContextType.Provider>
-        )
-    }
-
-    const { container, unmount } = render(<App />)
-
-    const updateProp = () =>
-        act(() => (container.querySelector("#updateProp") as HTMLElement).click())
-    const updateState = () =>
-        act(() => (container.querySelector("#updateState") as HTMLElement).click())
-    const updateContext = () =>
-        act(() => (container.querySelector("#updateContext") as HTMLElement).click())
-
-    expect(container).toHaveTextContent("000")
-    updateProp()
-    expect(container).toHaveTextContent("100")
-    updateState()
-    expect(container).toHaveTextContent("110")
-    updateContext()
-    expect(container).toHaveTextContent("111")
-
-    expect(reactionResults).toEqual(["000", "100", "110", "111"])
-    unmount()
-})
-
-test("Class observer can react to changes made before mount #3730", () => {
-    const o = observable.box(0)
-
-    @observer
-    class Child extends React.Component {
-        componentDidMount(): void {
-            o.set(1)
-        }
-        render() {
-            return ""
-        }
-    }
-
-    @observer
-    class Parent extends React.Component {
-        render() {
-            return (
-                <span>
-                    {o.get()}
-                    <Child />
-                </span>
-            )
-        }
-    }
-
-    const { container, unmount } = render(<Parent />)
-    expect(container).toHaveTextContent("1")
-    unmount()
 })

--- a/packages/mobx-react/src/observerClass.ts
+++ b/packages/mobx-react/src/observerClass.ts
@@ -1,10 +1,12 @@
 import { PureComponent, Component, ComponentClass, ClassAttributes } from "react"
 import {
+    createAtom,
     _allowStateChanges,
     Reaction,
     _allowStateReadsStart,
     _allowStateReadsEnd,
-    _getGlobalState
+    _getGlobalState,
+    IAtom
 } from "mobx"
 import {
     isUsingStaticRendering,
@@ -15,25 +17,22 @@ import { shallowEqual, patch } from "./utils/utils"
 const administrationSymbol = Symbol("ObserverAdministration")
 const isMobXReactObserverSymbol = Symbol("isMobXReactObserver")
 
-let observablePropDescriptors: PropertyDescriptorMap
-if (__DEV__) {
-    observablePropDescriptors = {
-        props: createObservablePropDescriptor("props"),
-        state: createObservablePropDescriptor("state"),
-        context: createObservablePropDescriptor("context")
-    }
-}
-
 type ObserverAdministration = {
     reaction: Reaction | null // also serves as disposed flag
     forceUpdate: Function | null
     mounted: boolean // we could use forceUpdate as mounted flag
     reactionInvalidatedBeforeMount: boolean
     name: string
-    // Used only on __DEV__
+    propsAtom: IAtom
+    stateAtom: IAtom
+    contextAtom: IAtom
     props: any
     state: any
     context: any
+    // Setting this.props causes forceUpdate, because this.props is observable.
+    // forceUpdate sets this.props.
+    // This flag is used to avoid the loop.
+    isUpdating: boolean
 }
 
 function getAdministration(component: Component): ObserverAdministration {
@@ -48,7 +47,11 @@ function getAdministration(component: Component): ObserverAdministration {
         name: getDisplayName(component.constructor as ComponentClass),
         state: undefined,
         props: undefined,
-        context: undefined
+        context: undefined,
+        propsAtom: createAtom("props"),
+        stateAtom: createAtom("state"),
+        contextAtom: createAtom("context"),
+        isUpdating: false
     })
 }
 
@@ -80,9 +83,15 @@ export function makeClassComponentObserver(
         }
     }
 
-    if (__DEV__) {
-        Object.defineProperties(prototype, observablePropDescriptors)
-    }
+    // this.props and this.state are made observable, just to make sure @computed fields that
+    // are defined inside the component, and which rely on state or props, re-compute if state or props change
+    // (otherwise the computed wouldn't update and become stale on props change, since props are not observable)
+    // However, this solution is not without it's own problems: https://github.com/mobxjs/mobx-react/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Aobservable-props-or-not+
+    Object.defineProperties(prototype, {
+        props: observablePropsDescriptor,
+        state: observableStateDescriptor,
+        context: observableContextDescriptor
+    })
 
     const originalRender = prototype.render
     if (typeof originalRender !== "function") {
@@ -216,6 +225,12 @@ function createReactiveRender(originalRender: any) {
 
 function createReaction(admin: ObserverAdministration) {
     return new Reaction(`${admin.name}.render()`, () => {
+        if (admin.isUpdating) {
+            // Reaction is suppressed when setting new state/props/context,
+            // this is when component is already being updated.
+            return
+        }
+
         if (!admin.mounted) {
             // This is neccessary to avoid react warning about calling forceUpdate on component that isn't mounted yet.
             // This happens when component is abandoned after render - our reaction is already created and reacts to changes.
@@ -226,10 +241,14 @@ function createReaction(admin: ObserverAdministration) {
         }
 
         try {
+            // forceUpdate sets new `props`, since we made it observable, it would `reportChanged`, causing a loop.
+            admin.isUpdating = true
             admin.forceUpdate?.()
         } catch (error) {
             admin.reaction?.dispose()
             admin.reaction = null
+        } finally {
+            admin.isUpdating = false
         }
     })
 }
@@ -252,23 +271,40 @@ function observerSCU(nextProps: ClassAttributes<any>, nextState: any): boolean {
 }
 
 function createObservablePropDescriptor(key: "props" | "state" | "context") {
+    const atomKey = `${key}Atom`
     return {
         configurable: true,
         enumerable: true,
         get() {
             const admin = getAdministration(this)
-            const derivation = _getGlobalState().trackingDerivation
-            if (derivation && derivation !== admin.reaction) {
-                throw new Error(
-                    `[mobx-react] Cannot read "${admin.name}.${key}" in a reactive context, as it isn't observable.
-                    Please use component lifecycle method to copy the value into a local observable first.
-                    See https://github.com/mobxjs/mobx/blob/main/packages/mobx-react/README.md#note-on-using-props-and-state-in-derivations`
-                )
-            }
+
+            let prevReadState = _allowStateReadsStart(true)
+
+            admin[atomKey].reportObserved()
+
+            _allowStateReadsEnd(prevReadState)
+
             return admin[key]
         },
         set(value) {
-            getAdministration(this)[key] = value
+            const admin = getAdministration(this)
+            // forceUpdate issued by reaction sets new props.
+            // It sets isUpdating to true to prevent loop.
+            if (!admin.isUpdating && !shallowEqual(admin[key], value)) {
+                admin[key] = value
+                // This notifies all observers including our component,
+                // but we don't want to cause `forceUpdate`, because component is already updating,
+                // therefore supress component reaction.
+                admin.isUpdating = true
+                admin[atomKey].reportChanged()
+                admin.isUpdating = false
+            } else {
+                admin[key] = value
+            }
         }
     }
 }
+
+const observablePropsDescriptor = createObservablePropDescriptor("props")
+const observableStateDescriptor = createObservablePropDescriptor("state")
+const observableContextDescriptor = createObservablePropDescriptor("context")


### PR DESCRIPTION
As described in https://github.com/mobxjs/mobx/discussions/3858 
### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

