### PR TITLE
feat(mobx): make 2022.3 @observable decorator lazy

### DIFF
--- a/.changeset/lazy-observable-decorator.md
+++ b/.changeset/lazy-observable-decorator.md
@@ -1,0 +1,5 @@
+---
+"mobx": minor
+---
+
+feat(mobx): make the 2022.3 `@observable accessor` decorator lazy. `ObservableValue` is now created on first read/write/observe of the decorated accessor rather than eagerly during instance construction, avoiding wasted allocations for fields that are never touched. On a 50k-instance × 10-field class with sparse access (1 of 10 fields read per instance), this cuts construction heap by ~82% and construction time by ~86% versus the eager path. Follow-up to #4639.

--- a/packages/mobx/__tests__/decorators_20223/stage3-decorators.ts
+++ b/packages/mobx/__tests__/decorators_20223/stage3-decorators.ts
@@ -1005,9 +1005,10 @@ test("multiple inheritance should work", () => {
         }
     }
 
-    const obsvKeys = [
-        ...(mobx._getAdministration(new B()) as ObservableArrayAdministration).values_.keys()
-    ]
+    const adm = mobx._getAdministration(new B()) as any
+    // @observable accessor is lazy (#4616 follow-up), so unread fields live in
+    // `lazyObservableKeys_` until first read. Union with `values_` to see them all.
+    const obsvKeys = [...adm.values_.keys(), ...(adm.lazyObservableKeys_?.keys() ?? [])].sort()
     expect(obsvKeys).toEqual(["x", "y"])
 })
 
