### PR TITLE
chore: Revert "chore(deps): bump changesets/action from 1.9.0 to 2.1.0"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.1.0
+        uses: changesets/action@v1.9.0
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release


### PR DESCRIPTION
Reverts mobxjs/mobx#4691. It causes release failures because the CLI packages are not updated. 