### PR TITLE
Shorten minified error URL to reduce production bundle size

### DIFF
--- a/.changeset/fix-minified-error-link.md
+++ b/.changeset/fix-minified-error-link.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Shorten minified error URL to reduce production bundle size.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage
 test/babel-tests.js
 test/typescript/typescript-tests.js
 dist/
+/docs/errors.md
 **/.idea/*
 !/.idea/icon.png
 !/.idea/vcs.xml

--- a/packages/mobx/src/errors.ts
+++ b/packages/mobx/src/errors.ts
@@ -87,7 +87,7 @@ export function die(error: string | keyof typeof errors, ...args: any[]): never 
         typeof error === "number"
             ? `[MobX] minified error nr: ${error}${
                   args.length ? " " + args.map(String).join(",") : ""
-              }. Find the full error at: https://github.com/mobxjs/mobx/blob/main/packages/mobx/src/errors.ts`
+              }. See http://mobx.js.org/errors`
             : `[MobX] ${error}`
     )
 }

--- a/packages/mobx/src/errors.ts
+++ b/packages/mobx/src/errors.ts
@@ -1,4 +1,4 @@
-const niceErrors = {
+export const niceErrors = {
     0: `Invalid value for configuration 'enforceActions', expected 'never', 'always' or 'observed'`,
     1(annotationType, key: PropertyKey) {
         return `Cannot apply '${annotationType}' to '${key.toString()}': Field not found.`

--- a/packages/mobx/src/internal.ts
+++ b/packages/mobx/src/internal.ts
@@ -6,7 +6,7 @@ With this file that will still happen,
 but at least in this file we can magically reorder the imports with trial and error until the build succeeds again.
 */
 export * from "./utils/global"
-export * from "./errors"
+export { die } from "./errors"
 export * from "./utils/utils"
 export * from "./api/decorators"
 export * from "./core/atom"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -64,6 +64,10 @@
         "title": "Decorators",
         "sidebar_label": "Decorators {🚀}"
       },
