### PR TITLE
Prevent release workflow from running in forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   release:
     name: Release
+    if: github.repository == 'mobxjs/mobx'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Issue - mobx forks on GitHub inherit the release workflow. It leads to confusing PR references like this: 

https://github.com/mobxjs/mobx/pull/4677
<img width="996" height="228" alt="image" src="https://github.com/user-attachments/assets/6fc9e69a-4d02-4d82-b6d4-d99d453cb686" />

https://github.com/mobxjs/mobx/pull/4659
<img width="898" height="200" alt="image" src="https://github.com/user-attachments/assets/b15b4080-73c5-4648-adb0-2b0c6ab34ef4" />

The fix should prevent that
