### PR TITLE
Fix Typescript 5.6.x support by introducing esnext iterator helpers (#3927)

### DIFF
--- a/.changeset/neat-ants-relate.md
+++ b/.changeset/neat-ants-relate.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Update typescript version to 5.6.2 and added support for esnext iterator helpers

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     ],
     "resolutions": {
         "jest": "^29.5.0",
-        "typescript": "^5.5.2",
+        "typescript": "^5.6.2",
         "recast": "^0.23.1"
     },
     "repository": {
@@ -68,7 +68,7 @@
         "tape": "^5.0.1",
         "ts-jest": "^29.0.5",
         "tsdx": "^0.14.1",
-        "typescript": "^5.5.2"
+        "typescript": "^5.6.2"
     },
     "husky": {
         "hooks": {

--- a/packages/mobx/__tests__/v5/base/map.js
+++ b/packages/mobx/__tests__/v5/base/map.js
@@ -915,6 +915,34 @@ test("maps.values, keys and maps.entries are iterables", () => {
     expect(Array.from(x.keys())).toEqual(["x", "y"])
 })
 
+// Test support for [iterator-helpers](https://github.com/tc39/proposal-iterator-helpers)
+test("esnext iterator helpers support", () => {
+    const map = mobx.observable(
+        new Map([
+            ["x", [1, 2]],
+            ["y", [3, 4]]
+        ])
+    )
+
+    expect(Array.from(map.keys().map(value => value))).toEqual(["x", "y"])
+    expect(Array.from(map.values().map(value => value))).toEqual([
+        [1, 2],
+        [3, 4]
+    ])
+    expect(Array.from(map.entries().map(([, value]) => value))).toEqual([
+        [1, 2],
+        [3, 4]
+    ])
+
+    expect(Array.from(map.entries().take(1))).toEqual([["x", [1, 2]]])
+    expect(Array.from(map.entries().drop(1))).toEqual([["y", [3, 4]]])
+    expect(Array.from(map.entries().filter(([key]) => key === "y"))).toEqual([["y", [3, 4]]])
+    expect(Array.from(map.entries().find(([key]) => key === "y"))).toEqual(["y", [3, 4]])
+    expect(map.entries().toArray()).toEqual(Array.from(map))
+
+    expect(map.entries().toString()).toEqual("[object MapIterator]")
+})
+
 test("toStringTag", () => {
     const x = mobx.observable.map({ x: 1, y: 2 })
     expect(x[Symbol.toStringTag]).toBe("Map")

--- a/packages/mobx/__tests__/v5/base/set.js
+++ b/packages/mobx/__tests__/v5/base/set.js
@@ -201,6 +201,34 @@ test("set should support iterall / iterable ", () => {
     expect(leech(a.values())).toEqual([1, 2])
 })
 
+// Test support for [iterator-helpers](https://github.com/tc39/proposal-iterator-helpers)
+test("esnext iterator helpers support", () => {
+    const set = mobx.observable(
+        new Set([
+            [1, 2],
+            [3, 4]
+        ])
+    )
+
+    expect(Array.from(set.values().map(value => value))).toEqual([
+        [1, 2],
+        [3, 4]
+    ])
+
+    expect(Array.from(set.entries().map(([, value]) => value))).toEqual([
+        [1, 2],
+        [3, 4]
+    ])
+
+    expect(Array.from(set.values().take(1))).toEqual([[1, 2]])
+    expect(Array.from(set.values().drop(1))).toEqual([[3, 4]])
+    expect(Array.from(set.values().filter(value => value[0] === 3))).toEqual([[3, 4]])
+    expect(Array.from(set.values().find(value => value[0] === 3))).toEqual([3, 4])
+    expect(Array.from(set.values().flatMap(value => value))).toEqual([1, 2, 3, 4])
+
+    expect(set.entries().toString()).toEqual("[object SetIterator]")
+})
+
 test("support for ES6 Set", () => {
     const x = new Set()
     x.add(1)

--- a/packages/mobx/src/types/observablemap.ts
+++ b/packages/mobx/src/types/observablemap.ts
@@ -9,6 +9,7 @@ import {
     checkIfStateModificationsAreAllowed,
     createAtom,
     createInstanceofPredicate,
+    makeIterable,
     deepEnhancer,
     getNextId,
     getPlainObjectKeys,
@@ -19,7 +20,6 @@ import {
     isPlainES6Map,
     isPlainObject,
     isSpyEnabled,
-    makeIterable,
     notifyListeners,
     referenceEnhancer,
     registerInterceptor,
@@ -296,15 +296,15 @@ export class ObservableMap<K = any, V = any>
         return value
     }
 
-    keys(): IterableIterator<K> {
+    keys(): MapIterator<K> {
         this.keysAtom_.reportObserved()
         return this.data_.keys()
     }
 
-    values(): IterableIterator<V> {
+    values(): MapIterator<V> {
         const self = this
         const keys = this.keys()
-        return makeIterable({
+        return makeIterableForMap({
             next() {
                 const { done, value } = keys.next()
                 return {
@@ -315,10 +315,10 @@ export class ObservableMap<K = any, V = any>
         })
     }
 
-    entries(): IterableIterator<IMapEntry<K, V>> {
+    entries(): MapIterator<IMapEntry<K, V>> {
         const self = this
         const keys = this.keys()
-        return makeIterable({
+        return makeIterableForMap({
             next() {
                 const { done, value } = keys.next()
                 return {
@@ -489,6 +489,11 @@ export class ObservableMap<K = any, V = any>
 export var isObservableMap = createInstanceofPredicate("ObservableMap", ObservableMap) as (
     thing: any
 ) => thing is ObservableMap<any, any>
+
+function makeIterableForMap<T>(iterator: Iterator<T>): MapIterator<T> {
+    iterator[Symbol.toStringTag] = "MapIterator"
+    return makeIterable<T, BuiltinIteratorReturn>(iterator)
+}
 
 function convertToMap(dataStructure: any): Map<any, any> {
     if (isES6Map(dataStructure) || isObservableMap(dataStructure)) {

--- a/packages/mobx/src/utils/iterable.ts
+++ b/packages/mobx/src/utils/iterable.ts
@@ -1,8 +1,5 @@
-export function makeIterable<T>(iterator: Iterator<T>): IterableIterator<T> {
-    iterator[Symbol.iterator] = getSelf
-    return iterator as any
-}
-
-function getSelf() {
-    return this
+export function makeIterable<T, TReturn = unknown>(
+    iterator: Iterator<T>
+): IteratorObject<T, TReturn> {
+    return Object.assign(Object.create(Iterator.prototype), iterator)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13588,10 +13588,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^3.7.3, typescript@^5.5.2:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
-  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
+typescript@^3.7.3, typescript@^5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
+  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->

### Context

Fixes https://github.com/mobxjs/mobx/issues/3927

### Purpose of the PR
TypeScript 5.6.x introduces new [Iterator Helper Methods](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#iterator-helper-methods) that enhance the `IterableObject` interface with methods like `map`, `flatMap`, `take`, and `drop`. However, when the `esnext` target is enabled, MobX becomes incompatible as its current implementation lacks these methods, resulting in type errors.

This PR addresses the compatibility issues by:

- **Updating the `IterableObject` Interface**: Aligning MobX’s implementation with TypeScript’s updated type definitions to prevent type errors.
- **Integrating Support for Iterator Helper Methods**: Adding the new methods within MobX and enabling conditional polyfill support for environments that do not natively implement them.


