### PR TITLE
Fix stack overflow in endBatch() when disposing a Reaction from onBecomeUnobserved

### DIFF
--- a/.changeset/fix-endbatch-unobservation-reentrancy.md
+++ b/.changeset/fix-endbatch-unobservation-reentrancy.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+Fix a stack overflow ("Maximum call stack size exceeded") that could occur when an `onBecomeUnobserved` handler disposes a `Reaction`. Disposing a `Reaction` re-enters `endBatch()`, which used to recurse into the same `pendingUnobservations` drain loop instead of letting the already-running outer loop pick up the newly queued items, causing unbounded stack depth for long enough chains.

--- a/packages/mobx/__tests__/base/become-observed.ts
+++ b/packages/mobx/__tests__/base/become-observed.ts
@@ -510,6 +510,33 @@ test("#2667", () => {
     ])
 })
 
+test("#3954 - disposing a chain of reactions from onBecomeUnobserved doesn't overflow the stack", () => {
+    // Each box's onBecomeUnobserved handler disposes the next reaction in the
+    // chain. Disposing reaction[0] unobserves box[0], whose handler disposes
+    // reaction[1], which unobserves box[1], and so on. Each of those disposals
+    // re-enters endBatch() while the previous one is still draining
+    // pendingUnobservations, so this used to recurse N deep instead of
+    // looping, overflowing the stack for a large enough chain.
+    const N = 10000
+    const boxes = Array.from({ length: N }, () => observable.box(0))
+    const disposers = boxes.map(box => autorun(() => box.get()))
+    let unobservedCount = 0
+
+    boxes.forEach((box, i) => {
+        onBecomeUnobserved(box, () => {
+            unobservedCount++
+            if (i + 1 < N) {
+                disposers[i + 1]()
+            }
+        })
+    })
+
+    expect(() => disposers[0]()).not.toThrow()
+
+    // the whole chain should have unwound, not just the first link
+    expect(unobservedCount).toBe(N)
+})
+
 test("works with ObservableSet #3595", () => {
     const onSetObserved = jest.fn()
     const onSetUnobserved = jest.fn()

--- a/packages/mobx/__tests__/base/become-observed.ts
+++ b/packages/mobx/__tests__/base/become-observed.ts
@@ -537,6 +537,31 @@ test("#3954 - disposing a chain of reactions from onBecomeUnobserved doesn't ove
     expect(unobservedCount).toBe(N)
 })
 
+test("#3954 followup - isRunningUnobservations is released even if an onBecomeUnobserved handler throws", () => {
+    const boxA = observable.box(0)
+    const disposeA = autorun(() => boxA.get())
+    onBecomeUnobserved(boxA, () => {
+        throw new Error("boom")
+    })
+
+    // the handler's exception should still surface to the caller, not be swallowed
+    expect(() => disposeA()).toThrow("boom")
+
+    // if the internal guard were left stuck true after that exception, every
+    // future endBatch() would silently stop draining pendingUnobservations,
+    // so this completely unrelated disposal would never fire its own handler
+    const boxB = observable.box(0)
+    const disposeB = autorun(() => boxB.get())
+    let unobservedB = false
+    onBecomeUnobserved(boxB, () => {
+        unobservedB = true
+    })
+
+    disposeB()
+
+    expect(unobservedB).toBe(true)
+})
+
 test("works with ObservableSet #3595", () => {
     const onSetObserved = jest.fn()
     const onSetUnobserved = jest.fn()

--- a/packages/mobx/src/core/globalstate.ts
+++ b/packages/mobx/src/core/globalstate.ts
@@ -82,6 +82,14 @@ export class MobXGlobals {
     isRunningReactions = false
 
     /**
+     * Are we currently draining pendingUnobservations in endBatch?
+     * An onBecomeUnobserved handler can dispose a Reaction, which calls
+     * startBatch/endBatch again; this guards against re-entering the same
+     * drain loop recursively (see endBatch in observable.ts).
+     */
+    isRunningUnobservations = false
+
+    /**
      * Is it allowed to change observables at this point?
      * In general, MobX doesn't allow that when running computations and React.render.
      * To ensure that those functions stay pure.

--- a/packages/mobx/src/core/observable.ts
+++ b/packages/mobx/src/core/observable.ts
@@ -111,24 +111,33 @@ export function endBatch() {
     if (--globalState.inBatch === 0) {
         runReactions()
         // the batch is actually about to finish, all unobserving should happen here.
-        const list = globalState.pendingUnobservations
-        for (let i = 0; i < list.length; i++) {
-            const observable = list[i]
-            observable.isPendingUnobservation = false
-            if (observable.observers_.size === 0) {
-                if (observable.isBeingObserved) {
-                    // if this observable had reactive observers, trigger the hooks
-                    observable.isBeingObserved = false
-                    observable.onBUO()
-                }
-                if (observable instanceof ComputedValue) {
-                    // computed values are automatically teared down when the last observer leaves
-                    // this process happens recursively, this computed might be the last observabe of another, etc..
-                    observable.suspend_()
+        // Guard against re-entering this loop: an onBUO handler can dispose a Reaction,
+        // which calls startBatch/endBatch again while we're still iterating. Bail out of
+        // the nested call instead of recursing; the outer loop re-reads list.length on
+        // every iteration, so it picks up anything the nested dispose() pushes onto the
+        // same pendingUnobservations array.
+        if (!globalState.isRunningUnobservations) {
+            globalState.isRunningUnobservations = true
+            const list = globalState.pendingUnobservations
+            for (let i = 0; i < list.length; i++) {
+                const observable = list[i]
+                observable.isPendingUnobservation = false
+                if (observable.observers_.size === 0) {
+                    if (observable.isBeingObserved) {
+                        // if this observable had reactive observers, trigger the hooks
+                        observable.isBeingObserved = false
+                        observable.onBUO()
+                    }
+                    if (observable instanceof ComputedValue) {
+                        // computed values are automatically teared down when the last observer leaves
+                        // this process happens recursively, this computed might be the last observabe of another, etc..
+                        observable.suspend_()
+                    }
                 }
             }
+            globalState.pendingUnobservations = []
+            globalState.isRunningUnobservations = false
         }
-        globalState.pendingUnobservations = []
     }
 }
 

--- a/packages/mobx/src/core/observable.ts
+++ b/packages/mobx/src/core/observable.ts
@@ -118,25 +118,31 @@ export function endBatch() {
         // same pendingUnobservations array.
         if (!globalState.isRunningUnobservations) {
             globalState.isRunningUnobservations = true
-            const list = globalState.pendingUnobservations
-            for (let i = 0; i < list.length; i++) {
-                const observable = list[i]
-                observable.isPendingUnobservation = false
-                if (observable.observers_.size === 0) {
-                    if (observable.isBeingObserved) {
-                        // if this observable had reactive observers, trigger the hooks
-                        observable.isBeingObserved = false
-                        observable.onBUO()
-                    }
-                    if (observable instanceof ComputedValue) {
-                        // computed values are automatically teared down when the last observer leaves
-                        // this process happens recursively, this computed might be the last observabe of another, etc..
-                        observable.suspend_()
+            try {
+                const list = globalState.pendingUnobservations
+                for (let i = 0; i < list.length; i++) {
+                    const observable = list[i]
+                    observable.isPendingUnobservation = false
+                    if (observable.observers_.size === 0) {
+                        if (observable.isBeingObserved) {
+                            // if this observable had reactive observers, trigger the hooks
+                            observable.isBeingObserved = false
+                            observable.onBUO()
+                        }
+                        if (observable instanceof ComputedValue) {
+                            // computed values are automatically teared down when the last observer leaves
+                            // this process happens recursively, this computed might be the last observabe of another, etc..
+                            observable.suspend_()
+                        }
                     }
                 }
+                globalState.pendingUnobservations = []
+            } finally {
+                // Always release the guard, even if an onBUO handler (user code) threw,
+                // otherwise every future endBatch() would see isRunningUnobservations
+                // stuck true and silently stop draining pendingUnobservations forever.
+                globalState.isRunningUnobservations = false
             }
-            globalState.pendingUnobservations = []
-            globalState.isRunningUnobservations = false
         }
     }
 }


### PR DESCRIPTION
Fixes #3954.

`endBatch()`'s `pendingUnobservations` drain loop calls `onBUO()` per observable, which can dispose a `Reaction` (a common pattern, e.g. tearing down a subscription once nothing observes it anymore). `Reaction.dispose()` calls `startBatch()`/`endBatch()` again, and since `inBatch` is already back at 0 at that point, the nested `endBatch()` recursed into the same drain loop instead of returning, unlike `runReactions()` which already guards against this exact kind of reentrancy with `isRunningReactions`. For long enough chains of `onBecomeUnobserved` handlers disposing reactions, this recursion overflowed the stack.

This adds an analogous `isRunningUnobservations` guard: a nested `endBatch()` call now just returns, and the already-running outer loop picks up anything a nested `dispose()` pushes onto `pendingUnobservations`, since it re-reads `list.length` on every iteration.

### Code change checklist

- [x] Added/updated unit tests (new regression test reproducing #3954 with a chain of 10,000 reactions, fails on current `main` with `RangeError: Maximum call stack size exceeded`, passes with this change)
- [ ] Updated `/docs`. No public API change, so nothing to document.
- [x] Verified that there is no significant performance drop (`npm -w mobx run test:performance`, both proxy and legacy modes, 37/37 passing with no timing anomalies)