### PR TITLE
fix: useObserver pinned every observer's first render result

### DIFF
--- a/.changeset/use-observer-first-render-retention.md
+++ b/.changeset/use-observer-first-render-retention.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+fix: `useObserver` no longer retains the element tree returned by a component's first render for the component's whole mounted life. `subscribe`/`getSnapshot` were created inside `useObserver`'s first invocation and therefore shared that invocation's closure context with the `reaction.track` callback's captures (`render`, `renderResult`); since React's `useSyncExternalStore` holds `subscribe` while the component is mounted, the first render result (and every fiber and DOM node reachable from it) could never be garbage collected. The administration object is now created by a module-level factory whose scope contains nothing render-related.

--- a/packages/mobx-react-lite/__tests__/useObserverRetention.test.tsx
+++ b/packages/mobx-react-lite/__tests__/useObserverRetention.test.tsx
@@ -1,0 +1,50 @@
+import { render } from "@testing-library/react"
+import * as React from "react"
+import gc from "expose-gc/function"
+import { observer } from "../src"
+
+function nextFrame() {
+    return new Promise(accept => setTimeout(accept, 1))
+}
+
+async function gc_cycle() {
+    await nextFrame()
+    gc()
+    await nextFrame()
+}
+
+// If `subscribe` shares a closure context with the `reaction.track` callback,
+// the first render's result stays reachable for as long as the component is mounted.
+// See the comment on `createObserverAdministration` in src/useObserver.ts.
+test("a mounted observer does not retain the element tree it first returned", async () => {
+    let capturedFirstTree: object | null = null
+
+    const TestComponent = observer(function TestComponent({ label }: { label: string }) {
+        const tree = <div data-label={label} />
+        if (!capturedFirstTree) {
+            capturedFirstTree = tree
+        }
+        return tree
+    })
+
+    const rendering = render(<TestComponent label="first" />)
+
+    const weakFirstTree = new WeakRef(capturedFirstTree!)
+    capturedFirstTree = null
+
+    // Several re-renders rather than one: React double-buffers fibers, so the
+    // `alternate` fiber legitimately keeps the immediately-previous render's
+    // tree alive for one extra commit. Distinct props are required because
+    // `observer` wraps the component in `React.memo`.
+    rendering.rerender(<TestComponent label="second" />)
+    rendering.rerender(<TestComponent label="third" />)
+    rendering.rerender(<TestComponent label="fourth" />)
+
+    await gc_cycle()
+
+    expect(weakFirstTree.deref()).toBeUndefined()
+})
+
+// There is deliberately no assertion that the first render's `props` become
+// collectable: a control component wrapped in plain `React.memo` (no MobX involved)
+// fails such an assertion too, so it cannot isolate MobX's contribution.

--- a/packages/mobx-react-lite/src/useObserver.ts
+++ b/packages/mobx-react-lite/src/useObserver.ts
@@ -30,6 +30,49 @@ function createReaction(adm: ObserverAdministration) {
     })
 }
 
