### PR TITLE
docs: remove unnecessary useState

### DIFF
--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -202,7 +202,6 @@ quite common. To make this pattern simpler the [`useLocalObservable`](https://gi
 
 ```javascript
 import { observer, useLocalObservable } from "mobx-react-lite"
-import { useState } from "react"
 
 const TimerView = observer(() => {
     const timer = useLocalObservable(() => ({


### PR DESCRIPTION
Delete unnecessary `useState` from code example