### PR TITLE
Fix(mobx): Typescript pre-5.6 backwards compatibility

### DIFF
--- a/packages/mobx/.changeset/odd-years-shop.md
+++ b/packages/mobx/.changeset/odd-years-shop.md
@@ -1,5 +1,0 @@
----
-"mobx": patch
----
-
-Fix typescript backwards compatability for versions pre 5.6

--- a/packages/mobx/.changeset/odd-years-shop.md
+++ b/packages/mobx/.changeset/odd-years-shop.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix typescript backwards compatability for versions pre 5.6

--- a/packages/mobx/src/lib.2015.iterable.backfill-pre-5.6.d.ts
+++ b/packages/mobx/src/lib.2015.iterable.backfill-pre-5.6.d.ts
@@ -1,0 +1,29 @@
+// for backward compatability with typescript pre version 5.6
+// copied from https://github.com/microsoft/TypeScript/blob/main/src/lib/es2015.iterable.d.ts
+
+/**
+ * Defines the `TReturn` type used for built-in iterators produced by `Array`, `Map`, `Set`, and others.
+ * This is `undefined` when `strictBuiltInIteratorReturn` is `true`; otherwise, this is `any`.
+ */
+type BuiltinIteratorReturn = intrinsic;
+
+
+interface SetIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+    [Symbol.iterator](): SetIterator<T>;
+}
+
+/**
+ * Describes an {@link Iterator} produced by the runtime that inherits from the intrinsic `Iterator.prototype`.
+ */
+interface IteratorObject<T, TReturn = unknown, TNext = unknown> extends Iterator<T, TReturn, TNext> {
+    [Symbol.iterator](): IteratorObject<T, TReturn, TNext>;
+}
+
+interface MapIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+    [Symbol.iterator](): MapIterator<T>;
+}
+
+
+interface MapIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+    [Symbol.iterator](): MapIterator<T>;
+}


### PR DESCRIPTION
### Description
I've received some negative feedback w.r.t this patch https://github.com/mobxjs/mobx/pull/3935 `mobx@6.13.4`.
as it breaks typescript backwards compatibility with versions before 5.6.

Apologies for any inconveniences this has caused, as far as I understand typescript isn't pinned to a specific version by design hence the updates being reported as a patch within previous changes, I am not entirely sure if this changeset makes much sense to include within the mobx package or it would be preferable to start specifying peer dependencies for typing.

Alternatively you can use `mobx@6.13.4+` with older typescripts versions by adding the attached `.d.ts` file to your project if you really need to type check dependencies.

Going to quote mwestrate [here](https://github.com/mobxjs/mobx/issues/3903#issuecomment-2234093654)
>  It is not ideal, and generally I avoid this problem (many libs suffer from it) by slamming a skipLibCheck: true in my projects' tsconfig.

probably not worth it to add this patch but keen for feedback non the less.