### PR TITLE
fix(mobx): prevent cycle when @computed overrides a base makeObservable computed (#4660)

### DIFF
--- a/.changeset/fix-computed-override-cycle.md
+++ b/.changeset/fix-computed-override-cycle.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix regression from #4639 where a `@computed` override of a base-class `makeObservable` computed threw "[MobX] Cycle detected in computation" (#4660)

--- a/packages/mobx/__tests__/decorators_20223/stage3-decorators.ts
+++ b/packages/mobx/__tests__/decorators_20223/stage3-decorators.ts
@@ -1319,3 +1319,59 @@ test(`decorated field can be inherited, but doesn't inherite the effect of decor
     const subStore = new SubStore()
     expect(isAction(subStore.action)).toBe(false)
 })
+
+test("issue 4660 - @computed override of a base makeObservable computed doesn't cycle", () => {
+    class Base {
+        _value = false
+        get value() {
+            return this._value
+        }
+        constructor() {
+            makeObservable(this, { _value: observable, value: computed })
+        }
+    }
+
+    class Child extends Base {
+        @computed
+        override get value() {
+            return super.value
+        }
+    }
+
+    const child = new Child()
+    // Used to throw "[MobX] Cycle detected in computation": base makeObservable
+    // built a ComputedValue from the child's @computed replacement getter.
+    expect(child.value).toBe(false)
+    child._value = true
+    expect(child.value).toBe(true)
+})
+
+test("issue 4660 - three-level inheritance with intermediate plain override", () => {
+    class ViewModelBase {
+        _mounted = false
+        get isMounted() {
+            return this._mounted
+        }
+        constructor() {
+            makeObservable(this, { _mounted: observable, isMounted: computed })
+        }
+    }
+
+    class RouteViewModel extends ViewModelBase {
+        override get isMounted() {
+            return super.isMounted
+        }
+    }
+
+    class ProductsPageVM extends RouteViewModel {
+        @computed
+        override get isMounted() {
+            return super.isMounted
+        }
+    }
+
+    const vm = new ProductsPageVM()
+    expect(vm.isMounted).toBe(false)
+    vm._mounted = true
+    expect(vm.isMounted).toBe(true)
+})

--- a/packages/mobx/src/types/computedannotation.ts
+++ b/packages/mobx/src/types/computedannotation.ts
@@ -60,6 +60,12 @@ function decorate_20223_(this: Annotation, get, context: ClassGetterDecoratorCon
     addInitializer(function () {
         const adm: ObservableObjectAdministration = asObservableObject(this)[$mobx]
         const target = this
+        // A base class `makeObservable(this, { [key]: computed })` running in super()
+        // may have already created a ComputedValue from *this* decorator's replacement
+        // getter (which just calls getObservablePropValue_(key)) — a self-referential
+        // cycle. Drop that stale entry so our lazy factory (built from the original
+        // getter) wins on first access. See #4660.
+        adm.values_.delete(key)
         ;(adm.lazyComputedKeys_ ??= new Map()).set(key, () => {
             const options = {
                 ...ann.options_,


### PR DESCRIPTION
## Fixes #4660

### Problem

Starting from MobX 6.16.0 (regression from #4639), accessing a `@computed` (2022.3 decorator) override of a property that a base class annotated as `computed` via `makeObservable` throws:

```
[MobX] Cycle detected in computation
```

```ts
class Base {
  _value = false
  get value() { return this._value }
  constructor() { makeObservable(this, { _value: observable, value: computed }) }
}

class Child extends Base {
  @computed
  override get value() { return super.value } // throws on access
}

new Child().value
```

### Root cause

The `@computed` decorator replaces the prototype getter with a replacement that calls `getObservablePropValue_(key)`, and (since #4639) registers a **lazy** `ComputedValue` factory in `adm.lazyComputedKeys_`.

When the base class's `makeObservable(this, { value: computed })` runs in `super()`, it walks the prototype chain, finds the child's **replacement getter**, and eagerly builds a `ComputedValue` from it — storing it directly in `adm.values_`. That derivation calls `getObservablePropValue_(key)` on the same key, so it references itself → cycle.

`getObservablePropValue_` checks `values_` before materialising the lazy factory, so the stale cyclic entry always wins. In 6.15.x the eager initializer happened to overwrite it; the lazy factory no longer does.

### Fix

In the `@computed` 2022.3 initializer, delete any stale `values_` entry for the key before registering the lazy factory, so the factory (built from the **original** getter) wins on first access. The lazy-computed optimization is preserved.

### Tests

Adds regression tests to `stage3-decorators.ts` covering:
- simple inheritance (`Base` makeObservable computed + `Child` `@computed` override)
- three-level inheritance with an intermediate plain-getter override

Both assert reactivity still works after the fix. They fail without the fix (`[MobX] Cycle detected in computation`) and pass with it.

Verified locally: full 2022.3 decorator suite (46 passed / 4 skipped) and full main suite (1000 passed / 10 skipped, 47 suites) green.
