### PR TITLE
perf: evaluate NODE_ENV once at module scope in env-agnostic esm builds

### DIFF
--- a/.changeset/hoist-node-env-check-esm-builds.md
+++ b/.changeset/hoist-node-env-check-esm-builds.md
@@ -1,0 +1,7 @@
+---
+"mobx": patch
+"mobx-react": patch
+"mobx-react-lite": patch
+---
+
+perf: evaluate `NODE_ENV` once at module scope in the env-agnostic esm bundles (`dist/<pkg>.esm.js` and `dist/<pkg>.mjs`) instead of at every `__DEV__` call site. `process.env` is an exotic object in Node, so each check performed a real environment lookup on hot paths; consumers that execute these files as-is (Node ESM, vitest, SSR) see roughly 10x faster observable writes in dev mode. All env-set artifacts and bundler output are unchanged.

--- a/scripts/create-rollup-config.mjs
+++ b/scripts/create-rollup-config.mjs
@@ -81,7 +81,16 @@ const stripShebang = () => ({
     }
 })
 
-const babelPlugin = () =>
+// The env-agnostic esm outputs (`dist/<pkg>.esm.js` and `dist/<pkg>.mjs`) keep a
+// runtime `NODE_ENV` check, but evaluate it once at module scope instead of at
+// every `__DEV__` call site: `process.env` is an exotic object in Node, so every
+// read performs a real environment lookup, and unbundled consumers pay that on hot paths.
+// The identifier is scoped (`__MOBX_DEV__`) so consumer-side replacers that blindly define
+// `__DEV__` (e.g. `DefinePlugin({ __DEV__: ... })`) cannot collide with the declaration.
+const DEV_IDENTIFIER = "__MOBX_DEV__"
+const DEV_DECLARATION = `const ${DEV_IDENTIFIER} = process.env.NODE_ENV !== "production";`
+
+const babelPlugin = ({ devExpression = true } = {}) =>
     babel({
         babelHelpers: "bundled",
         exclude: "node_modules/**",
@@ -105,7 +114,10 @@ const babelPlugin = () =>
         ],
         plugins: [
             "babel-plugin-annotate-pure-calls",
-            "babel-plugin-dev-expression",
+            // For env-agnostic builds `__DEV__` stays a free identifier; it is
+            // renamed to `__MOBX_DEV__` and defined once by the `DEV_DECLARATION`
+            // intro instead of being inlined at every call site.
+            devExpression && "babel-plugin-dev-expression",
             ["@babel/plugin-proposal-class-properties", { loose: true }]
         ].filter(Boolean)
     })
@@ -121,6 +133,7 @@ const createConfig = ({
     globals
 }) => {
     const shouldMinify = env === "production"
+    const isEnvAgnostic = env === undefined
     const outputName = [`${dist}/${packageBase}`, format, env, shouldMinify ? "min" : "", "js"]
         .filter(Boolean)
         .join(".")
@@ -136,6 +149,10 @@ const createConfig = ({
         exports: "named"
     }
 
+    const outputs = [output, ...extraOutputs].map(o =>
+        isEnvAgnostic ? { ...o, intro: DEV_DECLARATION } : o
+    )
+
     return {
         input,
         external(id) {
@@ -147,7 +164,7 @@ const createConfig = ({
         treeshake: {
             propertyReadSideEffects: false
         },
-        output: [output, ...extraOutputs],
+        output: outputs,
         plugins: [
             nodeResolve({
                 mainFields: ["module", "main", "browser"],
@@ -171,7 +188,14 @@ const createConfig = ({
                 check: declarations,
                 useTsconfigDeclarationDir: false
             }),
-            babelPlugin(),
+            babelPlugin({ devExpression: !isEnvAgnostic }),
+            isEnvAgnostic &&
+                replace({
+                    preventAssignment: true,
+                    values: {
+                        __DEV__: DEV_IDENTIFIER
+                    }
+                }),
             env !== undefined &&
                 replace({
                     preventAssignment: true,


### PR DESCRIPTION
Implements option 1 from #4692, which got the go-ahead there.

The env-agnostic bundles (`dist/<pkg>.esm.js` and `dist/<pkg>.mjs`) ship every `__DEV__` check as a live `process.env.NODE_ENV !== "production"` expression (147 of them in mobx). `process.env` is an exotic object in Node, so every check performs a real environment lookup (~120 ns vs ~0.9 ns for a const read), and the checks sit on hot paths: 7 per observed field write. Consumers that execute these files as-is (Node ESM, vitest, SSR, Metro dev builds) pay for it on every operation.

### What changed

For env-agnostic configs only (`env === undefined`), `babel-plugin-dev-expression` is skipped so `__DEV__` survives as a free identifier, `@rollup/plugin-replace` renames it to `__MOBX_DEV__`, and the bundle gets a single `const __MOBX_DEV__ = process.env.NODE_ENV !== "production";` via `output.intro`. The identifier is renamed so consumer-side replacers that blindly define `__DEV__` (e.g. `DefinePlugin({ __DEV__: ... })`) cannot collide with the declaration. Env-set builds go through the exact same pipeline as before.

### Verification

- All env-set artifacts are byte-identical before/after this change: cjs development/production, umd development/production, `dist/index.js`, `mobx.d.ts` (mobx-react and mobx-react-lite share the config).
- In the env-agnostic bundles the only differences are the intro line, the `__DEV__` call sites now reading the const, and one rename inside an already commented-out block coming from `observableobject.ts` (the replace plugin is textual; comment-only, no code effect).
- Live `process.env.NODE_ENV` reads in `mobx.esm.js` / `mobx.mjs`: 147 → 1 (the intro).
- Bundler dead-code elimination still removes dev branches: verified with rollup+terser, webpack 4 (including a deliberate `DefinePlugin({ __DEV__: false })` collision), esbuild and bun `--define`, and metro-transform-plugins in release mode. A production rspack build of an app consuming mobx is byte-identical before/after.
- Node dev mode, 2M observed field writes through `mobx.mjs`: 3371 ms → 326 ms (~10x). Node v26.7.0, macOS arm64.

One semantic note: for unbundled ESM consumers `NODE_ENV` is now snapshotted at import time, which matches what `dist/index.js` already does at require time for CJS consumers.

### Reproducing the byte-identity check

```sh
git checkout main
npm run build -w mobx
cp -r packages/mobx/dist /tmp/mobx-dist-main

gh pr checkout 4695
npm run build -w mobx
diff -rq /tmp/mobx-dist-main packages/mobx/dist
```

Only `mobx.esm.js`, `mobx.mjs` and their two sourcemaps differ; everything else in dist (cjs development/production, umd development/production, `index.js`, the declaration tree) is byte-identical. Same procedure for the react packages with `-w mobx-react` / `-w mobx-react-lite`.

To see that the difference in the esm files is only the intended one, normalize the old expression to the new identifier and diff:

```sh
sed 's/process\.env\.NODE_ENV !== "production"/__MOBX_DEV__/g' /tmp/mobx-dist-main/mobx.mjs | diff - packages/mobx/dist/mobx.mjs
```

which leaves the intro line, `!(x)` vs `!x` parenthesization, and the one rename inside a commented-out block.

### Code change checklist

-   [x] Added/updated unit tests: no test change needed, the artifacts the test suites exercise are byte-identical; the change is covered by the artifact diffs above
-   [x] Updated `/docs`: no API or documented behavior change
-   [x] Verified that there is no significant performance drop (`npm -w mobx run test:performance`): this PR is a measured ~10x improvement for the affected bundles, everything else is byte-identical
