### PR TITLE
feat(eslint-plugin-mobx): configurable default autofix annotation for makeObservable

### DIFF
--- a/.changeset/lovely-lemons-joke.md
+++ b/.changeset/lovely-lemons-joke.md
@@ -1,0 +1,7 @@
+---
+"eslint-plugin-mobx": patch
+---
+
+Adds an option for the `mobx/exhaustive-make-observable` eslint rule to configure whether fields are annotated with `true` or `false` with the autofixer.
+
+This option defaults to `true` if not present or an invalid value is received to maintain existing behavior.

--- a/packages/eslint-plugin-mobx/README.md
+++ b/packages/eslint-plugin-mobx/README.md
@@ -35,10 +35,22 @@ module.exports = {
 ### mobx/exhaustive-make-observable
 
 Makes sure that `makeObservable` annotates all fields defined on class or object literal.<br>
-**Autofix** adds `field: true` for each missing field.<br>
 To exclude a field, annotate it using `field: false`.<br>
 Does not support fields introduced by constructor (`this.foo = 5`).<br>
-Does not warn about annotated non-existing fields (there is a runtime check, but the autofix removing the field could be handy...).
+Does not warn about annotated non-existing fields (there is a runtime check, but the autofix removing the field could be handy...).<br>
+**Autofix** adds `field: true` for each missing field by default. You can change this behaviour by specifying options in your eslint config:
+
+```json
+{
+    "rules": {
+        "mobx/exhaustive-make-observable": ["error", { "autofixAnnotation": false }]
+    }
+}
+```
+
+This is a boolean value that controls if the field is annotated with `true` or `false`.
+If you are migrating an existing project using `makeObservable` and do not want this rule to override
+your current usage (even if it may be wrong), you should run the autofix with the annotation set to `false` to maintain existing behaviour: `eslint --no-eslintrc --fix --rule='mobx/exhaustive-make-observable: [2, { "autofixAnnotation": false }]' .`
 
 ### mobx/missing-make-observable
 

--- a/packages/eslint-plugin-mobx/src/exhaustive-make-observable.js
+++ b/packages/eslint-plugin-mobx/src/exhaustive-make-observable.js
@@ -1,55 +1,61 @@
-'use strict';
+"use strict"
 
-const { findAncestor, isMobxDecorator } = require('./utils.js');
+const { findAncestor, isMobxDecorator } = require("./utils.js")
 
 // TODO support this.foo = 5; in constructor
 // TODO? report on field as well
 function create(context) {
-  const sourceCode = context.getSourceCode();
+    const sourceCode = context.getSourceCode()
 
-  function fieldToKey(field) {
-    // TODO cache on field?
-    const key = sourceCode.getText(field.key);
-    return field.computed ? `[${key}]` : key;
-  }
+    function fieldToKey(field) {
+        // TODO cache on field?
+        const key = sourceCode.getText(field.key)
+        return field.computed ? `[${key}]` : key
+    }
 
-  return {
-    'CallExpression[callee.name="makeObservable"]': makeObservable => {
-      // Only interested about makeObservable(this, ...) in constructor or makeObservable({}, ...)
-      // ClassDeclaration 
-      //   ClassBody
-      //     MethodDefinition[kind="constructor"]
-      //       FunctionExpression
-      //         BlockStatement
-      //           ExpressionStatement
-      //             CallExpression[callee.name="makeObservable"]        
-      const [firstArg, secondArg] = makeObservable.arguments;
-      if (!firstArg) return;
-      let members;
-      if (firstArg.type === 'ThisExpression') {
-        const closestFunction = findAncestor(makeObservable, node => node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration')
-        if (closestFunction?.parent?.kind !== 'constructor') return;
-        members = closestFunction.parent.parent.parent.body.body;
-      } else if (firstArg.type === 'ObjectExpression') {
-        members = firstArg.properties;
-      } else {
-        return;
-      }
+    return {
+        'CallExpression[callee.name="makeObservable"]': makeObservable => {
+            // Only interested about makeObservable(this, ...) in constructor or makeObservable({}, ...)
+            // ClassDeclaration
+            //   ClassBody
+            //     MethodDefinition[kind="constructor"]
+            //       FunctionExpression
+            //         BlockStatement
+            //           ExpressionStatement
+            //             CallExpression[callee.name="makeObservable"]
+            const [firstArg, secondArg] = makeObservable.arguments
+            if (!firstArg) return
+            let members
+            if (firstArg.type === "ThisExpression") {
+                const closestFunction = findAncestor(
+                    makeObservable,
+                    node =>
+                        node.type === "FunctionExpression" || node.type === "FunctionDeclaration"
+                )
+                if (closestFunction?.parent?.kind !== "constructor") return
+                members = closestFunction.parent.parent.parent.body.body
+            } else if (firstArg.type === "ObjectExpression") {
+                members = firstArg.properties
+            } else {
+                return
+            }
 
-      const annotationProps = secondArg?.properties || [];
-      const nonAnnotatedMembers = [];
-      let hasAnyDecorator = false;
+            const annotationProps = secondArg?.properties || []
+            const nonAnnotatedMembers = []
+            let hasAnyDecorator = false
 
-      members.forEach(member => {
-        if (member.static) return;
-        if (member.kind === "constructor") return;
-        //if (member.type !== 'MethodDefinition' && member.type !== 'ClassProperty') return;                    
-        hasAnyDecorator = hasAnyDecorator || member.decorators?.some(isMobxDecorator) || false;
-        if (!annotationProps.some(prop => fieldToKey(prop) === fieldToKey(member))) { // TODO optimize?
-          nonAnnotatedMembers.push(member);
-        }
-      })
-      /*
+            members.forEach(member => {
+                if (member.static) return
+                if (member.kind === "constructor") return
+                //if (member.type !== 'MethodDefinition' && member.type !== 'ClassProperty') return;
+                hasAnyDecorator =
+                    hasAnyDecorator || member.decorators?.some(isMobxDecorator) || false
+                if (!annotationProps.some(prop => fieldToKey(prop) === fieldToKey(member))) {
+                    // TODO optimize?
+                    nonAnnotatedMembers.push(member)
+                }
+            })
+            /*
       // With decorators, second arg must be null/undefined or not provided
       if (hasAnyDecorator && secondArg && secondArg.name !== "undefined" && secondArg.value !== null) {
         context.report({
@@ -66,46 +72,47 @@ function create(context) {
       }
       */
 
-      if (!hasAnyDecorator && nonAnnotatedMembers.length) {
-        // Set avoids reporting twice for setter+getter pair or actual duplicates
-        const keys = [...new Set(nonAnnotatedMembers.map(fieldToKey))];
-        const keyList = keys.map(key => `\`${key}\``).join(', ');
+            if (!hasAnyDecorator && nonAnnotatedMembers.length) {
+                // Set avoids reporting twice for setter+getter pair or actual duplicates
+                const keys = [...new Set(nonAnnotatedMembers.map(fieldToKey))]
+                const keyList = keys.map(key => `\`${key}\``).join(", ")
 
-        const fix = fixer => {
-          const annotationList = keys.map(key => `${key}: true`).join(', ') + ',';
-          if (!secondArg) {
-            return fixer.insertTextAfter(firstArg, `, { ${annotationList} }`);
-          } else if (secondArg.type !== 'ObjectExpression') {
-            return fixer.replaceText(secondArg, `{ ${annotationList} }`);
-          } else {
-            const openingBracket = sourceCode.getFirstToken(secondArg)
-            return fixer.insertTextAfter(openingBracket, ` ${annotationList} `);
-          }
-        };
+                const fix = fixer => {
+                    const annotationList = keys.map(key => `${key}: true`).join(", ") + ","
+                    if (!secondArg) {
+                        return fixer.insertTextAfter(firstArg, `, { ${annotationList} }`)
+                    } else if (secondArg.type !== "ObjectExpression") {
+                        return fixer.replaceText(secondArg, `{ ${annotationList} }`)
+                    } else {
+                        const openingBracket = sourceCode.getFirstToken(secondArg)
+                        return fixer.insertTextAfter(openingBracket, ` ${annotationList} `)
+                    }
+                }
 
-        context.report({
-          node: makeObservable,
-          messageId: 'missingAnnotation',
-          data: { keyList },
-          fix,
-        })
-      }
-    },
-  };
+                context.report({
+                    node: makeObservable,
+                    messageId: "missingAnnotation",
+                    data: { keyList },
+                    fix
+                })
+            }
+        }
+    }
 }
 
 module.exports = {
-  meta: {
-    type: 'suggestion',
-    fixable: 'code',
-    docs: {
-      description: 'enforce all fields being listen in `makeObservable`',
-      recommended: true,
-      suggestion: false,
+    meta: {
+        type: "suggestion",
+        fixable: "code",
+        docs: {
+            description: "enforce all fields being listen in `makeObservable`",
+            recommended: true,
+            suggestion: false
+        },
+        messages: {
+            missingAnnotation:
+                "Missing annotation for {{ keyList }}. To exclude a field, use `false` as annotation."
+        }
     },
-    messages: {
-      'missingAnnotation': 'Missing annotation for {{ keyList }}. To exclude a field, use `false` as annotation.',
-    },
-  },
-  create,
-};
+    create
+}

--- a/packages/eslint-plugin-mobx/src/exhaustive-make-observable.js
+++ b/packages/eslint-plugin-mobx/src/exhaustive-make-observable.js
@@ -6,6 +6,7 @@ const { findAncestor, isMobxDecorator } = require("./utils.js")
 // TODO? report on field as well
 function create(context) {
     const sourceCode = context.getSourceCode()
+    const autofixAnnotation = context.options[0]?.autofixAnnotation ?? true
 
     function fieldToKey(field) {
         // TODO cache on field?
@@ -78,7 +79,8 @@ function create(context) {
                 const keyList = keys.map(key => `\`${key}\``).join(", ")
 
                 const fix = fixer => {
-                    const annotationList = keys.map(key => `${key}: true`).join(", ") + ","
+                    const annotationList =
+                        keys.map(key => `${key}: ${autofixAnnotation}`).join(", ") + ","
                     if (!secondArg) {
                         return fixer.insertTextAfter(firstArg, `, { ${annotationList} }`)
                     } else if (secondArg.type !== "ObjectExpression") {
@@ -104,6 +106,17 @@ module.exports = {
     meta: {
         type: "suggestion",
         fixable: "code",
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    autofixAnnotation: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
+            }
+        ],
         docs: {
             description: "enforce all fields being listen in `makeObservable`",
             recommended: true,


### PR DESCRIPTION
Adds an option for the `mobx/exhaustive-make-observable` eslint rule to configure whether fields are annotated with `true` or `false` with the autofixer.

This option defaults to `true` if not present or an invalid value is received to maintain existing behavior.

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests -- No unit testing in the eslint package, but I have tested these changes against some other projects that use this rule.
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->

Note: It looks like some formatting rules have changed since the last time this file was touched so there's quite a lot of changes.

Closes #3876 