### PR TITLE
Fix optional react-dom loading in mobx-react-lite

### DIFF
--- a/.changeset/optional-react-dom-batching.md
+++ b/.changeset/optional-react-dom-batching.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+Avoid requiring optional `react-dom` during module initialization and fall back to no-op batching when it is unavailable.

--- a/packages/mobx-react-lite/__tests__/optionalReactDom.test.ts
+++ b/packages/mobx-react-lite/__tests__/optionalReactDom.test.ts
@@ -1,0 +1,15 @@
+afterEach(() => {
+    jest.dontMock("react-dom")
+    jest.resetModules()
+})
+
+test("does not fail to load when react-dom is unavailable", () => {
+    jest.resetModules()
+    jest.doMock("react-dom", () => {
+        throw Object.assign(new Error("Cannot find module 'react-dom'"), {
+            code: "MODULE_NOT_FOUND"
+        })
+    })
+
+    expect(() => require("../src/index.ts")).not.toThrow()
+})

--- a/packages/mobx-react-lite/src/utils/reactBatchedUpdates.ts
+++ b/packages/mobx-react-lite/src/utils/reactBatchedUpdates.ts
@@ -1,1 +1,19 @@
-export { unstable_batchedUpdates } from "react-dom"
+import { defaultNoopBatch } from "./observerBatching"
+
+declare const require:
+    | ((moduleName: string) => { unstable_batchedUpdates?: typeof defaultNoopBatch })
+    | undefined
+
+export let unstable_batchedUpdates = defaultNoopBatch
+
+if (typeof require === "function") {
+    try {
+        const reactDom = require("react-dom")
+        if (reactDom.unstable_batchedUpdates) {
+            unstable_batchedUpdates = reactDom.unstable_batchedUpdates
+        }
+    } catch {
+        // react-dom is optional. React 18+ batches updates automatically, so fall back to no-op
+        // batching when react-dom isn't available (for example in React Native or server-only installs).
+    }
+}


### PR DESCRIPTION
Fixes #4663

### Summary
- Replace the static `react-dom` re-export in `mobx-react-lite` with a guarded optional load.
- Fall back to the existing no-op batch scheduler when `react-dom` is unavailable.
- Add a regression test that verifies `mobx-react-lite` can load when `react-dom` cannot be resolved.

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `/docs` (not applicable: bug fix, no docs/API change)
-   [x] Verified that there is no significant performance drop (not applicable to core MobX performance; ran targeted package checks and size test)

### Verification
- `npm ci --ignore-scripts`
- `npm -w mobx run build:test`
- `npm -w mobx-react run build:test`
- `npm -w mobx-react-lite run lint`
- `npm -w mobx-react-lite run test:types`
- `npm -w mobx-react-lite run build:test`
- `npm -w mobx-react-lite test -- --runInBand`
- `npm -w mobx-react-lite run test:size`
- `npx prettier --check packages/mobx-react-lite/src/utils/reactBatchedUpdates.ts packages/mobx-react-lite/__tests__/optionalReactDom.test.ts`
- `git diff --check`
- Built CJS smoke test with `react-dom` module loading blocked
