### PR TITLE
perf: fast-path primitives in deepEnhancer

### DIFF
--- a/.changeset/deep-enhancer-primitive-fast-path.md
+++ b/.changeset/deep-enhancer-primitive-fast-path.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+perf: fast-path primitives in `deepEnhancer`. Writing a primitive into a deep observable no longer runs the observable/array/plain-object/Map/Set/function type checks; primitives can never be made observable, so they are returned immediately. Creating an observable array of primitives is ~4x faster, and observable Set/Map writes are ~20-25% faster in the perf suite.

--- a/packages/mobx/__tests__/base/makereactive.js
+++ b/packages/mobx/__tests__/base/makereactive.js
@@ -715,3 +715,18 @@ test("#1650, toString is not treated correctly", () => {
     const oo = mobx.observable(o)
     expect(oo.toString).toBe("toString")
 })
+
+test("deep enhancer passes primitives through unchanged", () => {
+    const x = mobx.observable({ v: undefined })
+    const primitives = [1, "a", true, null, undefined, Symbol("test"), BigInt(42)]
+    primitives.forEach(value => {
+        x.v = value
+        expect(x.v).toBe(value)
+    })
+})
+
+test("deep enhancer still wraps functions assigned after creation into autoActions", () => {
+    const x = mobx.observable({ fn: undefined })
+    x.fn = function () {}
+    expect(mobx.isAction(x.fn)).toBe(true)
+})

--- a/packages/mobx/src/types/modifiers.ts
+++ b/packages/mobx/src/types/modifiers.ts
@@ -22,6 +22,11 @@ export interface IEnhancer<T> {
 }
 
 export function deepEnhancer(v, _, name) {
+    // primitives can never be made observable; skip the type checks below
+    if (v === null || (typeof v !== "object" && typeof v !== "function")) {
+        return v
+    }
+
     // it is an observable already, done
     if (isObservable(v)) {
         return v


### PR DESCRIPTION
## What / why

`deepEnhancer` runs on every value that enters a deep observable — including every scalar write. For a primitive, it currently walks the full chain of type checks (`isObservable`, `Array.isArray`, `isPlainObject`, `isES6Map`, `isES6Set`, `typeof function`) before falling through to `return v`. Primitives can never be made observable, so this PR returns them immediately:

```ts
// primitives can never be made observable; skip the type checks below
if (v === null || (typeof v !== "object" && typeof v !== "function")) {
    return v
}
```

Functions are deliberately excluded from the early return so they still get wrapped into `autoAction`/`flow`. Behavior is unchanged for every input class — primitives previously fell through all checks and returned as-is.

## Benchmarks

From `npm -w mobx run test:performance` (Node 26, macOS), alternating A/B runs against `main` with a rebuild on each side. Consistent across the proxy and legacy suites and across repeated runs:

| Benchmark | main | this PR |
|---|---|---|
| Create array (1M primitives) | 39–44 ms | **10 ms** |
| Set: setting/deleting 10k props × 1000 | ~1750 ms | ~1360 ms (−22%) |
| Map: setting/deleting 100 props × 1000 | 17 ms | 12–13 ms (−25%) |

All other benchmarks are within run-to-run noise.

## Tests

Full suite passes. Added two tests pinning the fast-path boundary in `makereactive.js`:

- every primitive type (number, string, boolean, `null`, `undefined`, symbol, bigint) passes through the deep enhancer unchanged
- a function assigned to a deep observable property after creation is still wrapped into an `autoAction`

A changeset (patch bump for `mobx`) is included.

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `/docs`. For new functionality, at least `API.md` should be updated — N/A, internal change only, no public API or documented behavior affected
-   [x] Verified that there is no significant performance drop (`npm -w mobx run test:performance`)
