### PR TITLE
fix: use Symbol.prototype.valueOf in deepEqual for Symbol wrapper objects

### DIFF
--- a/packages/mobx/__tests__/base/extras.js
+++ b/packages/mobx/__tests__/base/extras.js
@@ -511,6 +511,21 @@ test("deepEquals should yield correct results for complex objects #1118 - 2", ()
     expect(mobx.comparer.structural(a1, a4)).toBe(false)
 })
 
+test("deepEquals should correctly compare Symbol wrapper objects", () => {
+    const sym = Symbol("test")
+    const sameSym1 = Object(sym)
+    const sameSym2 = Object(sym)
+    const diffSym1 = Object(Symbol("test"))
+    const diffSym2 = Object(Symbol("test"))
+
+    // Two wrappers around the SAME symbol should be structurally equal
+    expect(mobx.comparer.structural(sameSym1, sameSym2)).toBe(true)
+    // Two wrappers around DIFFERENT symbols (same description) should not be equal
+    expect(mobx.comparer.structural(diffSym1, diffSym2)).toBe(false)
+    // A wrapper compared to itself is trivially equal
+    expect(mobx.comparer.structural(sameSym1, sameSym1)).toBe(true)
+})
+
 test("comparer.shallow should require types to be equal", () => {
     const sh = mobx.comparer.shallow
     const obs = mobx.observable

--- a/packages/mobx/src/utils/eq.ts
+++ b/packages/mobx/src/utils/eq.ts
@@ -69,7 +69,7 @@ function eq(a: any, b: any, depth: number, aStack?: any[], bStack?: any[]) {
             return +a === +b
         case "[object Symbol]":
             return (
-                typeof Symbol !== "undefined" && Symbol.valueOf.call(a) === Symbol.valueOf.call(b)
+                typeof Symbol !== "undefined" && Symbol.prototype.valueOf.call(a) === Symbol.prototype.valueOf.call(b)
             )
         case "[object Map]":
         case "[object Set]":


### PR DESCRIPTION
### Code change checklist

- [x] Added/updated unit tests
- [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
- [ ] Verified that there is no significant performance drop (`npm -w mobx run test:performance`)

---

### Problem

`deepEqual`'s `[object Symbol]` switch case compares boxed Symbol objects using `Symbol.valueOf.call(a)` — but `Symbol.valueOf` is actually `Function.prototype.valueOf` (since `Symbol` is itself a function), which simply returns `this`. Two `Object(sym)` wrappers around the **same** underlying symbol are always different objects, so the comparison always returns `false`:

```js
const sym = Symbol('test')
comparer.structural(Object(sym), Object(sym)) // false — should be true
```

### Root cause

The code in `eq.ts` was adapted from Underscore, which correctly uses `SymbolProto.valueOf.call(a)` where `SymbolProto = Symbol.prototype`. The MobX copy accidentally dropped the `.prototype`, making the call invoke `Function.prototype.valueOf` instead of the Symbol unwrapping method.

### Fix

Change `Symbol.valueOf.call(a)` → `Symbol.prototype.valueOf.call(a)` in the `[object Symbol]` case so the primitive symbol is extracted from the wrapper before comparison.

> AI-assisted contribution.