### PR TITLE
Fix "Cannot convert a Symbol value to a string"

### DIFF
--- a/packages/mobx/src/types/observablevalue.ts
+++ b/packages/mobx/src/types/observablevalue.ts
@@ -83,7 +83,7 @@ export class ObservableValue<T>
                 object: this,
                 observableKind: "value",
                 debugObjectName: this.name_,
-                newValue: "" + this.value_
+                newValue: "" + this.value_?.toString()
             })
         }
     }


### PR DESCRIPTION
Make ObservableValue spy compatible with Symbol by converting it safely

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`yarn mobx test:performance`)

<!--
    Feel free to ask help with any of these boxes!
-->
