### PR TITLE
Fix mobx-react Rolldown annotation warning

### DIFF
--- a/.changeset/clear-react-rolldown.md
+++ b/.changeset/clear-react-rolldown.md
@@ -1,0 +1,5 @@
+---
+"mobx-react": patch
+---
+
+Avoid Rolldown invalid PURE annotation warnings from Babel-generated React version parsing output.

--- a/packages/mobx-react/src/disposeOnUnmount.ts
+++ b/packages/mobx-react/src/disposeOnUnmount.ts
@@ -1,7 +1,7 @@
 import React from "react"
 import { patch } from "./utils/utils"
 
-const reactMajorVersion = Number.parseInt(React.version.split(".")[0])
+const reactMajorVersion = Number.parseInt(React.version, 10)
 let warnedAboutDisposeOnUnmountDeprecated = false
 
 type Disposer = () => void


### PR DESCRIPTION
Same as https://github.com/mobxjs/mobx/pull/4650 but for `mobx-react`