### PR TITLE
Fix onBecomeObserved not firing when a computed becomes observed while serving a cached value

### DIFF
--- a/.changeset/cascade-onbecomeobserved.md
+++ b/.changeset/cascade-onbecomeobserved.md
@@ -1,0 +1,5 @@
+---
+"mobx": patch
+---
+
+fix: `onBecomeObserved` is now called for the dependencies of a computed that becomes observed while serving a cached value. Previously, observation only cascaded when the newly observed computed also happened to recompute, so an observable with a live observer chain up to a running reaction could still report itself as unobserved and never fire its hook.

--- a/packages/mobx/__tests__/base/become-observed.ts
+++ b/packages/mobx/__tests__/base/become-observed.ts
@@ -518,3 +518,48 @@ test("works with ObservableSet #3595", () => {
     expect(onSetObserved).toHaveBeenCalledTimes(1)
     expect(onSetUnobserved).toHaveBeenCalledTimes(1)
 })
+
+test("onBecomeObserved fires when a computed becomes observed while serving a cached value #4547", () => {
+    const events: string[] = []
+
+    const o = observable.box(1)
+    onBecomeObserved(o, () => events.push("BO"))
+    onBecomeUnobserved(o, () => events.push("BUO"))
+    const c = computed(() => o.get())
+
+    let disposeAutorun: () => void
+    runInAction(() => {
+        // non-reactive read inside the batch leaves `c` up-to-date but unobserved
+        void c.get()
+        // `c` becomes observed during endBatch() without recomputing, so it never
+        // re-reports `o` — the hook has to cascade instead
+        disposeAutorun = autorun(() => void c.get())
+    })
+
+    expect(events).toEqual(["BO"])
+
+    disposeAutorun!()
+    expect(events).toEqual(["BO", "BUO"])
+})
+
+test("onBecomeObserved cascades through a chain of cached computeds #4547", () => {
+    const events: string[] = []
+
+    const o = observable.box(1)
+    onBecomeObserved(o, () => events.push("BO"))
+    onBecomeUnobserved(o, () => events.push("BUO"))
+    // two levels, as in the reported issue: the cascade has to recurse
+    const inner = computed(() => o.get())
+    const outer = computed(() => inner.get())
+
+    let disposeAutorun: () => void
+    runInAction(() => {
+        void outer.get()
+        disposeAutorun = autorun(() => void outer.get())
+    })
+
+    expect(events).toEqual(["BO"])
+
+    disposeAutorun!()
+    expect(events).toEqual(["BO", "BUO"])
+})

--- a/packages/mobx/src/core/computedvalue.ts
+++ b/packages/mobx/src/core/computedvalue.ts
@@ -14,6 +14,7 @@ import {
     globalState,
     isCaughtException,
     isSpyEnabled,
+    markObserved,
     propagateChangeConfirmed,
     propagateMaybeChanged,
     reportObserved,
@@ -210,6 +211,7 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
                 endBatch()
             }
         } else {
+            const wasBeingObserved = this.isBeingObserved
             reportObserved(this)
             if (shouldCompute(this)) {
                 let prevTrackingContext = globalState.trackingContext
@@ -220,6 +222,10 @@ export class ComputedValue<T> implements IObservable, IComputedValue<T>, IDeriva
                     propagateChangeConfirmed(this)
                 }
                 globalState.trackingContext = prevTrackingContext
+            } else if (!wasBeingObserved && this.isBeingObserved) {
+                // We just became observed while serving a cached value, so the getter
+                // won't run and won't re-report our dependencies. Cascade to them. #4547
+                this.observing_.forEach(markObserved)
             }
         }
         const result = this.value_!

--- a/packages/mobx/src/core/observable.ts
+++ b/packages/mobx/src/core/observable.ts
@@ -129,6 +129,24 @@ export function endBatch() {
     }
 }
 
