### PR TITLE
perf: route Node ESM imports to the env-switched CJS entry via a node export condition

### DIFF
--- a/.changeset/node-export-condition.md
+++ b/.changeset/node-export-condition.md
@@ -1,0 +1,7 @@
+---
+"mobx": patch
+"mobx-react": patch
+"mobx-react-lite": patch
+---
+
+perf: add a `node` export condition that routes Node and Bun to the existing `dist/index.js` entry, which picks the prebaked development or production CJS build once at require time. `import`ing mobx in Node no longer executes the env-agnostic `dist/mobx.mjs` with per-call `NODE_ENV` checks, and mixing `import` and `require` in one Node app now yields a single mobx instance.

--- a/packages/mobx-react-lite/package.json
+++ b/packages/mobx-react-lite/package.json
@@ -20,6 +20,10 @@
                 "types": "./dist/index.d.ts",
                 "default": "./dist/mobxreactlite.esm.js"
             },
+            "node": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            },
             "import": {
                 "types": "./dist/index.d.ts",
                 "default": "./dist/mobxreactlite.mjs"

--- a/packages/mobx-react/package.json
+++ b/packages/mobx-react/package.json
@@ -20,6 +20,10 @@
                 "types": "./dist/index.d.ts",
                 "default": "./dist/mobxreact.esm.js"
             },
+            "node": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            },
             "import": {
                 "types": "./dist/index.d.ts",
                 "default": "./dist/mobxreact.mjs"

--- a/packages/mobx/package.json
+++ b/packages/mobx/package.json
@@ -20,6 +20,10 @@
                 "types": "./dist/mobx.d.ts",
                 "default": "./dist/mobx.esm.js"
             },
+            "node": {
+                "types": "./dist/mobx.d.ts",
+                "default": "./dist/index.js"
+            },
             "import": {
                 "types": "./dist/mobx.d.ts",
                 "default": "./dist/mobx.mjs"


### PR DESCRIPTION
Implements option 2 from #4692, the follow-up to #4695. Adds a `node` export condition in `mobx`, `mobx-react` and `mobx-react-lite` that routes Node (and Bun) to the existing `dist/index.js`, the entry that already switches once at require time between the prebaked development and production CJS builds. vue ships this exact pattern; export conditions were previously discussed in #3809.

### What it fixes

- `NODE_ENV=production node` with `import` previously loaded the unminified env-agnostic `dist/mobx.mjs`; now it loads `mobx.cjs.production.min.js`. In #4692 I measured creating 1M boxed observables at 258 ms vs 27 ms (~9.5x).
- Dev-mode Node gets the prebaked development build, whose checks are prebaked literal comparisons.
- Node apps mixing `import` and `require` of mobx got two instances (the #1082 class of issues); both now resolve to the same entry.
- `arethetypeswrong` goes from "node16: ESM masquerading as CJS" to all green.

### What stays the same

Bundler-facing resolution is untouched: `import` still yields `dist/<pkg>.mjs` for bundlers, `react-native` still yields `dist/<pkg>.esm.js`. Verified with an enhanced-resolve condition matrix that only resolutions including the `node` condition change. Condition order is load-bearing: `node` is placed after `react-native` and before `import`.

Named exports keep working through the CJS entry: `import { observable } from "mobx"` in Node resolves via cjs-module-lexer, verified together with namespace equality across mixed `import`/`require`.

### Code change checklist

-   [x] Added/updated unit tests: exports-map-only change, covered by the resolution matrix and Node interop checks above
-   [x] Updated `/docs`: no API change
-   [x] Verified that there is no significant performance drop: production-mode Node gets ~9.5x faster, bundler paths resolve identically
