### PR TITLE
Fix issue with wrong inferred type of observable.map in TS 5.9+

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     ],
     "resolutions": {
         "jest": "^29.5.0",
-        "typescript": "^5.6.2",
+        "typescript": "^5.9.2",
         "recast": "^0.23.1"
     },
     "repository": {
@@ -68,7 +68,7 @@
         "tape": "^5.0.1",
         "ts-jest": "^29.0.5",
         "tsdx": "^0.14.1",
-        "typescript": "^5.6.2"
+        "typescript": "^5.9.2"
     },
     "husky": {
         "hooks": {

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -1962,6 +1962,15 @@ test("observable.map() accepts an undefined value with or without options", () =
     mobx.observable.map(undefined)
 })
 
+test("observable.map() accepts optional initial values", () => {
+    interface Usage {}
+
+    ;(data?: [string, Usage][]) => observable.map(data, { name: "test" })
+    ;(data?: readonly (readonly [string, Usage])[]) => observable.map(data, { name: "test" })
+    ;(data?: Record<string, Usage>) => observable.map(data, { name: "test" })
+    ;(data?: Map<string, Usage>) => observable.map(data, { name: "test" })
+})
+
 test("toJS bug #1413 (TS)", () => {
     class X {
         test = {

--- a/packages/mobx/__tests__/v5/base/typescript-tests.ts
+++ b/packages/mobx/__tests__/v5/base/typescript-tests.ts
@@ -1933,6 +1933,35 @@ test("allow 'as const' for creating tuples for observable.map()", () => {
     mobx.observable.map(newValues)
 })
 
+test("infers tuple type for observable.map() when using array.map", () => {
+    interface Usage {
+        daily: number
+        monthly: number
+    }
+    const data: Array<{ id: string; usage: Usage }> = [
+        { id: "1", usage: { daily: 5, monthly: 100 } },
+        { id: "2", usage: { daily: 10, monthly: 200 } },
+        { id: "3", usage: { daily: 15, monthly: 300 } }
+    ]
+
+    const map = mobx.observable.map(
+        data.map(app => [app.id, app.usage]),
+        { name: "test" }
+    )
+
+    expect(map.get("2")).toEqual({ daily: 10, monthly: 200 })
+})
+
+test("observable.map() accepts an undefined value with or without options", () => {
+    const map = mobx.observable.map<string, number>(undefined, { name: "custom name" })
+    map.set("test", 1)
+    expect(map.get("test")).toBe(1)
+    expect(map.name_).toBe("custom name")
+
+    // without options
+    mobx.observable.map(undefined)
+})
+
 test("toJS bug #1413 (TS)", () => {
     class X {
         test = {

--- a/packages/mobx/src/api/observable.ts
+++ b/packages/mobx/src/api/observable.ts
@@ -156,13 +156,16 @@ export interface IObservableValueFactory {
 
 export interface IObservableMapFactory {
     <K = any, V = any>(): ObservableMap<K, V>
-    <K, V>(initialValues: IMapEntries<K, V>, options?: CreateObservableOptions): ObservableMap<K, V>
+    <K, V>(initialValues?: IMapEntries<K, V>, options?: CreateObservableOptions): ObservableMap<
+        K,
+        V
+    >
     <K, V>(
-        initialValues: IReadonlyMapEntries<K, V>,
+        initialValues?: IReadonlyMapEntries<K, V>,
         options?: CreateObservableOptions
     ): ObservableMap<K, V>
-    <K, V>(initialValues: IKeyValueMap<V>, options?: CreateObservableOptions): ObservableMap<K, V>
-    <K, V>(initialValues: Map<K, V>, options?: CreateObservableOptions): ObservableMap<K, V>
+    <K, V>(initialValues?: IKeyValueMap<V>, options?: CreateObservableOptions): ObservableMap<K, V>
+    <K, V>(initialValues?: Map<K, V>, options?: CreateObservableOptions): ObservableMap<K, V>
     <K = any, V = any>(initialValues: undefined, options?: CreateObservableOptions): ObservableMap<
         K,
         V

--- a/packages/mobx/src/api/observable.ts
+++ b/packages/mobx/src/api/observable.ts
@@ -3,6 +3,9 @@ import {
     IEqualsComparer,
     IObservableArray,
     IObservableMapInitialValues,
+    IMapEntries,
+    IReadonlyMapEntries,
+    IKeyValueMap,
     IObservableSetInitialValues,
     IObservableValue,
     ObservableMap,
@@ -151,6 +154,21 @@ export interface IObservableValueFactory {
     <T>(value?: T, options?: CreateObservableOptions): IObservableValue<T | undefined>
 }
 
+export interface IObservableMapFactory {
+    <K = any, V = any>(): ObservableMap<K, V>
+    <K, V>(initialValues: IMapEntries<K, V>, options?: CreateObservableOptions): ObservableMap<K, V>
+    <K, V>(
+        initialValues: IReadonlyMapEntries<K, V>,
+        options?: CreateObservableOptions
+    ): ObservableMap<K, V>
+    <K, V>(initialValues: IKeyValueMap<V>, options?: CreateObservableOptions): ObservableMap<K, V>
+    <K, V>(initialValues: Map<K, V>, options?: CreateObservableOptions): ObservableMap<K, V>
+    <K = any, V = any>(initialValues: undefined, options?: CreateObservableOptions): ObservableMap<
+        K,
+        V
+    >
+}
+
 export interface IObservableFactory
     extends Annotation,
         PropertyDecorator,
@@ -172,10 +190,7 @@ export interface IObservableFactory
         initialValues?: IObservableSetInitialValues<T>,
         options?: CreateObservableOptions
     ) => ObservableSet<T>
-    map: <K = any, V = any>(
-        initialValues?: IObservableMapInitialValues<K, V>,
-        options?: CreateObservableOptions
-    ) => ObservableMap<K, V>
+    map: IObservableMapFactory
     object: <T = any>(
         props: T,
         decorators?: AnnotationsMap<T, never>,

--- a/packages/mobx/src/types/observablemap.ts
+++ b/packages/mobx/src/types/observablemap.ts
@@ -46,7 +46,7 @@ export interface IKeyValueMap<V = any> {
 export type IMapEntry<K = any, V = any> = [K, V]
 export type IReadonlyMapEntry<K = any, V = any> = readonly [K, V]
 export type IMapEntries<K = any, V = any> = IMapEntry<K, V>[]
-export type IReadonlyMapEntries<K = any, V = any> = IReadonlyMapEntry<K, V>[]
+export type IReadonlyMapEntries<K = any, V = any> = readonly IReadonlyMapEntry<K, V>[]
 
 export type IMapDidChange<K = any, V = any> = { observableKind: "map"; debugObjectName: string } & (
     | {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13778,10 +13778,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^3.7.3, typescript@^5.6.2:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
-  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
+typescript@^3.7.3, typescript@^5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
+  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
This fixes https://github.com/mobxjs/mobx/issues/4573

The issue is that since TypeScript 5.9, a particular pattern for calling `observable.map` caused a compiler error. Comparing with the definition of `new Map`, I saw that we could fix this by using function overloads instead of the union type.

Before
<img width="2374" height="419" alt="image" src="https://github.com/user-attachments/assets/f05af5b9-5828-490b-8a18-16f94809cf39" />

After
<img width="2297" height="400" alt="image" src="https://github.com/user-attachments/assets/070713f9-cb6e-4842-8b1d-def748cb6f70" />
