### PR TITLE
Shrink ComputedValue using a bitfield

### DIFF
--- a/.changeset/dirty-turtles-marry.md
+++ b/.changeset/dirty-turtles-marry.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Shrink ComputedValue using a bitfield

--- a/packages/mobx/__tests__/v5/base/errorhandling.js
+++ b/packages/mobx/__tests__/v5/base/errorhandling.js
@@ -4,7 +4,7 @@ const utils = require("../../v5/utils/test-utils")
 
 const { observable, computed, $mobx, autorun } = mobx
 
-const voidObserver = function () { }
+const voidObserver = function () {}
 
 function checkGlobalState() {
     const gs = mobx._getGlobalState()
@@ -148,7 +148,7 @@ test("deny state changes in views", function () {
 
     m.reaction(
         () => z.get(),
-        () => { }
+        () => {}
     )
     expect(
         utils.grabConsole(() => {
@@ -194,7 +194,7 @@ test("deny array change in view", function (done) {
     }).not.toThrow()
     m.reaction(
         () => z.length,
-        () => { }
+        () => {}
     )
 
     expect(
@@ -483,7 +483,7 @@ test("peeking inside erroring computed value doesn't bork (global) state", () =>
         b.get()
     }).toThrowError(/chocolademelk/)
 
-    expect(a.isPendingUnobservation_).toBe(false)
+    expect(a.isPendingUnobservation).toBe(false)
     expect(a.observers_.size).toBe(0)
     expect(a.diffValue_).toBe(0)
     expect(a.lowestObserverState_).toBe(-1)
@@ -493,7 +493,7 @@ test("peeking inside erroring computed value doesn't bork (global) state", () =>
     expect(b.dependenciesState_).toBe(-1) // NOT_TRACKING
     expect(b.observing_.length).toBe(0)
     expect(b.newObserving_).toBe(null)
-    expect(b.isPendingUnobservation_).toBe(false)
+    expect(b.isPendingUnobservation).toBe(false)
     expect(b.observers_.size).toBe(0)
     expect(b.diffValue_).toBe(0)
     expect(b.lowestObserverState_).toBe(0)
@@ -501,7 +501,7 @@ test("peeking inside erroring computed value doesn't bork (global) state", () =>
     expect(() => {
         b.get()
     }).toThrowError(/chocolademelk/)
-    expect(b.isComputing_).toBe(false)
+    expect(b.isComputing).toBe(false)
 
     checkGlobalState()
 })
@@ -521,7 +521,7 @@ describe("peeking inside autorun doesn't bork (global) state", () => {
     expect(r).toBe(1)
 
     test("it should update correctly initially", () => {
-        expect(a.isPendingUnobservation_).toBe(false)
+        expect(a.isPendingUnobservation).toBe(false)
         expect(a.observers_.size).toBe(1)
         expect(a.diffValue_).toBe(0)
         expect(a.lowestObserverState_).toBe(-1)
@@ -531,13 +531,13 @@ describe("peeking inside autorun doesn't bork (global) state", () => {
         expect(b.dependenciesState_).toBe(0)
         expect(b.observing_.length).toBe(1)
         expect(b.newObserving_).toBe(null)
-        expect(b.isPendingUnobservation_).toBe(false)
+        expect(b.isPendingUnobservation).toBe(false)
         expect(b.observers_.size).toBe(1)
         expect(b.diffValue_).toBe(0)
         expect(b.lowestObserverState_).toBe(0)
         expect(b.unboundDepsCount_).toBe(1) // value is always the last bound amount of observers
         expect(b.value_).toBe(1)
-        expect(b.isComputing_).toBe(false)
+        expect(b.isComputing).toBe(false)
 
         expect(c.dependenciesState_).toBe(0)
         expect(c.observing_.length).toBe(1)
@@ -558,7 +558,7 @@ describe("peeking inside autorun doesn't bork (global) state", () => {
         }, /chocolademelk/)
         expect(r).toBe(2)
 
-        expect(a.isPendingUnobservation_).toBe(false)
+        expect(a.isPendingUnobservation).toBe(false)
         expect(a.observers_.size).toBe(1)
         expect(a.diffValue_).toBe(0)
         expect(a.lowestObserverState_).toBe(0)
@@ -568,12 +568,12 @@ describe("peeking inside autorun doesn't bork (global) state", () => {
         expect(b.dependenciesState_).toBe(0) // up to date (for what it's worth)
         expect(b.observing_.length).toBe(1)
         expect(b.newObserving_).toBe(null)
-        expect(b.isPendingUnobservation_).toBe(false)
+        expect(b.isPendingUnobservation).toBe(false)
         expect(b.observers_.size).toBe(1)
         expect(b.diffValue_).toBe(0)
         expect(b.lowestObserverState_).toBe(0)
         expect(b.unboundDepsCount_).toBe(1)
-        expect(b.isComputing_).toBe(false)
+        expect(b.isComputing).toBe(false)
         expect(() => b.get()).toThrowError(/chocolademelk/)
 
         expect(c.dependenciesState_).toBe(0)
@@ -594,7 +594,7 @@ describe("peeking inside autorun doesn't bork (global) state", () => {
         a.set(3)
         expect(r).toBe(3)
 
-        expect(a.isPendingUnobservation_).toBe(false)
+        expect(a.isPendingUnobservation).toBe(false)
         expect(a.observers_.size).toBe(1)
         expect(a.diffValue_).toBe(0)
         expect(a.lowestObserverState_).toBe(0)
@@ -604,13 +604,13 @@ describe("peeking inside autorun doesn't bork (global) state", () => {
         expect(b.dependenciesState_).toBe(0) // up to date
         expect(b.observing_.length).toBe(1)
         expect(b.newObserving_).toBe(null)
-        expect(b.isPendingUnobservation_).toBe(false)
+        expect(b.isPendingUnobservation).toBe(false)
         expect(b.observers_.size).toBe(1)
         expect(b.diffValue_).toBe(0)
         expect(b.lowestObserverState_).toBe(0)
         expect(b.unboundDepsCount_).toBe(1)
         expect(b.value_).toBe(3)
-        expect(b.isComputing_).toBe(false)
+        expect(b.isComputing).toBe(false)
 
         expect(c.dependenciesState_).toBe(0)
         expect(c.observing_.length).toBe(1)
@@ -628,7 +628,7 @@ describe("peeking inside autorun doesn't bork (global) state", () => {
     test("it should clean up correctly", () => {
         d()
 
-        expect(a.isPendingUnobservation_).toBe(false)
+        expect(a.isPendingUnobservation).toBe(false)
         expect(a.observers_.size).toBe(0)
         expect(a.diffValue_).toBe(0)
         expect(a.lowestObserverState_).toBe(0)
@@ -638,13 +638,13 @@ describe("peeking inside autorun doesn't bork (global) state", () => {
         expect(b.dependenciesState_).toBe(-1) // not tracking
         expect(b.observing_.length).toBe(0)
         expect(b.newObserving_).toBe(null)
-        expect(b.isPendingUnobservation_).toBe(false)
+        expect(b.isPendingUnobservation).toBe(false)
         expect(b.observers_.size).toBe(0)
         expect(b.diffValue_).toBe(0)
         expect(b.lowestObserverState_).toBe(0)
         expect(b.unboundDepsCount_).toBe(1)
         expect(b.value_).not.toBe(3)
-        expect(b.isComputing_).toBe(false)
+        expect(b.isComputing).toBe(false)
 
         expect(c.dependenciesState_).toBe(-1)
         expect(c.observing_.length).toBe(0)
@@ -866,4 +866,4 @@ describe("es5 compat warnings", () => {
     })
 })
 
-test("should throw when adding properties in ES5 compat mode", () => { })
+test("should throw when adding properties in ES5 compat mode", () => {})

--- a/packages/mobx/src/core/atom.ts
+++ b/packages/mobx/src/core/atom.ts
@@ -22,8 +22,8 @@ export interface IAtom extends IObservable {
 }
 
 export class Atom implements IAtom {
-    isPendingUnobservation_ = false // for effective unobserving. BaseAtom has true, for extra optimization, so its onBecomeUnobserved never gets called, because it's not needed
-    isBeingObserved_ = false
+    isPendingUnobservation = false // for effective unobserving. BaseAtom has true, for extra optimization, so its onBecomeUnobserved never gets called, because it's not needed
+    isBeingObserved = false
     observers_ = new Set<IDerivation>()
 
     diffValue_ = 0

--- a/packages/mobx/src/core/observable.ts
+++ b/packages/mobx/src/core/observable.ts
@@ -24,10 +24,10 @@ export interface IObservable extends IDepTreeNode {
      * the dependency is already established
      */
     lastAccessedBy_: number
-    isBeingObserved_: boolean
+    isBeingObserved: boolean
 
     lowestObserverState_: IDerivationState_ // Used to avoid redundant propagations
-    isPendingUnobservation_: boolean // Used to push itself to global.pendingUnobservations at most once per batch.
+    isPendingUnobservation: boolean // Used to push itself to global.pendingUnobservations at most once per batch.
 
     observers_: Set<IDerivation>
 
@@ -91,9 +91,9 @@ export function removeObserver(observable: IObservable, node: IDerivation) {
 }
 
 export function queueForUnobservation(observable: IObservable) {
-    if (observable.isPendingUnobservation_ === false) {
+    if (observable.isPendingUnobservation === false) {
         // invariant(observable._observers.length === 0, "INTERNAL ERROR, should only queue for unobservation unobserved observables");
-        observable.isPendingUnobservation_ = true
+        observable.isPendingUnobservation = true
         globalState.pendingUnobservations.push(observable)
     }
 }
@@ -114,11 +114,11 @@ export function endBatch() {
         const list = globalState.pendingUnobservations
         for (let i = 0; i < list.length; i++) {
             const observable = list[i]
-            observable.isPendingUnobservation_ = false
+            observable.isPendingUnobservation = false
             if (observable.observers_.size === 0) {
-                if (observable.isBeingObserved_) {
+                if (observable.isBeingObserved) {
                     // if this observable had reactive observers, trigger the hooks
-                    observable.isBeingObserved_ = false
+                    observable.isBeingObserved = false
                     observable.onBUO()
                 }
                 if (observable instanceof ComputedValue) {
@@ -146,12 +146,12 @@ export function reportObserved(observable: IObservable): boolean {
             observable.lastAccessedBy_ = derivation.runId_
             // Tried storing newObserving, or observing, or both as Set, but performance didn't come close...
             derivation.newObserving_![derivation.unboundDepsCount_++] = observable
-            if (!observable.isBeingObserved_ && globalState.trackingContext) {
-                observable.isBeingObserved_ = true
+            if (!observable.isBeingObserved && globalState.trackingContext) {
+                observable.isBeingObserved = true
                 observable.onBO()
             }
         }
-        return observable.isBeingObserved_
+        return observable.isBeingObserved
     } else if (observable.observers_.size === 0 && globalState.inBatch > 0) {
         queueForUnobservation(observable)
     }


### PR DESCRIPTION
### Code change checklist

-   [] N/A: Added/updated unit tests
-   [] N/A: Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

`ComputedValue` is currently 112 bytes in 64-bit chromium browsers, and it's not unreasonable to see 10s or 100s of thousands of these on very large apps. This makes this class IMO a reasonable target for memory optimization, given small changes can give big wins in absolute memory.

This change takes four boolean fields and stores them in one bitfield, adding getters and setters to keep the API to access them the same.

This shrinks 112 bytes down to 100 (verified in devtools) by removing 4x 4 byte booleans and replacing them with 1x 4 byte integer in v8. In Safari the bools take 8 bytes so this should save 3x 8 bytes (but I didn't check).

There will be an increased overhead to get/set the boolean values now given the bit-shifting required. I don't see any regressions running `yarn test:performance`, but I'm happy to investigate further if this is a concern. I don't think these booleans are in any really performance critical paths. If they are, I'm pretty confident v8 at least will optimize the bit-shifting well, and only add a few machine instructions in optimized code.

Regarding the code, using a bitfield could be done in many different ways, so take what I have here as one suggestion, I'm happy to refactor or make more general. I'd like to avoid introducing a bitfield class, because the allocation of a new object per `ComputedValue` instance will cancel out the memory savings. Better to keep the bitfield as a direct member of `ComputedValue`.

If we can reach a suitable solution here, I'd like to do the same thing to `ObservableValue`, `Atom`, `Reaction` and `ObservableObjectAdministration` which from a brief glance can all save 12-ish bytes as well.