### PR TITLE
Fix(mobx): Safer method to consume Iterator.prototype

### DIFF
--- a/.changeset/five-news-hammer.md
+++ b/.changeset/five-news-hammer.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix browser compatability issue introduced in 6.13.4 release

--- a/packages/mobx/src/utils/iterable.ts
+++ b/packages/mobx/src/utils/iterable.ts
@@ -1,7 +1,7 @@
 import { getGlobal } from "../internal"
 
 // safely get iterator prototype if available
-const maybeIteratorPrototype = getGlobal()["Iterator"]?.prototype
+const maybeIteratorPrototype = getGlobal().Iterator?.prototype
 
 export function makeIterable<T, TReturn = unknown>(
     iterator: Iterator<T>

--- a/packages/mobx/src/utils/iterable.ts
+++ b/packages/mobx/src/utils/iterable.ts
@@ -1,5 +1,15 @@
+import { getGlobal } from "../internal"
+
+// safely get iterator prototype if available
+const maybeIteratorPrototype = getGlobal()["Iterator"]?.prototype
+
 export function makeIterable<T, TReturn = unknown>(
     iterator: Iterator<T>
 ): IteratorObject<T, TReturn> {
-    return Object.assign(Object.create(Iterator.prototype), iterator)
+    iterator[Symbol.iterator] = getSelf
+    return Object.assign(Object.create(maybeIteratorPrototype), iterator)
+}
+
+function getSelf() {
+    return this
 }

--- a/packages/mobx/src/utils/iterable.ts
+++ b/packages/mobx/src/utils/iterable.ts
@@ -1,7 +1,7 @@
 import { getGlobal } from "../internal"
 
 // safely get iterator prototype if available
-const maybeIteratorPrototype = getGlobal().Iterator?.prototype
+const maybeIteratorPrototype = getGlobal().Iterator?.prototype || {}
 
 export function makeIterable<T, TReturn = unknown>(
     iterator: Iterator<T>


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

Really sorry, I might have introduced a bug [here](https://github.com/mobxjs/mobx/pull/3935)
thanks @zeldigas for reporting! 

### Context

For some projects setups, `Observablemap.prototype.forEach`, `ObservableSet.prototype.forEach` might throw an error on older browsers and Safari, I am genuinely sorry about this one.

I wrongfully assumed that `Iterator.prototype` is widely available but that's not the case.

<img width="1317" alt="Screenshot 2024-10-16 at 11 01 48 pm" src="https://github.com/user-attachments/assets/ad9d9603-859f-43d6-b8e5-684244e6ece0">
