### PR TITLE
fix: Allow action field decorators without makeObservable (#3879)

### DIFF
--- a/.changeset/bright-tips-invite.md
+++ b/.changeset/bright-tips-invite.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix 2022.3 @action decorators on fields no longer require makeObservable

--- a/packages/mobx/__tests__/decorators_20223/stage3-decorators.ts
+++ b/packages/mobx/__tests__/decorators_20223/stage3-decorators.ts
@@ -334,9 +334,7 @@ function normalizeSpyEvents(events: any[]) {
 
 test("action decorator (2022.3)", () => {
     class Store {
-        constructor(private multiplier: number) {
-            makeObservable(this)
-        }
+        constructor(private multiplier: number) {}
 
         @action
         add(a: number, b: number): number {
@@ -366,9 +364,7 @@ test("action decorator (2022.3)", () => {
 
 test("custom action decorator (2022.3)", () => {
     class Store {
-        constructor(private multiplier: number) {
-            makeObservable(this)
-        }
+        constructor(private multiplier: number) {}
 
         @action("zoem zoem")
         add(a: number, b: number): number {
@@ -416,9 +412,7 @@ test("custom action decorator (2022.3)", () => {
 
 test("action decorator on field (2022.3)", () => {
     class Store {
-        constructor(private multiplier: number) {
-            makeObservable(this)
-        }
+        constructor(private multiplier: number) {}
 
         @action
         add = (a: number, b: number) => {
@@ -450,9 +444,7 @@ test("action decorator on field (2022.3)", () => {
 
 test("custom action decorator on field (2022.3)", () => {
     class Store {
-        constructor(private multiplier: number) {
-            makeObservable(this)
-        }
+        constructor(private multiplier: number) {}
 
         @action("zoem zoem")
         add = (a: number, b: number) => {

--- a/packages/mobx/src/types/actionannotation.ts
+++ b/packages/mobx/src/types/actionannotation.ts
@@ -8,8 +8,7 @@ import {
     Annotation,
     globalState,
     MakeResult,
-    assert20223DecoratorType,
-    storeAnnotation
+    assert20223DecoratorType
 } from "../internal"
 
 export function createActionAnnotation(name: string, options?: object): Annotation {
@@ -73,12 +72,8 @@ function decorate_20223_(this: Annotation, mthd, context: DecoratorContext) {
     const _createAction = m =>
         createAction(ann.options_?.name ?? name!.toString(), m, ann.options_?.autoAction ?? false)
 
-    // Backwards/Legacy behavior, expects makeObservable(this)
     if (kind == "field") {
-        addInitializer(function () {
-            storeAnnotation(this, name, ann)
-        })
-        return
+        return _createAction
     }
 
     if (kind == "method") {


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] N/A ~Updated `/docs`. For new functionality, at least `API.md` should be updated~
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

fixes #3879 

<!--
    Feel free to ask help with any of these boxes!
-->
