### PR TITLE
Rearrange observer type definitions to allow wrapping custom HOC

### DIFF
--- a/packages/mobx-react-lite/__tests__/observer.test.tsx
+++ b/packages/mobx-react-lite/__tests__/observer.test.tsx
@@ -594,6 +594,33 @@ test("useImperativeHandle and forwardRef should work with useObserver", () => {
     expect(consoleWarnMock).toMatchSnapshot()
 })
 
+test("observer should work with custom HOC and infer correct type", () => {
+    const validateChildrenWrapper = <T extends {}>(component: React.FC<T>): React.FC<T> => {
+        const wrapper: React.FC<T> = (...args) => {
+            const result = component(...args)
+            if (result && React.isValidElement(result) && result.type === "div") {
+                return result
+            }
+            throw new Error("Only <div> allowed as root element")
+        }
+        wrapper.displayName = component.displayName || component.name
+        return wrapper
+    }
+
+    interface IProps {
+        value: string
+    }
+
+    const TestComponent: React.FC<IProps> = observer(
+        validateChildrenWrapper(function TestComponent({ value }) {
+            return <div>{value}</div>
+        })
+    )
+
+    const rendered = render(<TestComponent value="1" />)
+    expect(rendered.container.querySelector("div")!.innerHTML).toBe("1")
+})
+
 it("should hoist known statics only", () => {
     function isNumber() {
         return null

--- a/packages/mobx-react-lite/src/observer.ts
+++ b/packages/mobx-react-lite/src/observer.ts
@@ -44,6 +44,11 @@ export function observer<P extends object, TRef = {}>(
     React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
 >
 
+export function observer<P extends object>(
+    baseComponent: React.FunctionComponent<P>,
+    options?: IObserverOptions
+): React.FunctionComponent<P>
+
 export function observer<P extends object, TRef = {}>(
     baseComponent: React.ForwardRefExoticComponent<
         React.PropsWithoutRef<P> & React.RefAttributes<TRef>
@@ -51,12 +56,6 @@ export function observer<P extends object, TRef = {}>(
 ): React.MemoExoticComponent<
     React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
 >
-
-export function observer<P extends object>(
-    baseComponent: React.FunctionComponent<P>,
-    options?: IObserverOptions
-): React.FunctionComponent<P>
-
 export function observer<
     C extends React.FunctionComponent<any> | React.ForwardRefRenderFunction<any>,
     Options extends IObserverOptions


### PR DESCRIPTION
This PR moves the `observer` definition for plain functional components before the definition for `forwardRef` component. Without this change, the code below will generate a TypeScript error

```ts
    const TestComponent: React.FC<IProps> = observer(
        validateChildrenWrapper(function TestComponent({ value }) {
            return <div>{value}</div>
        })
    )
```

Error: `Property 'value' does not exist on type '{}'`

Before:
<img width="1494" height="284" alt="image" src="https://github.com/user-attachments/assets/a6087dcc-e374-446e-a70b-4307c0709b1c" />

After:
<img width="1405" height="249" alt="image" src="https://github.com/user-attachments/assets/bbb6b41e-43b3-4eb9-9d9e-5ce4b8eef55e" />