### PR TITLE
Doc fix: observable fields is not specified

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -443,11 +443,18 @@ However, TypeScript isn't aware of that transformation, so `flowResult` will mak
 `flow`, like `action`, can be used to wrap functions directly. The above example could also have been written as follows:
 
 ```typescript
-import { flow } from "mobx"
+import { flow, makeObservable, observable } from "mobx"
 
 class Store {
     githubProjects = []
     state = "pending"
+
+    constructor() {
+        makeObservable(this, {
+            githubProjects: observable,
+            state: observable,
+        })
+    }
 
     fetchProjects = flow(function* (this: Store) {
         this.githubProjects = []


### PR DESCRIPTION
1. It should probably be explained in the documentation that fields marked with `flow(...)` should be excluded from wrapping in `makeObservable`/`makeAutoObservable`
2. Perhaps this place is a good place for example with `false` annotation `makeAutoObservable(this, { fetchProjects: false })`.