+/**
+ * Marks an observable as observed, cascading into the dependencies of a ComputedValue.
+ * Unobservation already cascades (`suspend_` -> `clearObserving`), observation normally
+ * only does so by accident: a newly observed computed usually recomputes and re-reports
+ * its dependencies. When it serves a cached value instead nothing re-reports them, so the
+ * transition has to be propagated by hand. See #4547.
+ */
+export function markObserved(observable: IObservable) {
+    if (observable.isBeingObserved) {
+        return
+    }
+    observable.isBeingObserved = true
+    observable.onBO()
+    // No queueForUnobservation here: the observer links already exist, so the regular
+    // suspend_ -> clearObserving -> removeObserver teardown still delivers the onBUO.
+    observable.observing_?.forEach(markObserved)
+}
+
 export function reportObserved(observable: IObservable): boolean {
     checkIfStateReadsAreAllowed(observable)
 


### PR DESCRIPTION
Fixes #4547.

Unobservation cascades: losing the last observer runs `ComputedValue.suspend_()` → `clearObserving` → `removeObserver` → `queueForUnobservation` down the whole chain. Observation does not. `isBeingObserved` is written in exactly two places, both in `core/observable.ts`, and the observe site marks only the observable handed to `reportObserved`.

That asymmetry is usually invisible, because a newly observed computed is normally suspended (`NOT_TRACKING_`), so `shouldCompute` is true, it recomputes, and the recompute reports its dependencies inside a live `trackingContext` — the cascade happens by accident. The broken path is the one where a computed becomes observed **without** recomputing.

Reduced to 12 lines:

```js
const events = []
const o = observable.box(1)
onBecomeObserved(o, () => events.push("BO"))
const c = computed(() => o.get())

runInAction(() => {
    void c.get()                // non-reactive read inside the batch
    autorun(() => void c.get()) // runs during endBatch(), before unobservation drains
})

events // [] on main, ["BO"] expected
```

Step by step: the non-reactive read inside the batch leaves `c` `UP_TO_DATE_` and merely *queued* for unobservation. `endBatch()` runs `runReactions()` before draining `pendingUnobservations`, so the `autorun` reads `c` with `trackingContext` set and `c.isBeingObserved` flips to true — but `shouldCompute(c)` is now false, so the getter body never runs, `reportObserved(o)` is never called again, and `o.onBO()` never fires. The drain then finds `c` still has observers, so nothing is suspended and the graph stays live permanently with the atom marked unobserved.

Measured end state on `main` for the reporter's own repro:

```
valueAtom.isBeingObserved    : false          <- the lie
valueAtom.observers_         : [isLoading]    <- live edge
isLoading.isBeingObserved    : true
isLoading.dependenciesState_ : 0 (UP_TO_DATE_) <- so shouldCompute() === false
isLoading.observers_         : [see, When@6]
isLoading.observing_         : [value]
```

The atom is transitively observed by a running `autorun`, yet reports `isBeingObserved === false`. This is not a non-reactive read by the time the hook is skipped — the observer chain is live — so I think this is a genuine inconsistency rather than the documented "non-reactive reads don't count" behaviour.

### The fix

`markObserved()` in `core/observable.ts` performs the `isBeingObserved`/`onBO()` transition and recurses through `observing_`, which `IDepTreeNode` already declares. `ComputedValue.get()` snapshots `isBeingObserved` before `reportObserved(this)` and calls it on the `else` (cache-hit) branch only, when the computed just transitioned to observed.

Gated to the cache-hit branch deliberately. Cascading unconditionally from `reportObserved` would also fire for computeds that are about to recompute, and if that recompute drops a dependency the dep gets a spurious `onBO` immediately followed by `onBUO` at `endBatch`. A computed serving a cached value is by definition `UP_TO_DATE_`, so its dependencies cannot be dropped by a pending recompute.

No new instance field (`wasBeingObserved` is a local — keeping the `Atom`/`ComputedValue` bitfields intact), no new public export, and the `trackingContext` guard in `reportObserved` and the `runReactions()`-before-drain order in `endBatch` are both untouched. `markObserved`'s early return makes the recursion cycle-safe and O(newly observed), off the per-read path.

Teardown needed no change: every observable reached through `observing_` already has the computed registered in its `observers_`, so `suspend_` → `clearObserving` → `removeObserver` → `queueForUnobservation` still delivers the matching `onBUO`.

### The tests

Two, both in `__tests__/base/become-observed.ts`, both verified to fail on `main` and pass with this change:

- the 12-line case above, asserting `onBecomeObserved` fires **and** that `onBecomeUnobserved` still fires exactly once when the autorun is disposed, so the fix cannot pass by leaking a permanently-observed atom;
- a two-level chain (`atom → inner → outer`), matching the shape of the reported issue, which is the only coverage of the recursive arm — with a single-level computed `markObserved` never actually recurses.

### Code change checklist

-   [x] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated — not applicable: bug fix, no API or documented behaviour change
-   [x] Verified that there is no significant performance drop (`npm -w mobx run test:performance`, 37/37 passing, timings within run-to-run noise of `main`). The added cost on the hot path is one bitfield read on a branch that already calls `reportObserved` and `shouldCompute`.