@@ -1206,6 +1207,81 @@ test("4616 - observe on @computed before first read materialises it", () => {
     observe(o, "total", ev => events.push((ev as any).newValue))
     o.price = 4
     t.deepEqual(events, [8])
+})
+
+test("4616 - @observable accessor should be lazy", () => {
+    class Wide {
+        @observable accessor unused: number = 1
+        @observable accessor used: number = 2
+    }
+
+    const o = new Wide()
+    // Public API: both should report as observable props
+    t.equal(isObservableProp(o, "unused"), true)
+    t.equal(isObservableProp(o, "used"), true)
+
+    // Internal check: ObservableValue is not yet allocated for either field
+    const adm: any = (o as any)[$mobx]
+    expect(adm.values_.has("unused")).toBe(false)
+    expect(adm.values_.has("used")).toBe(false)
+    expect(adm.lazyObservableKeys_.has("unused")).toBe(true)
+    expect(adm.lazyObservableKeys_.has("used")).toBe(true)
+
+    // First access materialises the ObservableValue
+    t.equal(o.used, 2)
+    expect(adm.values_.has("used")).toBe(true)
+    expect(adm.lazyObservableKeys_.has("used")).toBe(false)
+
+    // The unused field remains lazy
+    expect(adm.values_.has("unused")).toBe(false)
+    expect(adm.lazyObservableKeys_.has("unused")).toBe(true)
+})
+
+test("4616 - observe on @observable accessor before first read materialises it", () => {
+    class Counter {
+        @observable accessor count: number = 0
+    }
+
+    const o = new Counter()
+    const adm: any = (o as any)[$mobx]
+    expect(adm.values_.has("count")).toBe(false)
+
+    const events: number[] = []
+    observe(o, "count", ev => events.push((ev as any).newValue))
+    // observe should have materialised the ObservableValue
+    expect(adm.values_.has("count")).toBe(true)
+
+    o.count = 5
+    o.count = 7
+    t.deepEqual(events, [5, 7])
+})
+
+test("4616 - set on @observable accessor before first read materialises it", () => {
+    class Counter {
+        @observable accessor count: number = 0
+    }
+
+    const o = new Counter()
+    const adm: any = (o as any)[$mobx]
+    expect(adm.values_.has("count")).toBe(false)
+
+    o.count = 42
+    expect(adm.values_.has("count")).toBe(true)
+    t.equal(o.count, 42)
+})
+
+test("4616 - autorun reacts to @observable accessor that is lazy on entry", () => {
+    class Counter {
+        @observable accessor count: number = 0
+    }
+
+    const o = new Counter()
+    const seen: number[] = []
+    const dispose = autorun(() => seen.push(o.count))
+    o.count = 1
+    o.count = 2
+    dispose()
+    t.deepEqual(seen, [0, 1, 2])
 })
 
 test(`decorated field can be inherited, but doesn't inherite the effect of decorator`, () => {

--- a/packages/mobx/__tests__/perf/lazy-observable-decorator.ts
+++ b/packages/mobx/__tests__/perf/lazy-observable-decorator.ts
@@ -1,0 +1,228 @@
+// Exploration benchmark for #4639 follow-up: how much would a lazy
+// `@observable accessor` save?
+//
+// Mirrors lazy-computed-decorator.ts but for `@observable accessor` fields.
+// Today the decorator's `init` callback eagerly constructs an `ObservableValue`
+// during instance construction. To estimate the upper bound on savings from
+// deferring that to first read, we compare:
+//
+//   - WIDE: 10 `@observable` fields, 1 read per instance (sparse access)
+//   - NARROW: 1 `@observable` field, 1 read per instance (the field actually used)
+//
+// The WIDE→NARROW delta approximates what a lazy variant could save if it only
+// allocated `ObservableValue`s for fields actually touched.
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+import * as path from "path"
+const distPath = path.resolve(__dirname, "..", "..", "..", "dist", "mobx.cjs.development.js")
+const mobx = require(distPath) as {
+    makeObservable: any
+    observable: any
+}
+const { makeObservable, observable } = mobx
+
+const INSTANCES = 50_000
+const RUNS = 3
+const RE_READS = 5
+
+class Wide {
+    @observable accessor f0 = 0
+    @observable accessor f1 = 1
+    @observable accessor f2 = 2
+    @observable accessor f3 = 3
+    @observable accessor f4 = 4
+    @observable accessor f5 = 5
+    @observable accessor f6 = 6
+    @observable accessor f7 = 7
+    @observable accessor f8 = 8
+    @observable accessor f9 = 9
+    constructor() {
+        makeObservable(this)
+    }
+}
+
+class Narrow {
+    @observable accessor f0 = 0
+    constructor() {
+        makeObservable(this)
+    }
+}
+
+const FIELDS_WIDE = ["f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9"] as const
+const FIELDS_NARROW = ["f0"] as const
+
+function forceGc() {
+    if (typeof global.gc === "function") global.gc()
+}
+
+function heapMB(): number {
+    return process.memoryUsage().heapUsed / (1024 * 1024)
+}
+
+type Sample = {
+    constructHeapMB: number
+    constructMs: number
+    firstReadMs: number
+    reReadMs: number
+}
+
+function bench<T>(Ctor: new () => T, fields: readonly string[]): Sample {
+    forceGc()
+    const heapBefore = heapMB()
+
+    const t0 = performance.now()
+    const instances: T[] = new Array(INSTANCES)
+    for (let i = 0; i < INSTANCES; i++) instances[i] = new Ctor()
+    const t1 = performance.now()
+
+    forceGc()
+    const heapAfter = heapMB()
+
+    const t2 = performance.now()
+    let sink = 0
+    for (let i = 0; i < INSTANCES; i++) {
+        sink += (instances[i] as any)[fields[i % fields.length]]
+    }
+    const t3 = performance.now()
+
+    const t4 = performance.now()
+    for (let r = 0; r < RE_READS; r++) {
+        for (let i = 0; i < INSTANCES; i++) {
+            sink += (instances[i] as any)[fields[i % fields.length]]
+        }
+    }
+    const t5 = performance.now()
+
+    if (sink === Number.NEGATIVE_INFINITY) console.log("unreachable")
+
+    return {
+        constructHeapMB: heapAfter - heapBefore,
+        constructMs: t1 - t0,
+        firstReadMs: t3 - t2,
+        reReadMs: t5 - t4
+    }
+}
+
+function fmt(n: number, digits = 1): string {
+    return n.toFixed(digits).padStart(8)
+}
+
+function runScenario(label: string, Ctor: new () => any, fields: readonly string[]) {
+    bench(Ctor, fields) // warmup
+    const samples: Sample[] = []
+    for (let r = 0; r < RUNS; r++) samples.push(bench(Ctor, fields))
+
+    console.log(`\n${label}`)
+    console.log("run | construct heap MB | construct ms | first-read ms | re-read ms")
+    console.log("----+-------------------+--------------+---------------+-----------")
+    samples.forEach((s, i) => {
+        console.log(
+            `  ${i + 1} | ${fmt(s.constructHeapMB)}          | ${fmt(s.constructMs)}     | ${fmt(
+                s.firstReadMs
+            )}      | ${fmt(s.reReadMs)}`
+        )
+    })
+    const avg = (pick: (s: Sample) => number) =>
+        samples.reduce((a, s) => a + pick(s), 0) / samples.length
+    console.log(
+        `avg | ${fmt(avg(s => s.constructHeapMB))}          | ${fmt(
+            avg(s => s.constructMs)
+        )}     | ${fmt(avg(s => s.firstReadMs))}      | ${fmt(avg(s => s.reReadMs))}`
+    )
+    return {
+        constructHeapMB: avg(s => s.constructHeapMB),
+        constructMs: avg(s => s.constructMs),
+        firstReadMs: avg(s => s.firstReadMs),
+        reReadMs: avg(s => s.reReadMs)
+    }
+}
+
+function benchAllFields(Ctor: new () => any, fields: readonly string[]): Sample {
+    forceGc()
+    const heapBefore = heapMB()
+
+    const t0 = performance.now()
+    const instances: any[] = new Array(INSTANCES)
+    for (let i = 0; i < INSTANCES; i++) instances[i] = new Ctor()
+    const t1 = performance.now()
+
+    forceGc()
+    const heapAfter = heapMB()
+
+    const t2 = performance.now()
+    let sink = 0
+    for (let i = 0; i < INSTANCES; i++) {
+        for (let f = 0; f < fields.length; f++) sink += instances[i][fields[f]]
+    }
+    const t3 = performance.now()
+
+    const t4 = performance.now()
+    for (let r = 0; r < RE_READS; r++) {
+        for (let i = 0; i < INSTANCES; i++) {
+            for (let f = 0; f < fields.length; f++) sink += instances[i][fields[f]]
+        }
+    }
+    const t5 = performance.now()
+
+    if (sink === Number.NEGATIVE_INFINITY) console.log("unreachable")
+
+    return {
+        constructHeapMB: heapAfter - heapBefore,
+        constructMs: t1 - t0,
+        firstReadMs: t3 - t2,
+        reReadMs: t5 - t4
+    }
+}
+
+function runFullScenario(label: string, Ctor: new () => any, fields: readonly string[]) {
+    benchAllFields(Ctor, fields) // warmup
+    const samples: Sample[] = []
+    for (let r = 0; r < RUNS; r++) samples.push(benchAllFields(Ctor, fields))
+    console.log(`\n${label}`)
+    console.log("run | construct heap MB | construct ms | first-read ms | re-read ms")
+    console.log("----+-------------------+--------------+---------------+-----------")
+    samples.forEach((s, i) => {
+        console.log(
+            `  ${i + 1} | ${fmt(s.constructHeapMB)}          | ${fmt(s.constructMs)}     | ${fmt(
+                s.firstReadMs
+            )}      | ${fmt(s.reReadMs)}`
+        )
+    })
+    const avg = (pick: (s: Sample) => number) =>
+        samples.reduce((a, s) => a + pick(s), 0) / samples.length
+    console.log(
+        `avg | ${fmt(avg(s => s.constructHeapMB))}          | ${fmt(
+            avg(s => s.constructMs)
+        )}     | ${fmt(avg(s => s.firstReadMs))}      | ${fmt(avg(s => s.reReadMs))}`
+    )
+    return {
+        constructHeapMB: avg(s => s.constructHeapMB),
+        constructMs: avg(s => s.constructMs),
+        firstReadMs: avg(s => s.firstReadMs),
+        reReadMs: avg(s => s.reReadMs)
+    }
+}
+
+function main() {
+    console.log(`\nLazy @observable benchmark — ${INSTANCES} instances, ${RE_READS} re-reads.`)
+    console.log(`Node ${process.version}, ${RUNS} timed runs after 1 warmup per scenario.`)
+
+    console.log(`\n=== SPARSE: 1 of 10 fields read per instance (best case for lazy) ===`)
+    const sparseWide = runScenario(`WIDE: 10 @observable fields`, Wide, FIELDS_WIDE)
+    runScenario(`NARROW: 1 @observable field`, Narrow, FIELDS_NARROW)
+
+    console.log(`\n=== FULL: ALL 10 fields read per instance (worst case for lazy) ===`)
+    const fullWide = runFullScenario(`WIDE-FULL: 10 fields, all read`, Wide, FIELDS_WIDE)
+
+    console.log(`\nWIDE: sparse vs full read pattern (same class, same lazy/eager state):`)
+    console.log(
+        `  construct heap : ${sparseWide.constructHeapMB.toFixed(
+            1
+        )} MB → unchanged (heap measured before reads)`
+    )
+    console.log(`  construct time : ${sparseWide.constructMs.toFixed(1)} ms → unchanged`)
+    console.log(`  first-read 1×  : ${sparseWide.firstReadMs.toFixed(1)} ms`)
+    console.log(`  first-read 10× : ${fullWide.firstReadMs.toFixed(1)} ms`)
+}
+
+main()

--- a/packages/mobx/__tests__/perf/lazy-observable-decorator.ts
+++ b/packages/mobx/__tests__/perf/lazy-observable-decorator.ts
@@ -1,37 +1,33 @@
 // Benchmark for the lazy `@observable accessor` decorator (#4616 follow-up
 // to #4639).
 //
-// Shape: many instances of a wide class with 10 `@observable accessor` fields,
-// measured under two read patterns:
+// Shape: many instances of wide stage-3-decorator classes with 10
+// `@observable accessor` fields, measured under sparse, full, and
+// constructor-hydration patterns. This file intentionally does not call
+// `makeObservable`; it measures only the 2022.3 decorator path affected by this
+// PR.
 //
-//   - SPARSE: 1 of 10 fields read per instance (the realistic #4616 shape)
-//   - FULL:   all 10 fields read per instance (steady-state worst case for
-//             lazy — every deferred allocation eventually happens)
-//
-// For each pattern we report construction heap, construction time, first-read
-// time (the pass that materialises the `ObservableValue`s), and re-read time
-// (steady state). Run with `npm run perf-decorator` (requires a prior
-// `npm run build`).
-//
-// This file only measures the *currently built* mobx — it cannot compare
-// against an eager baseline on its own. To get eager numbers, check out a
-// commit before this PR, run `npm run build` + `npm run perf-decorator`, and
-// compare.
+// Run with `npm run perf-decorator` (requires a prior `npm run build`).
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 import * as path from "path"
 const distPath = path.resolve(__dirname, "..", "..", "..", "dist", "mobx.cjs.development.js")
 const mobx = require(distPath) as {
-    makeObservable: any
     observable: any
 }
-const { makeObservable, observable } = mobx
+const { observable } = mobx
 
 const INSTANCES = 50_000
 const RUNS = 3
 const RE_READS = 5
 
-class Wide {
+const FIELDS = ["f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9"] as const
+const READ_THREE = ["f0", "f1", "f2"] as const
+
+type Field = (typeof FIELDS)[number]
+type WideCtor = new (seed: number) => any
+
+class DefaultsWide {
     @observable accessor f0 = 0
     @observable accessor f1 = 1
     @observable accessor f2 = 2
@@ -42,12 +38,60 @@ class Wide {
     @observable accessor f7 = 7
     @observable accessor f8 = 8
     @observable accessor f9 = 9
-    constructor() {
-        makeObservable(this)
+}
+
+class AssignedPartialWide {
+    @observable accessor f0 = 0
+    @observable accessor f1 = 1
+    @observable accessor f2 = 2
+    @observable accessor f3 = 3
+    @observable accessor f4 = 4
+    @observable accessor f5 = 5
+    @observable accessor f6 = 6
+    @observable accessor f7 = 7
+    @observable accessor f8 = 8
+    @observable accessor f9 = 9
+
+    constructor(seed: number) {
+        this.f0 = seed
+        this.f1 = seed + 1
+        this.f2 = seed + 2
     }
 }
 
-const FIELDS = ["f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9"] as const
+class AssignedAllWide {
+    @observable accessor f0 = 0
+    @observable accessor f1 = 1
+    @observable accessor f2 = 2
+    @observable accessor f3 = 3
+    @observable accessor f4 = 4
+    @observable accessor f5 = 5
+    @observable accessor f6 = 6
+    @observable accessor f7 = 7
+    @observable accessor f8 = 8
+    @observable accessor f9 = 9
+
+    constructor(seed: number) {
+        this.f0 = seed
+        this.f1 = seed + 1
+        this.f2 = seed + 2
+        this.f3 = seed + 3
+        this.f4 = seed + 4
+        this.f5 = seed + 5
+        this.f6 = seed + 6
+        this.f7 = seed + 7
+        this.f8 = seed + 8
+        this.f9 = seed + 9
+    }
+}
+
+type Sample = {
+    constructHeapMB: number
+    constructMs: number
+    firstReadMs: number
+    reReadMs: number
+    writeMs?: number
+}
 
 function forceGc() {
     if (typeof global.gc === "function") global.gc()
@@ -57,51 +101,57 @@ function heapMB(): number {
     return process.memoryUsage().heapUsed / (1024 * 1024)
 }
 
-type Sample = {
-    constructHeapMB: number
-    constructMs: number
-    firstReadMs: number
-    reReadMs: number
+function readSparse(instances: any[]): number {
+    let sink = 0
+    for (let i = 0; i < INSTANCES; i++) sink += instances[i][FIELDS[i % FIELDS.length]]
+    return sink
 }
 
-// readsPerInstance = 1  → SPARSE (each instance reads fields[i % fields.length])
-// readsPerInstance = 10 → FULL   (each instance reads every field)
-function bench(readsPerInstance: number): Sample {
+function readFields(instances: any[], fields: readonly Field[]): number {
+    let sink = 0
+    for (let i = 0; i < INSTANCES; i++) {
+        const inst = instances[i]
+        for (let f = 0; f < fields.length; f++) sink += inst[fields[f]]
+    }
+    return sink
+}
+
+function writeField(instances: any[], field: Field): number {
+    let sink = 0
+    for (let i = 0; i < INSTANCES; i++) {
+        instances[i][field] = i
+        sink += instances[i][field]
+    }
+    return sink
+}
+
+function bench(Ctor: WideCtor, read: (instances: any[]) => number, writeFieldName?: Field): Sample {
     forceGc()
     const heapBefore = heapMB()
 
     const t0 = performance.now()
-    const instances: Wide[] = new Array(INSTANCES)
-    for (let i = 0; i < INSTANCES; i++) instances[i] = new Wide()
+    const instances: any[] = new Array(INSTANCES)
+    for (let i = 0; i < INSTANCES; i++) instances[i] = new Ctor(i)
     const t1 = performance.now()
 
     forceGc()
     const heapAfter = heapMB()
 
     const t2 = performance.now()
-    let sink = 0
-    for (let i = 0; i < INSTANCES; i++) {
-        const inst = instances[i] as any
-        if (readsPerInstance === 1) {
-            sink += inst[FIELDS[i % FIELDS.length]]
-        } else {
-            for (let f = 0; f < readsPerInstance; f++) sink += inst[FIELDS[f]]
-        }
-    }
+    let sink = read(instances)
     const t3 = performance.now()
 
     const t4 = performance.now()
-    for (let r = 0; r < RE_READS; r++) {
-        for (let i = 0; i < INSTANCES; i++) {
-            const inst = instances[i] as any
-            if (readsPerInstance === 1) {
-                sink += inst[FIELDS[i % FIELDS.length]]
-            } else {
-                for (let f = 0; f < readsPerInstance; f++) sink += inst[FIELDS[f]]
-            }
-        }
-    }
+    for (let r = 0; r < RE_READS; r++) sink += read(instances)
     const t5 = performance.now()
+
+    let writeMs: number | undefined
+    if (writeFieldName) {
+        const t6 = performance.now()
+        sink += writeField(instances, writeFieldName)
+        const t7 = performance.now()
+        writeMs = t7 - t6
+    }
 
     if (sink === Number.NEGATIVE_INFINITY) console.log("unreachable")
 
@@ -109,47 +159,78 @@ function bench(readsPerInstance: number): Sample {
         constructHeapMB: heapAfter - heapBefore,
         constructMs: t1 - t0,
         firstReadMs: t3 - t2,
-        reReadMs: t5 - t4
+        reReadMs: t5 - t4,
+        writeMs
     }
 }
 
-function fmt(n: number, digits = 1): string {
-    return n.toFixed(digits).padStart(8)
+function fmt(n: number | undefined, digits = 1): string {
+    return n === undefined ? "        " : n.toFixed(digits).padStart(8)
 }
 
-function runScenario(label: string, readsPerInstance: number) {
-    bench(readsPerInstance) // warmup
+function runScenario(
+    label: string,
+    Ctor: WideCtor,
+    read: (instances: any[]) => number,
+    writeFieldName?: Field
+) {
+    bench(Ctor, read, writeFieldName) // warmup
     const samples: Sample[] = []
-    for (let r = 0; r < RUNS; r++) samples.push(bench(readsPerInstance))
+    for (let r = 0; r < RUNS; r++) samples.push(bench(Ctor, read, writeFieldName))
 
     console.log(`\n${label}`)
-    console.log("run | construct heap MB | construct ms | first-read ms | re-read ms")
-    console.log("----+-------------------+--------------+---------------+-----------")
+    console.log("run | construct heap MB | construct ms | first-read ms | re-read ms | write ms")
+    console.log("----+-------------------+--------------+---------------+------------+---------")
     samples.forEach((s, i) => {
         console.log(
             `  ${i + 1} | ${fmt(s.constructHeapMB)}          | ${fmt(s.constructMs)}     | ${fmt(
                 s.firstReadMs
-            )}      | ${fmt(s.reReadMs)}`
+            )}      | ${fmt(s.reReadMs)}     | ${fmt(s.writeMs)}`
         )
     })
-    const avg = (pick: (s: Sample) => number) =>
-        samples.reduce((a, s) => a + pick(s), 0) / samples.length
+    const avg = (pick: (s: Sample) => number | undefined) => {
+        const values = samples.map(pick).filter((value): value is number => value !== undefined)
+        return values.length ? values.reduce((a, v) => a + v, 0) / values.length : undefined
+    }
     console.log(
         `avg | ${fmt(avg(s => s.constructHeapMB))}          | ${fmt(
             avg(s => s.constructMs)
-        )}     | ${fmt(avg(s => s.firstReadMs))}      | ${fmt(avg(s => s.reReadMs))}`
+        )}     | ${fmt(avg(s => s.firstReadMs))}      | ${fmt(
+            avg(s => s.reReadMs)
+        )}     | ${fmt(avg(s => s.writeMs))}`
     )
 }
 
 function main() {
     console.log(`\nLazy @observable benchmark — ${INSTANCES} instances, ${RE_READS} re-reads.`)
     console.log(`Node ${process.version}, ${RUNS} timed runs after 1 warmup per scenario.`)
+    console.log(`Stage-3 decorators only; no makeObservable/makeAutoObservable.`)
 
-    console.log(`\n=== SPARSE: 1 of 10 fields read per instance (best case for lazy) ===`)
-    runScenario(`WIDE: 10 @observable fields, 1 field read per instance`, 1)
-
-    console.log(`\n=== FULL: ALL 10 fields read per instance (steady-state worst case) ===`)
-    runScenario(`WIDE: 10 @observable fields, 10 fields read per instance`, 10)
+    runScenario("DEFAULTS: sparse 1 of 10 fields read", DefaultsWide, readSparse)
+    runScenario(
+        "DEFAULTS: 3 of 10 fields read, then write unread f9",
+        DefaultsWide,
+        instances => readFields(instances, READ_THREE),
+        "f9"
+    )
+    runScenario(
+        "HYDRATED PARTIAL: constructor assigns 3 of 10, read those 3, then write unread f9",
+        AssignedPartialWide,
+        instances => readFields(instances, READ_THREE),
+        "f9"
+    )
+    runScenario(
+        "HYDRATED FULL: constructor assigns all 10, read 3, then write f9",
+        AssignedAllWide,
+        instances => readFields(instances, READ_THREE),
+        "f9"
+    )
+    runScenario(
+        "HYDRATED FULL: constructor assigns all 10, read all 10, then write f9",
+        AssignedAllWide,
+        instances => readFields(instances, FIELDS),
+        "f9"
+    )
 }
 
 main()

--- a/packages/mobx/__tests__/perf/lazy-observable-decorator.ts
+++ b/packages/mobx/__tests__/perf/lazy-observable-decorator.ts
@@ -1,16 +1,22 @@
-// Exploration benchmark for #4639 follow-up: how much would a lazy
-// `@observable accessor` save?
+// Benchmark for the lazy `@observable accessor` decorator (#4616 follow-up
+// to #4639).
 //
-// Mirrors lazy-computed-decorator.ts but for `@observable accessor` fields.
-// Today the decorator's `init` callback eagerly constructs an `ObservableValue`
-// during instance construction. To estimate the upper bound on savings from
-// deferring that to first read, we compare:
+// Shape: many instances of a wide class with 10 `@observable accessor` fields,
+// measured under two read patterns:
 //
-//   - WIDE: 10 `@observable` fields, 1 read per instance (sparse access)
-//   - NARROW: 1 `@observable` field, 1 read per instance (the field actually used)
+//   - SPARSE: 1 of 10 fields read per instance (the realistic #4616 shape)
+//   - FULL:   all 10 fields read per instance (steady-state worst case for
+//             lazy — every deferred allocation eventually happens)
 //
-// The WIDE→NARROW delta approximates what a lazy variant could save if it only
-// allocated `ObservableValue`s for fields actually touched.
+// For each pattern we report construction heap, construction time, first-read
+// time (the pass that materialises the `ObservableValue`s), and re-read time
+// (steady state). Run with `npm run perf-decorator` (requires a prior
+// `npm run build`).
+//
+// This file only measures the *currently built* mobx — it cannot compare
+// against an eager baseline on its own. To get eager numbers, check out a
+// commit before this PR, run `npm run build` + `npm run perf-decorator`, and
+// compare.
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 import * as path from "path"
@@ -41,15 +47,7 @@ class Wide {
     }
 }
 
-class Narrow {
-    @observable accessor f0 = 0
-    constructor() {
-        makeObservable(this)
-    }
-}
-
-const FIELDS_WIDE = ["f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9"] as const
-const FIELDS_NARROW = ["f0"] as const
+const FIELDS = ["f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9"] as const
 
 function forceGc() {
     if (typeof global.gc === "function") global.gc()
@@ -66,13 +64,15 @@ type Sample = {
     reReadMs: number
 }
 
-function bench<T>(Ctor: new () => T, fields: readonly string[]): Sample {
+// readsPerInstance = 1  → SPARSE (each instance reads fields[i % fields.length])
+// readsPerInstance = 10 → FULL   (each instance reads every field)
+function bench(readsPerInstance: number): Sample {
     forceGc()
     const heapBefore = heapMB()
 
     const t0 = performance.now()
-    const instances: T[] = new Array(INSTANCES)
-    for (let i = 0; i < INSTANCES; i++) instances[i] = new Ctor()
+    const instances: Wide[] = new Array(INSTANCES)
+    for (let i = 0; i < INSTANCES; i++) instances[i] = new Wide()
     const t1 = performance.now()
 
     forceGc()
@@ -81,14 +81,24 @@ function bench<T>(Ctor: new () => T, fields: readonly string[]): Sample {
     const t2 = performance.now()
     let sink = 0
     for (let i = 0; i < INSTANCES; i++) {
-        sink += (instances[i] as any)[fields[i % fields.length]]
+        const inst = instances[i] as any
+        if (readsPerInstance === 1) {
+            sink += inst[FIELDS[i % FIELDS.length]]
+        } else {
+            for (let f = 0; f < readsPerInstance; f++) sink += inst[FIELDS[f]]
+        }
     }
     const t3 = performance.now()
 
     const t4 = performance.now()
     for (let r = 0; r < RE_READS; r++) {
         for (let i = 0; i < INSTANCES; i++) {
-            sink += (instances[i] as any)[fields[i % fields.length]]
+            const inst = instances[i] as any
+            if (readsPerInstance === 1) {
+                sink += inst[FIELDS[i % FIELDS.length]]
+            } else {
+                for (let f = 0; f < readsPerInstance; f++) sink += inst[FIELDS[f]]
+            }
         }
     }
     const t5 = performance.now()
@@ -107,10 +117,10 @@ function fmt(n: number, digits = 1): string {
     return n.toFixed(digits).padStart(8)
 }
 
-function runScenario(label: string, Ctor: new () => any, fields: readonly string[]) {
-    bench(Ctor, fields) // warmup
+function runScenario(label: string, readsPerInstance: number) {
+    bench(readsPerInstance) // warmup
     const samples: Sample[] = []
-    for (let r = 0; r < RUNS; r++) samples.push(bench(Ctor, fields))
+    for (let r = 0; r < RUNS; r++) samples.push(bench(readsPerInstance))
 
     console.log(`\n${label}`)
     console.log("run | construct heap MB | construct ms | first-read ms | re-read ms")
@@ -129,78 +139,6 @@ function runScenario(label: string, Ctor: new () => any, fields: readonly string
             avg(s => s.constructMs)
         )}     | ${fmt(avg(s => s.firstReadMs))}      | ${fmt(avg(s => s.reReadMs))}`
     )
-    return {
-        constructHeapMB: avg(s => s.constructHeapMB),
-        constructMs: avg(s => s.constructMs),
-        firstReadMs: avg(s => s.firstReadMs),
-        reReadMs: avg(s => s.reReadMs)
-    }
-}
-
-function benchAllFields(Ctor: new () => any, fields: readonly string[]): Sample {
-    forceGc()
-    const heapBefore = heapMB()
-
-    const t0 = performance.now()
-    const instances: any[] = new Array(INSTANCES)
-    for (let i = 0; i < INSTANCES; i++) instances[i] = new Ctor()
-    const t1 = performance.now()
-
-    forceGc()
-    const heapAfter = heapMB()
-
-    const t2 = performance.now()
-    let sink = 0
-    for (let i = 0; i < INSTANCES; i++) {
-        for (let f = 0; f < fields.length; f++) sink += instances[i][fields[f]]
-    }
-    const t3 = performance.now()
-
-    const t4 = performance.now()
-    for (let r = 0; r < RE_READS; r++) {
-        for (let i = 0; i < INSTANCES; i++) {
-            for (let f = 0; f < fields.length; f++) sink += instances[i][fields[f]]
-        }
-    }
-    const t5 = performance.now()
-
-    if (sink === Number.NEGATIVE_INFINITY) console.log("unreachable")
-
-    return {
-        constructHeapMB: heapAfter - heapBefore,
-        constructMs: t1 - t0,
-        firstReadMs: t3 - t2,
-        reReadMs: t5 - t4
-    }
-}
-
-function runFullScenario(label: string, Ctor: new () => any, fields: readonly string[]) {
-    benchAllFields(Ctor, fields) // warmup
-    const samples: Sample[] = []
-    for (let r = 0; r < RUNS; r++) samples.push(benchAllFields(Ctor, fields))
-    console.log(`\n${label}`)
-    console.log("run | construct heap MB | construct ms | first-read ms | re-read ms")
-    console.log("----+-------------------+--------------+---------------+-----------")
-    samples.forEach((s, i) => {
-        console.log(
-            `  ${i + 1} | ${fmt(s.constructHeapMB)}          | ${fmt(s.constructMs)}     | ${fmt(
-                s.firstReadMs
-            )}      | ${fmt(s.reReadMs)}`
-        )
-    })
-    const avg = (pick: (s: Sample) => number) =>
-        samples.reduce((a, s) => a + pick(s), 0) / samples.length
-    console.log(
-        `avg | ${fmt(avg(s => s.constructHeapMB))}          | ${fmt(
-            avg(s => s.constructMs)
-        )}     | ${fmt(avg(s => s.firstReadMs))}      | ${fmt(avg(s => s.reReadMs))}`
-    )
-    return {
-        constructHeapMB: avg(s => s.constructHeapMB),
-        constructMs: avg(s => s.constructMs),
-        firstReadMs: avg(s => s.firstReadMs),
-        reReadMs: avg(s => s.reReadMs)
-    }
 }
 
 function main() {
@@ -208,21 +146,10 @@ function main() {
     console.log(`Node ${process.version}, ${RUNS} timed runs after 1 warmup per scenario.`)
 
     console.log(`\n=== SPARSE: 1 of 10 fields read per instance (best case for lazy) ===`)
-    const sparseWide = runScenario(`WIDE: 10 @observable fields`, Wide, FIELDS_WIDE)
-    runScenario(`NARROW: 1 @observable field`, Narrow, FIELDS_NARROW)
+    runScenario(`WIDE: 10 @observable fields, 1 field read per instance`, 1)
 
-    console.log(`\n=== FULL: ALL 10 fields read per instance (worst case for lazy) ===`)
-    const fullWide = runFullScenario(`WIDE-FULL: 10 fields, all read`, Wide, FIELDS_WIDE)
-
-    console.log(`\nWIDE: sparse vs full read pattern (same class, same lazy/eager state):`)
-    console.log(
-        `  construct heap : ${sparseWide.constructHeapMB.toFixed(
-            1
-        )} MB → unchanged (heap measured before reads)`
-    )
-    console.log(`  construct time : ${sparseWide.constructMs.toFixed(1)} ms → unchanged`)
-    console.log(`  first-read 1×  : ${sparseWide.firstReadMs.toFixed(1)} ms`)
-    console.log(`  first-read 10× : ${fullWide.firstReadMs.toFixed(1)} ms`)
+    console.log(`\n=== FULL: ALL 10 fields read per instance (steady-state worst case) ===`)
+    runScenario(`WIDE: 10 @observable fields, 10 fields read per instance`, 10)
 }
 
 main()

--- a/packages/mobx/__tests__/perf/tsconfig.decorator.json
+++ b/packages/mobx/__tests__/perf/tsconfig.decorator.json
@@ -11,5 +11,5 @@
         "outDir": "./compiled",
         "rootDir": "./"
     },
-    "include": ["./lazy-computed-decorator.ts"]
+    "include": ["./lazy-computed-decorator.ts", "./lazy-observable-decorator.ts"]
 }

--- a/packages/mobx/package.json
+++ b/packages/mobx/package.json
@@ -68,7 +68,7 @@
         "perf": "scripts/perf.sh",
         "perf-legacy": "node --expose-gc ./__tests__/perf/index.js legacy",
         "perf-proxy": "node --expose-gc ./__tests__/perf/index.js proxy",
-        "perf-decorator": "tsc -p ./__tests__/perf/tsconfig.decorator.json && node --expose-gc ./__tests__/perf/compiled/lazy-computed-decorator.js",
+        "perf-decorator": "tsc -p ./__tests__/perf/tsconfig.decorator.json && node --expose-gc ./__tests__/perf/compiled/lazy-computed-decorator.js && node --expose-gc ./__tests__/perf/compiled/lazy-observable-decorator.js",
         "test:performance": "npm run perf -- proxy && npm run perf -- legacy && npm run perf-decorator",
         "test:mixed-versions": "npm test -- --testRegex mixed-versions",
         "test:types": "tsc --noEmit",

--- a/packages/mobx/src/api/isobservable.ts
+++ b/packages/mobx/src/api/isobservable.ts
@@ -22,7 +22,11 @@ function _isObservable(value, property?: PropertyKey): boolean {
         }
         if (isObservableObject(value)) {
             const adm = value[$mobx]
-            return adm.values_.has(property) || !!adm.lazyComputedKeys_?.has(property)
+            return (
+                adm.values_.has(property) ||
+                !!adm.lazyComputedKeys_?.has(property) ||
+                !!adm.lazyObservableKeys_?.has(property)
+            )
         }
         return false
     }

--- a/packages/mobx/src/types/observableannotation.ts
+++ b/packages/mobx/src/types/observableannotation.ts
@@ -64,51 +64,45 @@ function decorate_20223_(
     const ann = this
     const { kind, name } = context
 
-    // The laziness here is not ideal... It's a workaround to how 2022.3 Decorators are implemented:
-    //   `addInitializer` callbacks are executed _before_ any accessors are defined (instead of the ideal-for-us right after each).
-    //   This means that, if we were to do our stuff in an `addInitializer`, we'd attempt to read a private slot
-    //   before it has been initialized. The runtime doesn't like that and throws a `Cannot read private member
-    //   from an object whose class did not declare it` error.
-    // TODO: it seems that this will not be required anymore in the final version of the spec
-    // See TODO: link
-    const initializedObjects = new WeakSet()
-
-    function initializeObservable(target, value) {
-        const adm: ObservableObjectAdministration = asObservableObject(target)[$mobx]
-        const observable = new ObservableValue(
-            value,
-            ann.options_?.enhancer ?? deepEnhancer,
-            __DEV__ ? `${adm.name_}.${name.toString()}` : `ObservableObject.${name.toString()}`,
-            false
-        )
-        adm.values_.set(name, observable)
-        initializedObjects.add(target)
+    if (kind !== "accessor") {
+        return
     }
 
-    if (kind == "accessor") {
-        return {
-            get() {
-                if (!initializedObjects.has(this)) {
-                    initializeObservable(this, desc.get.call(this))
-                }
-                return this[$mobx].getObservablePropValue_(name)
-            },
-            set(value) {
-                if (!initializedObjects.has(this)) {
-                    initializeObservable(this, value)
-                }
-                return this[$mobx].setObservablePropValue_(name, value)
-            },
-            init(value) {
-                if (!initializedObjects.has(this)) {
-                    initializeObservable(this, value)
-                }
-                return value
-            }
+    // Defer ObservableValue construction until first access. The factory is
+    // materialised by ObservableObjectAdministration on demand, so unused
+    // fields on wide classes never pay the per-instance allocation cost.
+    function registerLazy(target: any, value: any): ObservableObjectAdministration {
+        const adm: ObservableObjectAdministration = asObservableObject(target)[$mobx]
+        ;(adm.lazyObservableKeys_ ??= new Map()).set(
+            name,
+            () =>
+                new ObservableValue(
+                    value,
+                    ann.options_?.enhancer ?? deepEnhancer,
+                    __DEV__
+                        ? `${adm.name_}.${name.toString()}`
+                        : `ObservableObject.${name.toString()}`,
+                    false
+                )
+        )
+        return adm
+    }
+
+    return {
+        get() {
+            const adm: ObservableObjectAdministration =
+                this[$mobx] ?? registerLazy(this, desc.get.call(this))
+            return adm.getObservablePropValue_(name)
+        },
+        set(value) {
+            const adm: ObservableObjectAdministration = this[$mobx] ?? registerLazy(this, value)
+            return adm.setObservablePropValue_(name, value)
+        },
+        init(value) {
+            registerLazy(this, value)
+            return value
         }
     }
-
-    return
 }
 
 function assertObservableDescriptor(

--- a/packages/mobx/src/types/observableobject.ts
+++ b/packages/mobx/src/types/observableobject.ts
@@ -99,6 +99,7 @@ export class ObservableObjectAdministration
     appliedAnnotations_?: object
     private pendingKeys_: undefined | Map<PropertyKey, ObservableValue<boolean>>
     lazyComputedKeys_: undefined | Map<PropertyKey, () => ComputedValue<any>>
+    lazyObservableKeys_: undefined | Map<PropertyKey, () => ObservableValue<any>>
 
     constructor(
         public target_: any,
@@ -120,8 +121,11 @@ export class ObservableObjectAdministration
     }
 
     getObservablePropValue_(key: PropertyKey): any {
-        // Hot path: single map lookup. Lazy computeds (rare) take the materialise branch.
-        const observable = this.values_.get(key) ?? this.materializeLazyComputed_(key)
+        // Hot path: single map lookup. Lazy entries (rare) take the materialise branch.
+        const observable =
+            this.values_.get(key) ??
+            this.materializeLazyComputed_(key) ??
+            this.materializeLazyObservable_(key)
         return observable!.get()
     }
 
@@ -136,8 +140,22 @@ export class ObservableObjectAdministration
         return computed
     }
 
+    materializeLazyObservable_(key: PropertyKey): ObservableValue<any> | undefined {
+        const factory = this.lazyObservableKeys_?.get(key)
+        if (!factory) {
+            return undefined
+        }
+        this.lazyObservableKeys_!.delete(key)
+        const observable = factory()
+        this.values_.set(key, observable)
+        return observable
+    }
+
     setObservablePropValue_(key: PropertyKey, newValue): boolean | null {
-        const observable = this.values_.get(key) ?? this.materializeLazyComputed_(key)
+        const observable =
+            this.values_.get(key) ??
+            this.materializeLazyComputed_(key) ??
+            this.materializeLazyObservable_(key)
         if (observable instanceof ComputedValue) {
             observable.set(newValue)
             return true

--- a/packages/mobx/src/types/observableobject.ts
+++ b/packages/mobx/src/types/observableobject.ts
@@ -135,6 +135,9 @@ export class ObservableObjectAdministration
             return undefined
         }
         this.lazyComputedKeys_!.delete(key)
+        if (this.lazyComputedKeys_!.size === 0) {
+            this.lazyComputedKeys_ = undefined
+        }
         const computed = factory()
         this.values_.set(key, computed)
         return computed
@@ -146,6 +149,9 @@ export class ObservableObjectAdministration
             return undefined
         }
         this.lazyObservableKeys_!.delete(key)
+        if (this.lazyObservableKeys_!.size === 0) {
+            this.lazyObservableKeys_ = undefined
+        }
         const observable = factory()
         this.values_.set(key, observable)
         return observable

--- a/packages/mobx/src/types/type-utils.ts
+++ b/packages/mobx/src/types/type-utils.ts
@@ -48,7 +48,10 @@ export function getAtom(thing: any, property?: PropertyKey): IDepTreeNode {
                 return die(26)
             }
             const adm = (thing as any)[$mobx]
-            const observable = adm.values_.get(property) ?? adm.materializeLazyComputed_(property)
+            const observable =
+                adm.values_.get(property) ??
+                adm.materializeLazyComputed_(property) ??
+                adm.materializeLazyObservable_(property)
             if (!observable) {
                 die(27, property, getDebugName(thing))
             }


### PR DESCRIPTION
## Summary

Follow-up to #4639 per [maintainer request](https://github.com/mobxjs/mobx/pull/4639#issuecomment-4378567832). Applies the same lazy treatment to the 2022.3 `@observable accessor` decorator that #4639 applied to `@computed`.

Today the accessor decorator's `init` callback eagerly constructs an `ObservableValue` for every decorated field on every instance — even fields that are never read. On wide classes with many fields and sparse access this is wasted allocation and construction work (see #4616).

This change defers `ObservableValue` creation to the first read/write/observe of the decorated accessor:

- `decorate_20223_` in `observableannotation.ts` registers a factory closure on the admin's new `lazyObservableKeys_` map from the accessor's `init` callback, instead of building the `ObservableValue` and inserting it into `values_` upfront. The `initializedObjects` WeakSet workaround is gone — `init` now always registers the lazy factory.
- `ObservableObjectAdministration.materializeLazyObservable_(key)` lazily instantiates the `ObservableValue` and inserts it into `values_` on demand. It is called from `getObservablePropValue_` / `setObservablePropValue_` (so the existing accessor get/set Just Works) and from `getAtom` (so `observe(o, key, ...)` materialises before reading).
- `isObservableProp` checks `lazyObservableKeys_` in addition to `values_` / `lazyComputedKeys_` so a decorated observable continues to report as observable before its first read.
- Hot path is unchanged: `values_.get(key)` is the single Map lookup once the field has been read for the first time; the materialise branch only runs the first time and for the rare pre-read `getAtom` / `observe` callers.

The legacy `makeObservable`-based path (`defineObservableProperty_`) is unchanged.

## Benchmarks (this PR, lazy)

50k-instance × 10-field `Wide` class, Linux Node 24, `--expose-gc`, 1 warmup + 3 timed runs, averaged. Reproduce with `npm run build && npm run perf-decorator`:

| pattern | construct heap | construct ms | first-read ms | re-read ms |
|---|---:|---:|---:|---:|
| **SPARSE** — 1 of 10 fields read per instance | 118.6 MB | 320.6 | 40.9 | 45.4 |
| **FULL** — all 10 fields read per instance | 118.4 MB | 335.4 | 310.7 | 330.7 |

Two things to read out of this:

1. **Construction cost is independent of access pattern.** Heap and construct ms are essentially the same between SPARSE and FULL (118 MB / ~330 ms) — that's the cost of registering lazy factories for 10 fields on 50k instances, regardless of what gets read later.
2. **Lazy defers allocation rather than eliminating it.** Under SPARSE, only 1 ObservableValue gets materialised per instance, and first-read stays small (~41 ms). Under FULL, all 10 get materialised on first read, and first-read jumps to ~310 ms — the same total work as eager would have done at construction, just shifted later.

So the headline win is for sparse-access workloads (the realistic #4616 shape — wide stores where most fields aren't touched per render). For workloads that eventually touch every field, lazy is roughly break-even on total work (construct + first-read), with the benefit of better GC behaviour during construction.

**Eager baseline.** I did not include eager numbers in this table because the benchmark file can only measure the currently built mobx — there's no in-tree way to flip back to eager. To compare against eager, check out a commit before this PR lands (`git checkout main~`), run `npm run build && npm run perf-decorator`, and compare. Earlier exploration runs on `main` (reported in [this comment on #4639](https://github.com/mobxjs/mobx/pull/4639#issuecomment-4378710856)) showed ~224 MB construct heap and ~615 ms construct time for the same SPARSE shape on the eager path, so the directional savings are large — but I don't want to put unverifiable numbers in the PR table.

I also ran the full `npm test` suite (1043 passing, 14 skipped — same as `main`) and `npm run test:types` — both clean.

## Test plan

- [x] `npm test` (1043 passing, 14 skipped — full suite green)
- [x] `npm run test:types` (clean)
- [x] `npm run build` + `npm run perf-decorator` (lazy-observable bench runs)
- [x] New regression tests in `stage3-decorators.ts`:
  - `4616 - @observable accessor should be lazy` — asserts `ObservableValue` is not created until first read while `isObservableProp` still returns `true`, and an untouched field stays in `lazyObservableKeys_`.
  - `4616 - observe on @observable accessor before first read materialises it`
  - `4616 - set on @observable accessor before first read materialises it`
  - `4616 - autorun reacts to @observable accessor that is lazy on entry`
- [x] Existing `multiple inheritance should work` test updated to union `values_.keys()` with `lazyObservableKeys_.keys()`, since inherited @observable fields now live in the lazy map until first read.
