### PR TITLE
Fix ES6 Map/Set checks for cross-window scripts

### DIFF
--- a/.changeset/fresh-apricots-heal.md
+++ b/.changeset/fresh-apricots-heal.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix ES6 Map/Set checks for cross-window scripts

--- a/packages/mobx/src/types/observablemap.ts
+++ b/packages/mobx/src/types/observablemap.ts
@@ -16,6 +16,7 @@ import {
     hasListeners,
     interceptChange,
     isES6Map,
+    isPlainES6Map,
     isPlainObject,
     isSpyEnabled,
     makeIterable,
@@ -351,7 +352,7 @@ export class ObservableMap<K = any, V = any>
             } else if (Array.isArray(other)) {
                 other.forEach(([key, value]) => this.set(key, value))
             } else if (isES6Map(other)) {
-                if (other.constructor.name !== "Map") {
+                if (!isPlainES6Map(other)) {
                     die(19, other)
                 }
                 other.forEach((value, key) => this.set(key, value))

--- a/packages/mobx/src/types/observablemap.ts
+++ b/packages/mobx/src/types/observablemap.ts
@@ -351,7 +351,7 @@ export class ObservableMap<K = any, V = any>
             } else if (Array.isArray(other)) {
                 other.forEach(([key, value]) => this.set(key, value))
             } else if (isES6Map(other)) {
-                if (other.constructor !== Map) {
+                if (other.constructor.name !== "Map") {
                     die(19, other)
                 }
                 other.forEach((value, key) => this.set(key, value))

--- a/packages/mobx/src/utils/utils.ts
+++ b/packages/mobx/src/utils/utils.ts
@@ -141,11 +141,11 @@ export function createInstanceofPredicate<T>(
 }
 
 export function isES6Map(thing: any): thing is Map<any, any> {
-    return thing instanceof Map
+    return thing != null && Object.prototype.toString.call(thing) === "[object Map]"
 }
 
 export function isES6Set(thing: any): thing is Set<any> {
-    return thing instanceof Set
+    return thing != null && Object.prototype.toString.call(thing) === "[object Set]"
 }
 
 const hasGetOwnPropertySymbols = typeof Object.getOwnPropertySymbols !== "undefined"

--- a/packages/mobx/src/utils/utils.ts
+++ b/packages/mobx/src/utils/utils.ts
@@ -144,6 +144,13 @@ export function isES6Map(thing: any): thing is Map<any, any> {
     return thing != null && Object.prototype.toString.call(thing) === "[object Map]"
 }
 
+export function isPlainES6Map(thing: Map<any, any>): boolean {
+    const mapProto = Object.getPrototypeOf(thing)
+    const objectProto = Object.getPrototypeOf(mapProto)
+    const nullProto = Object.getPrototypeOf(objectProto)
+    return nullProto === null
+}
+
 export function isES6Set(thing: any): thing is Set<any> {
     return thing != null && Object.prototype.toString.call(thing) === "[object Set]"
 }


### PR DESCRIPTION
### Related Issue

Fixes #3892 

### Code change checklist

-   [ ] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

Do I have to add unit tests for this change? I'm not sure is it even possible to make cross-realm ES6 Map/Set instance in jest/jsdom test envionrment.