+      "errors": {
+        "title": "MobX error codes",
+        "sidebar_label": "Error codes"
+      },
       "faq/migrate-to-6": {
         "title": "Migrating from MobX 4/5"
       },

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,9 @@
 {
   "scripts": {
     "examples": "docusaurus-examples",
+    "prestart": "node scripts/generate-error-docs.mjs",
     "start": "docusaurus-start",
+    "prebuild": "node scripts/generate-error-docs.mjs",
     "build": "docusaurus-build",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",

--- a/website/package.json
+++ b/website/package.json
@@ -1,9 +1,9 @@
 {
   "scripts": {
     "examples": "docusaurus-examples",
-    "prestart": "node scripts/generate-error-docs.mjs",
+    "prestart": "node scripts/generate-error-docs.js",
     "start": "docusaurus-start",
-    "prebuild": "node scripts/generate-error-docs.mjs",
+    "prebuild": "node scripts/generate-error-docs.js",
     "build": "docusaurus-build",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",

--- a/website/scripts/generate-error-docs.js
+++ b/website/scripts/generate-error-docs.js
@@ -43,7 +43,7 @@ custom_edit_url: https://github.com/mobxjs/mobx/edit/main/packages/mobx/src/erro
 
 # MobX error codes
 
-In development builds, MobX throws full error messages. Production builds replace known messages with short numeric codes to keep the published bundle small.
+In development builds, MobX throws full error messages. Production builds replace known messages with short numeric codes to keep the published bundle smaller.
 
 | Code | Message |
 | ---- | ------- |

--- a/website/scripts/generate-error-docs.js
+++ b/website/scripts/generate-error-docs.js
@@ -10,28 +10,26 @@ const outputPath = resolve(repoRoot, "docs/errors.md")
 globalThis.__DEV__ = true
 const { niceErrors } = require(errorsPath)
 
-function getParamNames(fn) {
-    const match = fn.toString().match(/^[^(]*\(([^)]*)\)/)
-    return match ? match[1].split(",").map(name => name.trim()).filter(Boolean) : []
-}
+function formatMarkdownCell(message) {
+    let value = message
 
-function renderMessage(message) {
-    if (typeof message !== "function") {
-        return message
+    if (typeof message === "function") {
+        // Render dynamic errors with visible placeholders instead of real runtime values
+        const match = message.toString().match(/^[^(]*\(([^)]*)\)/)
+        const params = match ? match[1] : ""
+        const names = params.split(",").map(name => name.trim()).filter(Boolean)
+        const args = names.map(name => `{${name}}`)
+        value = message(...args).replace("String", args[0])
     }
 
-    const args = getParamNames(message).map(name => `{${name}}`)
-    return message(...args).replace("String", args[0])
-}
-
-function escapeMarkdownTableCell(value) {
+    // Keep the generated table valid Markdown
     return String(value).replace(/\r?\n/g, "<br />").replace(/\|/g, "\\|")
 }
 
 function renderDocs(errors) {
     const rows = Object.keys(errors)
         .sort((left, right) => Number(left) - Number(right))
-        .map(code => `| ${code} | ${escapeMarkdownTableCell(renderMessage(errors[code]))} |`)
+        .map(code => `| ${code} | ${formatMarkdownCell(errors[code])} |`)
         .join("\n")
 
     return `---

--- a/website/scripts/generate-error-docs.js
+++ b/website/scripts/generate-error-docs.js
@@ -1,24 +1,14 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from "node:fs"
-import { relative } from "node:path"
-import { fileURLToPath } from "node:url"
+const { writeFileSync } = require("fs")
+const { relative, resolve } = require("path")
 
-const repoRoot = fileURLToPath(new URL("../..", import.meta.url))
-const errorsPath = fileURLToPath(new URL("../../packages/mobx/src/errors.ts", import.meta.url))
-const outputPath = fileURLToPath(new URL("../../docs/errors.md", import.meta.url))
+const repoRoot = resolve(__dirname, "../..")
+const errorsPath = resolve(repoRoot, "packages/mobx/src/errors.ts")
+const outputPath = resolve(repoRoot, "docs/errors.md")
 
-function readNiceErrors() {
-    const source = readFileSync(errorsPath, "utf8")
-    const match = source.match(/const niceErrors = ([\s\S]*?) as const/)
-
-    if (!match) {
-        throw new Error(`Could not find niceErrors in ${errorsPath}`)
-    }
-
-    const objectLiteral = match[1].replace(": PropertyKey", "")
-    return eval(`(${objectLiteral})`)
-}
+globalThis.__DEV__ = true
+const { niceErrors } = require(errorsPath)
 
 function getParamNames(fn) {
     const match = fn.toString().match(/^[^(]*\(([^)]*)\)/)
@@ -63,7 +53,7 @@ ${rows}
 `
 }
 
-const docs = renderDocs(readNiceErrors())
+const docs = renderDocs(niceErrors)
 writeFileSync(outputPath, docs)
 
 console.log(`Generated ${relative(repoRoot, outputPath)} from ${relative(repoRoot, errorsPath)}`)

--- a/website/scripts/generate-error-docs.mjs
+++ b/website/scripts/generate-error-docs.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs"
+import { relative } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url))
+const errorsPath = fileURLToPath(new URL("../../packages/mobx/src/errors.ts", import.meta.url))
+const outputPath = fileURLToPath(new URL("../../docs/errors.md", import.meta.url))
+
+function readNiceErrors() {
+    const source = readFileSync(errorsPath, "utf8")
+    const match = source.match(/const niceErrors = ([\s\S]*?) as const/)
+
+    if (!match) {
+        throw new Error(`Could not find niceErrors in ${errorsPath}`)
+    }
+
+    const objectLiteral = match[1].replace(": PropertyKey", "")
+    return eval(`(${objectLiteral})`)
+}
+
+function getParamNames(fn) {
+    const match = fn.toString().match(/^[^(]*\(([^)]*)\)/)
+    return match ? match[1].split(",").map(name => name.trim()).filter(Boolean) : []
+}
+
+function renderMessage(message) {
+    if (typeof message !== "function") {
+        return message
+    }
+
+    const args = getParamNames(message).map(name => `{${name}}`)
+    return message(...args).replace("String", args[0])
+}
+
+function escapeMarkdownTableCell(value) {
+    return String(value).replace(/\r?\n/g, "<br />").replace(/\|/g, "\\|")
+}
+
+function renderDocs(errors) {
+    const rows = Object.keys(errors)
+        .sort((left, right) => Number(left) - Number(right))
+        .map(code => `| ${code} | ${escapeMarkdownTableCell(renderMessage(errors[code]))} |`)
+        .join("\n")
+
+    return `---
+title: MobX error codes
+sidebar_label: Error codes
+hide_title: true
+custom_edit_url: https://github.com/mobxjs/mobx/edit/main/packages/mobx/src/errors.ts
+---
+
+<script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CEBD4KQ7&placement=mobxjsorg" id="_carbonads_js"></script>
+
+# MobX error codes
+
+In development builds, MobX throws full error messages. Production builds replace known messages with short numeric codes to keep the published bundle small.
+
+| Code | Message |
+| ---- | ------- |
+${rows}
+`
+}
+
+const docs = renderDocs(readNiceErrors())
+writeFileSync(outputPath, docs)
+
+console.log(`Generated ${relative(repoRoot, outputPath)} from ${relative(repoRoot, errorsPath)}`)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -22,6 +22,7 @@
       "understanding-reactivity",
       "subclassing",
       "analyzing-reactivity",
+      "errors",
       "computeds-with-args",
       "mobx-utils",
       "custom-observables",


### PR DESCRIPTION
Added a separate documentation page for the production error codes we have. Benefits:
- Make the error list discoverable for Google / AI agents
- Allows to use the short url `mobx.js.org/errors` in the production bundle since gzip does not shorten unique strings

The page will be always up-to-date with the source code