### PR TITLE
Avoid Rolldown invalid PURE annotation warnings

### DIFF
--- a/.changeset/clean-rolldown-annotation.md
+++ b/.changeset/clean-rolldown-annotation.md
@@ -1,0 +1,5 @@
+---
+"mobx": minor
+---
+
+Avoid Rolldown invalid PURE annotation warnings from Babel-generated optional chaining output.

--- a/.changeset/clean-rolldown-annotation.md
+++ b/.changeset/clean-rolldown-annotation.md
@@ -1,5 +1,5 @@
 ---
-"mobx": minor
+"mobx": patch
 ---
 
 Avoid Rolldown invalid PURE annotation warnings from Babel-generated optional chaining output.

--- a/packages/mobx/src/utils/iterable.ts
+++ b/packages/mobx/src/utils/iterable.ts
@@ -1,7 +1,8 @@
 import { getGlobal } from "../internal"
 
 // safely get iterator prototype if available
-const maybeIteratorPrototype = getGlobal().Iterator?.prototype || {}
+const global = getGlobal()
+const maybeIteratorPrototype = global.Iterator?.prototype || {}
 
 export function makeIterable<T, TReturn = unknown>(
     iterator: Iterator<T>


### PR DESCRIPTION
Fix https://github.com/mobxjs/mobx/issues/4649