+// This must stay a module-level factory and must NOT be inlined into `useObserver`:
+// all closures created during the same function invocation share one context object.
+// If `subscribe`/`getSnapshot` were created inside `useObserver`, that shared context
+// would also hold the `reaction.track` callback's captures (`render`, `renderResult`),
+// and since `useSyncExternalStore` holds `subscribe` for as long as the component is
+// mounted, every observer would retain its first render's element tree, fibers and DOM.
+// Module scope also makes it impossible for these closures to capture `admRef`,
+// which would prevent its collection and break leaked-reaction disposal via the
+// FinalizationRegistry (see the comment on `ObserverAdministration`).
+function createObserverAdministration(baseComponentName: string): ObserverAdministration {
+    const adm: ObserverAdministration = {
+        reaction: null,
+        onStoreChange: null,
+        stateVersion: Symbol(),
+        name: baseComponentName,
+        subscribe(onStoreChange: () => void) {
+            observerFinalizationRegistry.unregister(adm)
+            adm.onStoreChange = onStoreChange
+            if (!adm.reaction) {
+                // We've lost our reaction and therefore all subscriptions, occurs when:
+                // 1. Timer based finalization registry disposed reaction before component mounted.
+                // 2. React "re-mounts" same component without calling render in between (typically <StrictMode>).
+                // We have to recreate reaction and schedule re-render to recreate subscriptions,
+                // even if state did not change.
+                createReaction(adm)
+                // `onStoreChange` won't force update if subsequent `getSnapshot` returns same value.
+                // So we make sure that is not the case
+                adm.stateVersion = Symbol()
+            }
+
+            return () => {
+                adm.onStoreChange = null
+                adm.reaction?.dispose()
+                adm.reaction = null
+            }
+        },
+        getSnapshot() {
+            return adm.stateVersion
+        }
+    }
+    return adm
+}
+
 export function useObserver<T>(render: () => T, baseComponentName: string = "observed"): T {
     if (isUsingStaticRendering()) {
         return render()
@@ -39,41 +82,7 @@ export function useObserver<T>(render: () => T, baseComponentName: string = "obs
 
     if (!admRef.current) {
         // First render
-        const adm: ObserverAdministration = {
-            reaction: null,
-            onStoreChange: null,
-            stateVersion: Symbol(),
-            name: baseComponentName,
-            subscribe(onStoreChange: () => void) {
-                // Do NOT access admRef here!
-                observerFinalizationRegistry.unregister(adm)
-                adm.onStoreChange = onStoreChange
-                if (!adm.reaction) {
-                    // We've lost our reaction and therefore all subscriptions, occurs when:
-                    // 1. Timer based finalization registry disposed reaction before component mounted.
-                    // 2. React "re-mounts" same component without calling render in between (typically <StrictMode>).
-                    // We have to recreate reaction and schedule re-render to recreate subscriptions,
-                    // even if state did not change.
-                    createReaction(adm)
-                    // `onStoreChange` won't force update if subsequent `getSnapshot` returns same value.
-                    // So we make sure that is not the case
-                    adm.stateVersion = Symbol()
-                }
-
-                return () => {
-                    // Do NOT access admRef here!
-                    adm.onStoreChange = null
-                    adm.reaction?.dispose()
-                    adm.reaction = null
-                }
-            },
-            getSnapshot() {
-                // Do NOT access admRef here!
-                return adm.stateVersion
-            }
-        }
-
-        admRef.current = adm
+        admRef.current = createObserverAdministration(baseComponentName)
     }
 
     const adm = admRef.current!


### PR DESCRIPTION
### The problem

Every mounted `observer` component permanently retains the element tree returned by its **first** render, along with every fiber and DOM node reachable from it.

`useObserver` creates `adm.subscribe`/`adm.getSnapshot` inside its first invocation (`if (!admRef.current)`), while `renderResult` is declared in that same invocation and assigned inside `adm.reaction.track(() => { renderResult = render() })`. All closures created during the same function invocation share one context object, and variables captured by *any* of them (here: `render` and `renderResult`) live in that shared context. Since `useSyncExternalStore` holds `subscribe` for as long as the component is mounted, the first invocation's context (including the first render's result and the first `render` closure) can never be collected. Subsequent renders allocate fresh contexts that die normally; only the first invocation's survives.

This matters because a React element tree reaches fibers: via `_owner` in development, and in production via props that close over fibers (for example any `useState` setter passed down as a prop). A long-lived observer parent therefore pins the child elements it was first rendered with; after a route change those belong to a stale route, holding its fiber tree and detached DOM.

Found while tracing detached-DOM growth in a production app. Representative heap-snapshot retainer path (weak edges excluded):

```
Reaction --onInvalidate_--> closure --context--> Context
  --adm--> Object --subscribe--> closure      <- held by useSyncExternalStore while mounted
  --context--> Context
  --renderResult--> Object                    <- first render output, still in scope
  --props--> ... --> FiberNode
  --stateNode--> native:<div>                 «DETACHED»
```

### The fix

Create the administration object in a module-level factory (`createObserverAdministration`), so `subscribe`/`getSnapshot` close over the administration object and nothing render-related. No behavior change: the `subscribe`/`getSnapshot` bodies are untouched, they are still created once per component instance, and their identity is still stable across renders.

The file already guarded against a sibling hazard by convention ("Do not store `admRef` (even as part of a closure!)"); this is the same class of problem, reached through the shared invocation context instead. The factory makes both constraints structural, which is also why the three `// Do NOT access admRef here!` comments are removed: `admRef` is no longer in scope where those closures are created.

### The test

`useObserverRetention.test.tsx` mounts an observer, takes a `WeakRef` to the first returned element tree, re-renders a few times (React double-buffers fibers, so the `alternate` legitimately keeps the immediately-previous render alive for one extra commit), forces GC with the same `expose-gc` idiom as `strictAndConcurrentModeUsingFinalizationRegistry.test.tsx`, and asserts the first tree was collected.

Fails on current `main` (the retained element surfaces complete with its `_owner` FiberNode, matching the production heap traces), passes with this change.

There is deliberately no assertion that the first render's `props` become collectable: a control component wrapped in plain `React.memo` (no MobX involved) fails such an assertion too, so a test cannot isolate MobX's contribution. The factory removes both `renderResult` and `render` from `subscribe`'s scope regardless.

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated — not applicable: internal memory fix, no API or documented behavior change
-   [x] Verified that there is no significant performance drop (`npm -w mobx run test:performance`) — no `mobx` core changes; `mobx-react-lite` creates the same objects and closures once per component instance as before
