### PR TITLE
deprecate `IObserverOptions` options and its properties in JSDoc

### DIFF
--- a/packages/mobx-react-lite/src/observer.ts
+++ b/packages/mobx-react-lite/src/observer.ts
@@ -18,13 +18,27 @@ const ReactMemoSymbol = hasSymbol
     ? Symbol.for("react.memo")
     : typeof memo === "function" && memo((props: any) => null)["$$typeof"]
 
+/**
+ * @deprecated Observer options will be removed in the next major version of mobx-react-lite.
+ * Look at the individual properties for alternatives.
+ */
 export interface IObserverOptions {
+    /**
+     * @deprecated Pass a `React.forwardRef` component to observer instead of using the options object
+     * e.g. `observer(React.forwardRef(fn))`
+     */
     readonly forwardRef?: boolean
 }
 
 export function observer<P extends object, TRef = {}>(
     baseComponent: React.ForwardRefRenderFunction<TRef, P>,
-    options: IObserverOptions & { forwardRef: true }
+    options: IObserverOptions & {
+        /**
+         * @deprecated Pass a `React.forwardRef` component to observer instead of using the options object
+         * e.g. `observer(React.forwardRef(fn))`
+         */
+        forwardRef: true
+    }
 ): React.MemoExoticComponent<
     React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
 >


### PR DESCRIPTION
Added some JSDoc that marks `IObserverOptions` as deprecated along with its individual properties. This gives some developers some feedback inside their editors instead of `console.warn` messages at runtime.