### PR TITLE
Fix Set interceptors

### DIFF
--- a/.changeset/set-interceptors.md
+++ b/.changeset/set-interceptors.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix observable.set not respecting the new value from interceptors 

--- a/packages/mobx/__tests__/v5/base/set.js
+++ b/packages/mobx/__tests__/v5/base/set.js
@@ -474,3 +474,48 @@ describe("Observable Set methods are reactive", () => {
         expect(c).toBe(3)
     })
 })
+
+
+describe("Observable Set interceptors", () => {
+
+    let s = set()
+
+    beforeEach(() => {
+        s = set()
+    })
+
+    test("Add does not add value if interceptor returned no change", () => {
+        mobx.intercept(s, (change) => {
+            if(change.type === 'add' && change.newValue === 2) {
+                return undefined;
+            }
+
+            return change;
+        })
+
+        s.add(1);
+        s.add(2);
+
+        expect([...s]).toStrictEqual([1]);
+
+
+    })
+
+    test("Add respects newValue from interceptor", () => {
+
+        mobx.intercept(s, (change) => {
+            if(change.type === 'add' && change.newValue === 2) {
+                change.newValue = 10;
+            }
+
+            return change;
+        })
+
+        s.add(1);
+        s.add(2);
+
+        expect([...s]).toStrictEqual([1, 10])
+    })
+
+
+})


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [x] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->


I'm sorry for the missing related issue. 
Just figured out that the `newValue` returned from the `ObservableSet`'s interceptor is ignored. The following code still uses the base value passed to `add()` method. At a quick glance, the `set()` method of the `ObservableMap` just re-defines the value variable with the `change.newValue`. So I've reproduced the logic and added coupe of tests.