### PR TITLE
fix(eslint-plugin-mobx)!: invert exhausive-make-observable autofix

### DIFF
--- a/.changeset/twenty-coins-matter.md
+++ b/.changeset/twenty-coins-matter.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-mobx": minor
+---
+
+The exhaustive-make-observable autofix has been changed to specify a false annotation instead of true

--- a/packages/eslint-plugin-mobx/README.md
+++ b/packages/eslint-plugin-mobx/README.md
@@ -35,7 +35,7 @@ module.exports = {
 ### mobx/exhaustive-make-observable
 
 Makes sure that `makeObservable` annotates all fields defined on class or object literal.<br>
-**Autofix** adds `field: true` for each missing field.<br>
+**Autofix** adds `field: false` for each missing field.<br>
 To exclude a field, annotate it using `field: false`.<br>
 Does not support fields introduced by constructor (`this.foo = 5`).<br>
 Does not warn about annotated non-existing fields (there is a runtime check, but the autofix removing the field could be handy...).

--- a/packages/eslint-plugin-mobx/src/exhaustive-make-observable.js
+++ b/packages/eslint-plugin-mobx/src/exhaustive-make-observable.js
@@ -72,7 +72,7 @@ function create(context) {
         const keyList = keys.map(key => `\`${key}\``).join(', ');
 
         const fix = fixer => {
-          const annotationList = keys.map(key => `${key}: true`).join(', ') + ',';
+          const annotationList = keys.map(key => `${key}: false`).join(', ') + ',';
           if (!secondArg) {
             return fixer.insertTextAfter(firstArg, `, { ${annotationList} }`);
           } else if (secondArg.type !== 'ObjectExpression') {


### PR DESCRIPTION
To avoid changing behaviour of existing logic, the autofix for this rule should specify a `false` annotation to avoid changing code behaviour.

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests -- There were none before and this change is pretty minor.
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated (Just updated the README.md in this case)
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`) -- I don't believe this is relevant for this change

<!--
    Feel free to ask help with any of these boxes!
-->

