### PR TITLE
fix(mobx): ObservableSet union/intersection/symmetricDifference result ordering

### DIFF
--- a/.changeset/fix-observableset-receiver-order.md
+++ b/.changeset/fix-observableset-receiver-order.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix ObservableSet union, intersection and symmetricDifference to return results in receiver order, matching native Set, when the argument is a plain Set.

--- a/packages/mobx/__tests__/base/set.js
+++ b/packages/mobx/__tests__/base/set.js
@@ -339,6 +339,17 @@ describe("The Set object methods do what they are supposed to do", () => {
         expect(isDisjointFromObservableResult).toBeTruthy()
     })
 
+    test("set methods preserve receiver order (matches native Set)", () => {
+        const nativeCopy = new Set(reactiveSet)
+        const other = new Set([6, 2, 1])
+
+        expect([...reactiveSet.union(other)]).toEqual([...nativeCopy.union(other)])
+        expect([...reactiveSet.intersection(other)]).toEqual([...nativeCopy.intersection(other)])
+        expect([...reactiveSet.symmetricDifference(other)]).toEqual([
+            ...nativeCopy.symmetricDifference(other)
+        ])
+    })
+
     test("with ObservableSet #3919", () => {
         const intersectionObservableResult = reactiveSet.intersection(set([1, 2, 6]))
         const unionObservableResult = reactiveSet.union(set([1, 2, 6]))

--- a/packages/mobx/src/types/observableset.ts
+++ b/packages/mobx/src/types/observableset.ts
@@ -55,16 +55,14 @@ export type ISetWillDeleteChange<T = any> = {
     type: "delete"
     object: ObservableSet<T>
     oldValue: T
-};
+}
 export type ISetWillAddChange<T = any> = {
     type: "add"
     object: ObservableSet<T>
     newValue: T
-};
+}
 
-export type ISetWillChange<T = any> =
-    | ISetWillDeleteChange<T>
-    | ISetWillAddChange<T>
+export type ISetWillChange<T = any> = ISetWillDeleteChange<T> | ISetWillAddChange<T>
 
 export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillChange>, IListenable {
     [$mobx] = ObservableSetMarker
@@ -133,8 +131,7 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
             }
 
             // implemented reassignment same as it's done for ObservableMap
-            value = change.newValue!;
-
+            value = change.newValue!
         }
         if (!this.has(value)) {
             transaction(() => {
@@ -244,21 +241,11 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
     }
 
     intersection<U>(otherSet: ReadonlySetLike<U> | Set<U>): Set<T & U> {
-        if (isES6Set(otherSet) && !isObservableSet(otherSet)) {
-            return otherSet.intersection(this)
-        } else {
-            const dehancedSet = new Set(this)
-            return dehancedSet.intersection(otherSet)
-        }
+        return new Set(this).intersection(otherSet)
     }
 
     union<U>(otherSet: ReadonlySetLike<U> | Set<U>): Set<T | U> {
-        if (isES6Set(otherSet) && !isObservableSet(otherSet)) {
-            return otherSet.union(this)
-        } else {
-            const dehancedSet = new Set(this)
-            return dehancedSet.union(otherSet)
-        }
+        return new Set(this).union(otherSet)
     }
 
     difference<U>(otherSet: ReadonlySetLike<U>): Set<T> {
@@ -266,12 +253,7 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
     }
 
     symmetricDifference<U>(otherSet: ReadonlySetLike<U> | Set<U>): Set<T | U> {
-        if (isES6Set(otherSet) && !isObservableSet(otherSet)) {
-            return otherSet.symmetricDifference(this)
-        } else {
-            const dehancedSet = new Set(this)
-            return dehancedSet.symmetricDifference(otherSet)
-        }
+        return new Set(this).symmetricDifference(otherSet)
     }
 
     isSubsetOf(otherSet: ReadonlySetLike<unknown>): boolean {
@@ -283,12 +265,7 @@ export class ObservableSet<T = any> implements Set<T>, IInterceptable<ISetWillCh
     }
 
     isDisjointFrom(otherSet: ReadonlySetLike<unknown> | Set<unknown>): boolean {
-        if (isES6Set(otherSet) && !isObservableSet(otherSet)) {
-            return otherSet.isDisjointFrom(this)
-        } else {
-            const dehancedSet = new Set(this)
-            return dehancedSet.isDisjointFrom(otherSet)
-        }
+        return new Set(this).isDisjointFrom(otherSet)
     }
 
     replace(other: ObservableSet<T> | IObservableSetInitialValues<T>): ObservableSet<T> {


### PR DESCRIPTION
`ObservableSet` implements `Set<T>`, so its ES2024 set methods should match native `Set` result ordering: `union` appends the argument's new elements after the receiver's, and `intersection` and `symmetricDifference` keep the receiver's order. When the argument is a plain (non-observable) `Set`, `union`, `intersection` and `symmetricDifference` instead delegate to the argument (`otherSet.method(this)`), so the result comes out in the argument's order.

```js
const s = observable.set([1, 2, 3])
;[...s.union(new Set([3, 4]))]        // was [3, 4, 1, 2], native is [1, 2, 3, 4]
;[...s.intersection(new Set([3, 2]))] // argument-ordered instead of receiver-ordered
```

Values and membership are correct, so this slipped past the existing tests, which compare with `toEqual(new Set([...]))` (order-insensitive). It surfaces whenever the result is iterated (spread, `Array.from`, `forEach`, rendering a list) after moving from a plain `Set` to `observable.set`.

## Fix

Build the result from the receiver in every case: `return new Set(this).method(otherSet)`, matching the already-correct `difference`, `isSubsetOf` and `isSupersetOf`. The observable-argument case already used this form (the previous `else` branch), so the `#3919` stack-overflow behavior is unchanged; only the plain-`Set` path changes, from argument-order to receiver-order. `isDisjointFrom` is aligned to the same form as well (its boolean result was already correct, so this is only for consistency).

## Testing

Added an order-sensitive test to `__tests__/base/set.js` that compares against a native `Set` built from the same receiver. It fails before this change; the full set suite (28 tests, including the `#3919` case) stays green with it.
