### PR TITLE
fix: Symbol.toPrimitive of a null observable no longer throws on ES5 targets

### DIFF
--- a/.changeset/toprimitive-null-es5.md
+++ b/.changeset/toprimitive-null-es5.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix `ObservableValue`/`ComputedValue` `[Symbol.toPrimitive]` returning `null` when the value is `null`. Native engines accept this, but ES5-transpiled consumer code routes coercion through Babel's inlined `_toPrimitive` helper, which treats `null` as an object (`typeof null === "object"`) and throws `TypeError: @@toPrimitive must return a primitive value.`. The method is now hint-aware and mirrors native coercion of `null` (`String(null) === "null"`, `Number(null) === 0`), so coercing a null-holding observable no longer throws on ES5 targets.

--- a/packages/mobx/__tests__/base/observables.js
+++ b/packages/mobx/__tests__/base/observables.js
@@ -1693,6 +1693,47 @@ test("#561 test toPrimitive() of observable objects", function () {
     }
 })
 
+test("#4673 Symbol.toPrimitive of a null observable does not throw in Babel's ES5 _toPrimitive helper", function () {
+    // Exactly what Babel inlines into ES5-transpiled consumer code. It uses
+    // `typeof x === "object"` to test for a primitive, so it misclassifies the
+    // spec-legal `null` result and throws.
+    function _toPrimitive(t, r) {
+        if ("object" != typeof t || !t) return t
+        var e = t[Symbol.toPrimitive]
+        if (void 0 !== e) {
+            var i = e.call(t, r || "default")
+            if ("object" != typeof i) return i
+            throw new TypeError("@@toPrimitive must return a primitive value.")
+        }
+        return ("string" === r ? String : Number)(t)
+    }
+    function _toPropertyKey(t) {
+        var i = _toPrimitive(t, "string")
+        return "symbol" == typeof i ? i : i + ""
+    }
+
+    const box = observable.box(null)
+
+    // The transpiled coercion path must not throw and must mirror native
+    // coercion of `null` (String(null) === "null", Number(null) === 0).
+    expect(() => _toPropertyKey(box)).not.toThrow()
+    expect(_toPropertyKey(box)).toBe("null")
+    expect(_toPrimitive(box, "number")).toBe(0)
+
+    // Native ToPrimitive is and stays unaffected.
+    expect(String(box)).toBe("null")
+
+    // Non-null values still coerce as before.
+    box.set(5)
+    expect(_toPropertyKey(box)).toBe("5")
+    expect(+box).toBe(5)
+
+    // computed values share the same coercion path.
+    const c = computed(() => null)
+    expect(() => _toPropertyKey(c)).not.toThrow()
+    expect(_toPropertyKey(c)).toBe("null")
+})
+
 test("computed equals function only invoked when necessary", () => {
     utils.supressConsole(() => {
         const comparisons = []

--- a/packages/mobx/src/core/computedvalue.ts
+++ b/packages/mobx/src/core/computedvalue.ts
@@ -372,8 +372,18 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
         return toPrimitive(this.get())
     }
 
-    [Symbol.toPrimitive]() {
-        return this.valueOf()
+    [Symbol.toPrimitive](hint: "default" | "string" | "number") {
+        const value = this.valueOf()
+        // `null` is a valid Symbol.toPrimitive result per spec, but Babel's
+        // inlined ES5 `_toPrimitive` helper rejects it (it checks
+        // `typeof x === "object"`, and `typeof null === "object"`), throwing
+        // "@@toPrimitive must return a primitive value." Return a non-null
+        // primitive that mirrors native coercion of `null`
+        // (`Number(null) === 0`, `String(null) === "null"`). See #4673.
+        if (value === null) {
+            return hint === "number" ? 0 : "null"
+        }
+        return value
     }
 }
 

--- a/packages/mobx/src/types/observablevalue.ts
+++ b/packages/mobx/src/types/observablevalue.ts
@@ -189,8 +189,18 @@ export class ObservableValue<T>
         return toPrimitive(this.get())
     }
 
-    [Symbol.toPrimitive]() {
-        return this.valueOf()
+    [Symbol.toPrimitive](hint: "default" | "string" | "number") {
+        const value = this.valueOf()
+        // `null` is a valid Symbol.toPrimitive result per spec, but Babel's
+        // inlined ES5 `_toPrimitive` helper rejects it — it checks
+        // `typeof x === "object"`, and `typeof null === "object"`, so it throws
+        // "@@toPrimitive must return a primitive value." Return a non-null
+        // primitive that mirrors native coercion of `null`
+        // (`Number(null) === 0`, `String(null) === "null"`). See #4673.
+        if (value === null) {
+            return hint === "number" ? 0 : "null"
+        }
+        return value
     }
 }
 


### PR DESCRIPTION
Closes #4673.

## Problem

`ObservableValue` and `ComputedValue` implement `[Symbol.toPrimitive]` by returning `valueOf()`:

```ts
valueOf(): T { return toPrimitive(this.get()) }
[Symbol.toPrimitive]() { return this.valueOf() }
```

When the held value is `null`, `valueOf()` returns `null`. Native engines accept that (`null` is a valid `ToPrimitive` result per spec), but **ES5-transpiled consumer code** routes coercion through Babel's inlined `_toPrimitive` helper:

```js
if ("object" != typeof i) return i;
throw new TypeError("@@toPrimitive must return a primitive value.");
```

Because `typeof null === "object"`, the helper misclassifies `null` as an object and throws. So coercing a null-holding observable (template strings, object keys, etc.) throws on ES5 targets — e.g. `` `${box}` `` / `obj[box]` on old Chrome / Smart-TV builds.

```js
const box = observable.box(null)
String(box)         // "null"  (native, fine)
_toPropertyKey(box) // throws TypeError on the Babel ES5 path
```

This is technically a limitation of Babel's helper (unchanged even in `@babel/runtime@8`), but mobx is well-placed to be defensive here, and its own `toPrimitive` util already special-cases values.

## Fix

Make `[Symbol.toPrimitive]` hint-aware and never return `null`, mirroring native coercion of `null`:

```ts
[Symbol.toPrimitive](hint) {
  const value = this.valueOf()
  if (value === null) return hint === "number" ? 0 : "null"
  return value
}
```

`String(null) === "null"` and `Number(null) === 0`, so the coerced results match the native path (and `+box` of a null observable stays `0` rather than becoming `NaN`). `valueOf()` and `toJSON()` are left untouched, so numeric coercion and `JSON.stringify` are unchanged. The same fix is applied to `ComputedValue`, which shares the identical coercion path.

## Tests

Adds a regression test (`#4673 …`) that inlines Babel's exact ES5 `_toPrimitive`/`_toPropertyKey` helpers and asserts that coercing a null-holding observable **and** computed no longer throws and yields `"null"` / `0`, while non-null values still coerce as before. It throws (fails) on the current code and passes with this change. The full `observables` suite passes and `tsc` is clean. A changeset is included.
